### PR TITLE
Isolate the vehicle editor dialog

### DIFF
--- a/frontend/src/features/vehicles/VehicleEditorDialog.tsx
+++ b/frontend/src/features/vehicles/VehicleEditorDialog.tsx
@@ -1,0 +1,146 @@
+import type { ComponentProps, FormEventHandler } from "react";
+import { X } from "lucide-react";
+
+import type { Vehicle } from "../../shared/api";
+import { useI18n } from "../../shared/i18n";
+import { VehicleCVTab } from "./VehicleCVTab";
+import { VehicleFunctionsTab } from "./VehicleFunctionsTab";
+import { VehicleMaintenanceTab } from "./VehicleMaintenanceTab";
+import { VehicleModelTab } from "./VehicleModelTab";
+import { VehicleReadOnlyView } from "./VehicleReadOnlyView";
+import { VehicleSparePartsTab } from "./VehicleSparePartsTab";
+import { VehicleSpeedCurveTab } from "./VehicleSpeedCurveTab";
+import { VehicleUploadsTab } from "./VehicleUploadsTab";
+import type { ModalMode, ModalTab } from "./vehicleViewModel";
+
+type EditorTabs = {
+  model: ComponentProps<typeof VehicleModelTab>;
+  functions: ComponentProps<typeof VehicleFunctionsTab>;
+  speedCurve: ComponentProps<typeof VehicleSpeedCurveTab>;
+  cv: ComponentProps<typeof VehicleCVTab>;
+  uploads: ComponentProps<typeof VehicleUploadsTab>;
+  maintenance: ComponentProps<typeof VehicleMaintenanceTab>;
+  spareParts: ComponentProps<typeof VehicleSparePartsTab>;
+};
+
+type VehicleEditorDialogProps = {
+  mode: ModalMode;
+  selected: Vehicle | null;
+  activeTab: ModalTab;
+  saving: boolean;
+  message: string;
+  tabs: EditorTabs;
+  onSubmit: FormEventHandler<HTMLFormElement>;
+  onClose: () => void;
+  onTabChange: (tab: ModalTab) => void;
+  onEdit: () => void;
+  onPrint: () => void;
+  onQr: () => void;
+  onPreviewImage: ComponentProps<typeof VehicleReadOnlyView>["onPreviewImage"];
+};
+
+const editorTabs: Array<{ key: ModalTab; labelKey?: string; label?: string }> = [
+  { key: "model", labelKey: "vehicles.tab.model" },
+  { key: "control", labelKey: "vehicles.tab.control" },
+  { key: "speedCurve", labelKey: "vehicles.tab.speedCurve" },
+  { key: "cv", label: "CV" },
+  { key: "uploads", labelKey: "vehicles.tab.uploads" },
+  { key: "maintenance", labelKey: "vehicles.tab.maintenance" },
+  { key: "spareParts", labelKey: "vehicles.tab.spareParts" }
+];
+
+export function VehicleEditorDialog({
+  mode,
+  selected,
+  activeTab,
+  saving,
+  message,
+  tabs,
+  onSubmit,
+  onClose,
+  onTabChange,
+  onEdit,
+  onPrint,
+  onQr,
+  onPreviewImage
+}: VehicleEditorDialogProps) {
+  const { t } = useI18n();
+
+  return (
+    <div className="modal-layer" role="dialog" aria-modal="true" aria-label={t("vehicles.modal.aria")}>
+      <form
+        key={`${mode}-${selected?.id || "new"}`}
+        className={mode === "view" ? "vehicle-modal vehicle-read-modal-shell" : "vehicle-modal"}
+        onSubmit={onSubmit}
+      >
+        <header className="modal-head">
+          <h2>
+            {mode === "create"
+              ? t("vehicles.modal.create")
+              : mode === "edit"
+                ? t("vehicles.modal.edit")
+                : t("vehicles.modal.view")}
+          </h2>
+          <button
+            type="button"
+            className="icon-button"
+            onClick={onClose}
+            aria-label={t("vehicles.close")}
+            title={t("vehicles.close")}
+          >
+            <X size={18} />
+          </button>
+        </header>
+
+        {mode === "view" && selected ? (
+          <VehicleReadOnlyView
+            vehicle={selected}
+            onEdit={onEdit}
+            onPrint={onPrint}
+            onQr={onQr}
+            onPreviewImage={onPreviewImage}
+          />
+        ) : (
+          <>
+            <nav className="modal-tabs" aria-label={t("vehicles.modal.aria")}>
+              {editorTabs.map((tab) => (
+                <button
+                  key={tab.key}
+                  type="button"
+                  className={activeTab === tab.key ? "active" : ""}
+                  onClick={() => onTabChange(tab.key)}
+                >
+                  {tab.label || t(tab.labelKey || "")}
+                </button>
+              ))}
+            </nav>
+
+            <div className="modal-body">
+              {activeTab === "model" && <VehicleModelTab {...tabs.model} />}
+              {activeTab === "control" && <VehicleFunctionsTab {...tabs.functions} />}
+              {activeTab === "speedCurve" && <VehicleSpeedCurveTab {...tabs.speedCurve} />}
+              {activeTab === "cv" && <VehicleCVTab {...tabs.cv} />}
+              {activeTab === "uploads" && <VehicleUploadsTab {...tabs.uploads} />}
+              {activeTab === "maintenance" && <VehicleMaintenanceTab {...tabs.maintenance} />}
+              {activeTab === "spareParts" && <VehicleSparePartsTab {...tabs.spareParts} />}
+            </div>
+
+            <footer className="modal-actions">
+              {message && <p className="form-message">{message}</p>}
+              <button type="button" className="secondary-button" onClick={onClose}>
+                {t("vehicles.cancel")}
+              </button>
+              <button className="primary-button" disabled={saving}>
+                {saving
+                  ? t("vehicles.saving")
+                  : mode === "create"
+                    ? t("vehicles.createAndContinue")
+                    : t("vehicles.saveChanges")}
+              </button>
+            </footer>
+          </>
+        )}
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/features/vehicles/VehiclesView.tsx
+++ b/frontend/src/features/vehicles/VehiclesView.tsx
@@ -1,165 +1,30 @@
-import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
-
+import { useCallback, useEffect, useState } from "react";
 import {
-
-  ArrowUpDown,
-
-  ChevronDown,
-
-  ChevronUp,
-
-  Circle,
-
-  CircleOff,
-
-  Cpu,
-
-  Eye,
-
-  Image,
-
-  ImageOff,
-
-  MoreVertical,
-
-  PackageSearch,
-
-  Pencil,
-
-  Printer,
-
-  QrCode,
-
-  Trash2,
-
-  Upload,
-
-  Wrench,
-
-  X
-
-} from "lucide-react";
-
-import {
-
   api,
-
   CreateVehicleRequest,
-
-  ExhibitionEntry,
-
-  ExhibitionEntryInput,
-
-  ExhibitionList,
-
-  MasterDataEntry,
-
-  MasterDataRelation,
-
-  VehicleAttachment,
-
-  VehicleExternalMappingInput,
-
-  VehicleFunctionInput,
-
   Vehicle
-
 } from "../../shared/api";
-
 import { useI18n } from "../../shared/i18n";
-
 import { ArticleSearchDialog } from "./ArticleSearchDialog";
-
 import { BarcodeSearchDialog } from "./BarcodeSearchDialog";
-
 import { DeleteAttachmentDialog, DeleteVehicleDialog, ExhibitionAssignmentDialog, ImagePreviewDialog, QrDialog, ReportDialog } from "./VehicleDialogs";
-
 import { VehicleInventoryPanel } from "./VehicleInventoryPanel";
-
-import { VehicleFunctionsTab } from "./VehicleFunctionsTab";
-
-import { VehicleMaintenanceTab } from "./VehicleMaintenanceTab";
-
-import { VehicleModelTab } from "./VehicleModelTab";
-
-import { VehicleSparePartsTab } from "./VehicleSparePartsTab";
-
-import { VehicleSpeedCurveTab } from "./VehicleSpeedCurveTab";
-
-import { VehicleUploadsTab } from "./VehicleUploadsTab";
-
-import { VehicleCVTab } from "./VehicleCVTab";
-
-import { VehicleReadOnlyView } from "./VehicleReadOnlyView";
-
-import {
-
-  cvValueKey,
-
-  functionKeys,
-
-  functionMappingsFromImport,
-
-  isValidFunctionMapping
-
-} from "./cvImport";
-
+import { VehicleEditorDialog } from "./VehicleEditorDialog";
 import { maintenanceIsDue } from "./vehicleMaintenance";
-
-import { buildBrandedQrPngDataUrl, buildQrSvg, downloadQrPngFile, downloadQrSvgFile, printQrSvgLabel, qrPayload } from "./vehicleQr";
-
-import { InventoryReportAssets, inventoryReportHtml, openPrintDocument, reservePrintDocument } from "./vehicleReports";
-
 import {
-
-  functionsToEditState,
-
-  normalizedText,
-
   PendingArticleImage,
-
   previewImageUrl,
-
   primaryImage,
-
-  vehicleExhibitionEligible,
-
-  vehicleToExhibitionEntry,
-
   vehicleToForm
-
 } from "./vehicleTransforms";
-
-import type { FunctionEditState } from "./vehicleTransforms";
-
-
-
 import {
-
-  compactValue,
-
-  emptyFunctionEdit,
-
   emptyOptions,
-
-  emptyVehicle,
-
-  ecosImportSessionStorageKey,
-
-  ecosRequiredFields,
-
-  ecosVehicleDraftStorageKey,
-
   fieldValue,
-
   hasArticleSearchCriteria,
-
   hasQrPayloadData,
-
+  gattungenForCategory,
+  missingVehicleModelFieldLabels,
   inferFunctionTypeFromSymbol,
-
-  optionValue
-
 } from "./vehicleViewModel";
 import { useVehicleInventoryController } from "./useVehicleInventoryController";
 import { useVehicleEditorController } from "./useVehicleEditorController";
@@ -170,83 +35,23 @@ import { useVehicleSparePartsController } from "./useVehicleSparePartsController
 import { useVehicleCVController } from "./useVehicleCVController";
 import { useVehicleDecoderFilesController } from "./useVehicleDecoderFilesController";
 import { useVehicleDocumentsController } from "./useVehicleDocumentsController";
-
-import type {
-
-  ECoSRequiredField,
-
-  ECoSVehicleDraftPayload,
-
-  ExhibitionAssignment,
-
-  InventoryFilter,
-
-  InventoryReportMode,
-
-  InventoryViewMode,
-
-  InventoryReportSelection,
-
-  MaintenanceFilter,
-
-  MasterDataOptions,
-
-  ModalTab,
-
-  SortKey
-
-} from "./vehicleViewModel";
-
-
+import { useVehicleOutputController } from "./useVehicleOutputController";
+import { useVehicleFunctionsController } from "./useVehicleFunctionsController";
+import { useVehicleECoSDraftController } from "./useVehicleECoSDraftController";
+import { createVehicleMutationCommands } from "./vehicleMutationCommands";
+import { createVehicleFilterDefinitions, createVehicleInventoryRenderers } from "./vehicleInventoryRenderers";
+import type { MasterDataOptions } from "./vehicleViewModel";
 
 export function VehiclesView({ username }: { username: string }) {
-
   const { language, t } = useI18n();
-
   const [vehicles, setVehicles] = useState<Vehicle[]>([]);
-
   const [options, setOptions] = useState<MasterDataOptions>(emptyOptions);
-
   const [query, setQuery] = useState("");
-
   const [message, setMessage] = useState("");
-
   const [loading, setLoading] = useState(false);
-
   const [deleteCandidate, setDeleteCandidate] = useState<Vehicle | null>(null);
-  const [functionEdits, setFunctionEdits] = useState<FunctionEditState>({});
-
-  const [showConfiguredFunctionsOnly, setShowConfiguredFunctionsOnly] = useState(false);
-
-  const [ecosDraft, setEcosDraft] = useState<ECoSVehicleDraftPayload | null>(null);
-
-  const [ecosUnclearFields, setEcosUnclearFields] = useState<Set<ECoSRequiredField>>(() => new Set());
-
-  const functionImportInputRef = useRef<HTMLInputElement | null>(null);
-
-  const [qrDialogOpen, setQrDialogOpen] = useState(false);
-
-  const [qrSvg, setQrSvg] = useState("");
-
-  const [qrError, setQrError] = useState("");
-
-  const [reportDialogOpen, setReportDialogOpen] = useState(false);
-
-  const [reportMode, setReportMode] = useState<InventoryReportMode>("summary");
-
-  const [reportTitle, setReportTitle] = useState("Fahrzeugsammlung");
-
-  const [reportSelection, setReportSelection] = useState<InventoryReportSelection>("all");
-
-  const [reportIncludeQRCode, setReportIncludeQRCode] = useState(true);
-
-  const [reportIncludeImages, setReportIncludeImages] = useState(true);
-
-  const [reportCreating, setReportCreating] = useState(false);
-
-  const [exhibitionAssignment, setExhibitionAssignment] = useState<ExhibitionAssignment | null>(null);
-
   const [quickMenuVehicleID, setQuickMenuVehicleID] = useState("");
+
   const {
     state: {
       form,
@@ -286,8 +91,7 @@ export function VehiclesView({ username }: { username: string }) {
     onMessage: setMessage,
     onFormChange: (nextForm) => syncECoSUnclearFields(nextForm),
     onReset: (reason) => {
-      setEcosDraft(null);
-      setEcosUnclearFields(new Set());
+      clearECoSDraft();
       resetVehicleMedia(reason === "close");
       setFunctionEdits({});
       resetMaintenanceForm();
@@ -298,16 +102,47 @@ export function VehiclesView({ username }: { username: string }) {
       resetDecoderFiles();
     },
     onDetailLoaded: (detail) => {
-      setEcosDraft(null);
-      setEcosUnclearFields(new Set());
+      clearECoSDraft();
       loadVehicleMedia(detail);
-      setFunctionEdits(functionsToEditState(detail.functions));
+      loadFunctionEdits(detail.functions);
       resetMaintenanceForm();
       resetSparePartDetail();
       resetCVController();
       resetDecoderFiles();
     }
   });
+
+  const {
+    state: {
+      showConfiguredOnly: showConfiguredFunctionsOnly,
+      configuredKeys: configuredFunctionKeys,
+      visibleKeys: visibleFunctionKeys,
+      summary: functionSummary
+    },
+    refs: { importInputRef: functionImportInputRef },
+    setters: {
+      setEdits: setFunctionEdits,
+      setShowConfiguredOnly: setShowConfiguredFunctionsOnly
+    },
+    commands: {
+      functionEdit,
+      updateFunctionEdit,
+      reset: resetFunctionEdits,
+      loadDetail: loadFunctionEdits,
+      mergeDetail: mergeFunctionEdits,
+      save: saveFunction,
+      remove: deleteFunction,
+      exportValues: exportFunctions,
+      importValues: importFunctions
+    }
+  } = useVehicleFunctionsController({
+    selected,
+    form,
+    setSaving,
+    onMessage: setMessage,
+    refreshSelectedVehicle: (vehicleId) => refreshSelectedVehicle(vehicleId)
+  });
+
   const {
     state: {
       attachmentDeleteCandidate,
@@ -359,6 +194,7 @@ export function VehiclesView({ username }: { username: string }) {
       setCVFileDescription("");
     }
   });
+
   const {
     state: {
       form: maintenanceForm,
@@ -378,6 +214,7 @@ export function VehiclesView({ username }: { username: string }) {
     onMessage: setMessage,
     refreshSelectedVehicle: (vehicleId) => refreshSelectedVehicle(vehicleId)
   });
+
   const {
     state: {
       form: sparePartForm,
@@ -426,6 +263,7 @@ export function VehiclesView({ username }: { username: string }) {
     refreshSelectedVehicle: (vehicleId) => refreshSelectedVehicle(vehicleId),
     t
   });
+
   const {
     state: {
       form: cvForm,
@@ -459,6 +297,7 @@ export function VehiclesView({ username }: { username: string }) {
     onMessage: setMessage,
     refreshSelectedVehicle: (vehicleId) => refreshSelectedVehicle(vehicleId)
   });
+
   const {
     state: {
       fileProfile: cvFileProfile,
@@ -486,6 +325,7 @@ export function VehiclesView({ username }: { username: string }) {
     onImportPreview: setCVImportPreview,
     refreshSelectedVehicle: (vehicleId) => refreshSelectedVehicle(vehicleId)
   });
+
   const {
     state: {
       loading: documentSearchLoading,
@@ -509,6 +349,7 @@ export function VehiclesView({ username }: { username: string }) {
     refreshSelectedVehicle: (vehicleId) => refreshSelectedVehicle(vehicleId),
     t
   });
+
   const {
     state: {
       open: articleSearchOpen,
@@ -542,6 +383,7 @@ export function VehiclesView({ username }: { username: string }) {
     t,
     addImages: addPendingImages
   });
+
   const {
     allVisibleSelected,
     categoryFilter,
@@ -576,2379 +418,579 @@ export function VehiclesView({ username }: { username: string }) {
     toggleSort,
     toggleVehicleSelection
   } = useVehicleInventoryController(vehicles);
-
-
-
   const load = useCallback(() => {
-
     setLoading(true);
-
     setMessage("");
-
     api
-
       .vehicles(query)
-
       .then(setVehicles)
-
       .catch((error: Error) => setMessage(error.message))
-
       .finally(() => setLoading(false));
-
   }, [query]);
 
-
-
-  useEffect(() => {
-
-    load();
-
-  }, [load]);
-
-
-
-  useEffect(() => {
-
-    const reloadVisible = () => {
-
-      if (!document.hidden) {
-
-        load();
-
+  const {
+    qr: {
+      state: { open: qrDialogOpen, svg: qrSvg, error: qrError },
+      commands: {
+        close: closeQrDialog,
+        generate: generateQr,
+        downloadPng: downloadQrPng,
+        downloadSvg: downloadQrSvg,
+        print: printQr,
+        openForVehicle: openQrForVehicle
       }
-
-    };
-
-
-
-    window.addEventListener("focus", reloadVisible);
-
-    window.addEventListener("online", reloadVisible);
-
-    document.addEventListener("visibilitychange", reloadVisible);
-
-
-
-    return () => {
-
-      window.removeEventListener("focus", reloadVisible);
-
-      window.removeEventListener("online", reloadVisible);
-
-      document.removeEventListener("visibilitychange", reloadVisible);
-
-    };
-
-  }, [load]);
-
-
-
-  useEffect(() => {
-
-    Promise.all([
-
-      api.masterDataAll(true),
-
-      api.masterDataRelations("vehicle_category", "vehicle_gattung")
-
-    ])
-
-      .then(([entriesByType, categoryRelations]) => {
-
-        setOptions({
-
-          manufacturers: entriesByType.manufacturer || [],
-
-          gauges: entriesByType.gauge || [],
-
-          epochs: entriesByType.epoch || [],
-
-          railwayCompanies: entriesByType.railway_company || [],
-
-          categories: entriesByType.vehicle_category || [],
-
-          gattungen: entriesByType.vehicle_gattung || [],
-
-          symbols: entriesByType.symbols || [],
-
-          categoryRelations
-
-        });
-
-      })
-
-      .catch((error: Error) => setMessage(error.message));
-
-  }, []);
-
-
-
-  const openECoSDraft = useCallback((draft: ECoSVehicleDraftPayload) => {
-
-    const draftImages: PendingArticleImage[] = (draft.imageSuggestions || []).map((image, index) => ({
-
-      ...image,
-
-      id: image.id || `ecos-${draft.sourceSummary.objectId}-${index}`,
-
-      isPrimary: index === 0,
-
-      maintenanceId: ""
-
-    }));
-
-    const mergeDraftImages = (current: PendingArticleImage[]) => {
-
-      if (draftImages.length === 0) return current;
-
-      const existing = new Set(current.map((image) => image.url));
-
-      const next = [...current, ...draftImages.filter((image) => !existing.has(image.url))];
-
-      if (!next.some((image) => image.isPrimary) && next.length > 0) {
-
-        next[0] = { ...next[0], isPrimary: true };
-
-      }
-
-      return next;
-
-    };
-
-    const draftFunctionEdits = Object.fromEntries((draft.functionValues || []).map((item) => [
-
-      item.functionKey,
-
-      {
-
-        name: item.name || "",
-
-        symbolKey: item.symbolKey || "",
-
-        functionType: item.functionType || "standard",
-
-        mode: item.mode || "dauer",
-
-        directionDependent: Boolean(item.directionDependent),
-
-        notes: item.notes || "",
-
-        persisted: false
-
-      }
-
-    ]));
-
-    const applyDraftValues = (base: CreateVehicleRequest) => {
-
-      const next = { ...base };
-
-      const keys = draft.importedKeys?.length
-
-        ? draft.importedKeys
-
-        : Object.keys(draft.vehicle) as (keyof CreateVehicleRequest)[];
-
-      keys.forEach((key) => {
-
-        const value = draft.vehicle[key];
-
-        if (typeof value === "boolean" || (typeof value === "string" && value.trim() !== "")) {
-
-          (next as Record<string, unknown>)[key] = value;
-
-        }
-
-      });
-
-      return next;
-
-    };
-
-    const finishOpen = () => {
-
-      resetMaintenanceForm();
-
-      resetSparePartForm();
-
-      resetSparePartSearch();
-
-      resetUploadDocumentSearch();
-
-      resetCVController();
-
-      resetDecoderFiles();
-
-      setEcosDraft(draft);
-
-      setEcosUnclearFields(new Set(draft.unclearFields));
-
-      setShowConfiguredFunctionsOnly((draft.functionValues || []).length > 0);
-
-      setActiveTab("model");
-
-      setOpenSections({ model: true, details: false, vehicle: false });
-
-      setModalOpen(true);
-
-      setMessage(draft.mode === "update" ? t("vehicles.ecosDraft.loadedUpdate") : t("vehicles.ecosDraft.loaded"));
-
-    };
-
-    if (draft.mode === "update" && draft.targetVehicleId) {
-
-      api.vehicle(draft.targetVehicleId)
-
-        .then((detail) => {
-
-          setSelectedDetail(detail);
-
-          setPendingArticleImages((current) => mergeDraftImages(current));
-
-          setMode("edit");
-
-          setForm(applyDraftValues(vehicleToForm(detail)));
-
-          setFunctionEdits({
-
-            ...functionsToEditState(detail.functions),
-
-            ...draftFunctionEdits
-
-          });
-
-          finishOpen();
-
-        })
-
-        .catch((error: Error) => setMessage(error.message));
-
-      return;
-
-    }
-
-    const nextForm = applyDraftValues(emptyVehicle);
-
-    setSelected(null);
-
-    setMode("create");
-
-    setForm(nextForm);
-
-    setPendingArticleImages(mergeDraftImages([]));
-
-    setAttachmentEdits({});
-
-    setImageUploadMaintenanceID("");
-
-    setAttachmentUploadCategory("");
-
-    setAttachmentUploadDescription("");
-
-    setAttachmentDragActive(false);
-    setAttachmentDeleteCandidate(null);
-    setSaveAttempted(false);
-
-    setFunctionEdits(draftFunctionEdits);
-
-    finishOpen();
-
-  }, [t]);
-
-
-
-  useEffect(() => {
-
-    const rawDraft = window.sessionStorage.getItem(ecosVehicleDraftStorageKey);
-
-    if (!rawDraft) return;
-
-
-
-    try {
-
-      const draft = JSON.parse(rawDraft) as ECoSVehicleDraftPayload;
-
-      if (draft?.source === "ecos") {
-
-        openECoSDraft(draft);
-
-      }
-
-    } catch {
-
-      setMessage(t("vehicles.ecosDraft.invalid"));
-
-    } finally {
-
-      window.sessionStorage.removeItem(ecosVehicleDraftStorageKey);
-
-      if (window.location.search.includes("source=ecos")) {
-
-        window.history.replaceState(null, "", "/vehicles");
-
-      }
-
-    }
-
-  }, [openECoSDraft, t]);
-
-
-
-  useEffect(() => {
-
-    if (!quickMenuVehicleID) return;
-
-
-
-    const closeOnPointerDown = (event: PointerEvent) => {
-
-      if (event.target instanceof Element && event.target.closest(".quick-menu-wrap")) {
-
-        return;
-
-      }
-
-      setQuickMenuVehicleID("");
-
-    };
-
-    const closeOnEscape = (event: KeyboardEvent) => {
-
-      if (event.key === "Escape") {
-
-        setQuickMenuVehicleID("");
-
-      }
-
-    };
-
-
-
-    window.addEventListener("pointerdown", closeOnPointerDown);
-
-    window.addEventListener("keydown", closeOnEscape);
-
-    return () => {
-
-      window.removeEventListener("pointerdown", closeOnPointerDown);
-
-      window.removeEventListener("keydown", closeOnEscape);
-
-    };
-
-  }, [quickMenuVehicleID]);
-
-
-
-  const canRunArticleSearch = hasArticleSearchCriteria(form);
-
-  const canGenerateQr = hasQrPayloadData(selected, form);
-
-  const requiredModelFields = [
-    { key: "manufacturer" as const, label: t("vehicle.field.manufacturer"), value: form.manufacturer },
-    { key: "name" as const, label: t("vehicle.field.name"), value: form.name },
-    { key: "gauge" as const, label: t("vehicle.field.gauge"), value: form.gauge },
-    { key: "category" as const, label: t("vehicle.field.category"), value: form.category },
-    { key: "gattung" as const, label: t("vehicle.field.gattung"), value: form.gattung }
-  ];
-
-  const missingRequiredModelFields = requiredModelFields.filter((field) => !compactValue(field.value));
-
-  const showRequiredErrors = saveAttempted || Boolean(ecosDraft);
-
-
-
-  const inventoryFilters = [
-
-    { key: "all" as const, label: t("vehicles.filter.all"), count: inventoryFilterCounts.all },
-
-    { key: "digital" as const, label: t("vehicles.filter.digital"), count: inventoryFilterCounts.digital, icon: <Cpu size={15} aria-hidden="true" /> },
-
-    { key: "analog" as const, label: t("vehicles.filter.analog"), count: inventoryFilterCounts.analog, icon: <Circle size={15} aria-hidden="true" /> },
-
-    { key: "withImages" as const, label: t("vehicles.filter.withImages"), count: inventoryFilterCounts.withImages, icon: <Image size={15} aria-hidden="true" /> },
-
-    { key: "withoutImages" as const, label: t("vehicles.filter.withoutImages"), count: inventoryFilterCounts.withoutImages, icon: <ImageOff size={15} aria-hidden="true" /> }
-
-  ];
-
-
-
-  const maintenanceFilters = [
-
-    { key: "all" as const, label: t("vehicles.filter.all"), count: vehicles.length },
-
-    { key: "due" as const, label: t("vehicles.filter.maintenanceDue"), count: inventoryFilterCounts.maintenanceDue, icon: <Wrench size={15} aria-hidden="true" /> },
-
-    { key: "none" as const, label: t("vehicles.filter.withoutMaintenance"), count: inventoryFilterCounts.withoutMaintenance, icon: <CircleOff size={15} aria-hidden="true" /> }
-
-  ];
-
-
-
-  const filteredGattungen = useMemo(() => {
-
-    const categoryKey = options.categories.find((entry) => optionValue(entry) === form.category)?.key;
-
-    if (!categoryKey) {
-
-      return options.gattungen;
-
-    }
-
-    const allowed = new Set(
-
-      options.categoryRelations
-
-        .filter((relation) => relation.parentKey === categoryKey)
-
-        .map((relation) => relation.childKey)
-
-    );
-
-    return options.gattungen.filter((entry) => allowed.has(entry.key));
-
-  }, [form.category, options]);
-
-
-
-  const syncECoSUnclearFields = (nextForm: CreateVehicleRequest) => {
-
-    setEcosUnclearFields((current) => {
-
-      if (!ecosDraft && current.size === 0) return current;
-
-      const next = new Set(current);
-
-      ecosRequiredFields.forEach((field) => {
-
-        if (compactValue(nextForm[field])) {
-
-          next.delete(field);
-
-        } else if (ecosDraft?.unclearFields.includes(field)) {
-
-          next.add(field);
-
-        }
-
-      });
-
-      return next;
-
-    });
-
-  };
-
-
-
-  const ecosFieldClass = (field: ECoSRequiredField) => (ecosDraft && ecosUnclearFields.has(field) ? "ecos-unclear-field" : "");
-
-
-
-  const refreshSelectedVehicle = (vehicleID = selected?.id) => {
-
-    if (!vehicleID) return Promise.resolve();
-
-    return api
-
-      .vehicle(vehicleID)
-
-      .then((detail) => {
-
-        setSelectedDetail(detail);
-
-        load();
-
-      })
-
-      .catch((error: Error) => setMessage(error.message));
-
-  };
-
-
-
-  const functionEdit = (functionKey: string) => functionEdits[functionKey] || emptyFunctionEdit(functionKey);
-
-
-
-  const updateFunctionEdit = (functionKey: string, patch: Partial<VehicleFunctionInput>) => {
-
-    setFunctionEdits((current) => ({
-
-      ...current,
-
-      [functionKey]: {
-
-        ...emptyFunctionEdit(functionKey),
-
-        ...current[functionKey],
-
-        ...patch
-
-      }
-
-    }));
-
-  };
-
-
-
-  const saveFunction = (functionKey: string) => {
-
-    if (!selected) return;
-
-    const edit = functionEdit(functionKey);
-
-    if (!edit.persisted && !edit.name?.trim() && !edit.symbolKey && !edit.notes?.trim()) {
-
-      setMessage(`${functionKey}: Bitte Funktionsname, Symbol oder Notiz eintragen.`);
-
-      return;
-
-    }
-
-    setSaving(true);
-
-    setMessage("");
-
-    api
-
-      .updateVehicleFunction(selected.id, functionKey, {
-
-        name: edit.name || "",
-
-        symbolKey: edit.symbolKey || "",
-
-        functionType: edit.functionType || "standard",
-
-        mode: edit.mode || "dauer",
-
-        directionDependent: Boolean(edit.directionDependent),
-
-        notes: edit.notes || ""
-
-      })
-
-      .then(() => refreshSelectedVehicle(selected.id))
-
-      .catch((error: Error) => setMessage(error.message))
-
-      .finally(() => setSaving(false));
-
-  };
-
-
-
-  const deleteFunction = (functionKey: string) => {
-
-    if (!selected) return;
-
-    setSaving(true);
-
-    setMessage("");
-
-    api
-
-      .deleteVehicleFunction(selected.id, functionKey)
-
-      .then(() => refreshSelectedVehicle(selected.id))
-
-      .catch((error: Error) => setMessage(error.message))
-
-      .finally(() => setSaving(false));
-
-  };
-
-
-
-  const exportFunctions = () => {
-
-    if (!selected) return;
-
-    const functionMappings = configuredFunctionKeys.map((functionKey) => {
-
-      const edit = functionEdit(functionKey);
-
-      return {
-
-        functionKey,
-
-        name: edit.name || "",
-
-        symbolKey: edit.symbolKey || "",
-
-        functionType: edit.functionType || "standard",
-
-        mode: edit.mode || "dauer",
-
-        directionDependent: Boolean(edit.directionDependent),
-
-        notes: edit.notes || ""
-
-      };
-
-    });
-
-    const payload = {
-
-      vehicle: {
-
-        inventoryNumber: selected.inventoryNumber,
-
-        name: selected.name,
-
-        decoder: form.digitalDecoderNumber || form.dtDecoderNumber || ""
-
-      },
-
-      functions: functionMappings
-
-    };
-
-    const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
-
-    const url = URL.createObjectURL(blob);
-
-    const anchor = document.createElement("a");
-
-    anchor.href = url;
-
-    anchor.download = `${selected.inventoryNumber || "railkeeper"}-funktionen.json`;
-
-    anchor.click();
-
-    URL.revokeObjectURL(url);
-
-  };
-
-
-
-  const importFunctions = (files: FileList | null) => {
-
-    if (!selected || !files || files.length === 0) return;
-
-    const [file] = Array.from(files);
-
-    setSaving(true);
-
-    setMessage("");
-
-    file
-
-      .text()
-
-      .then(functionMappingsFromImport)
-
-      .then(async (rows) => {
-
-        const valid = rows.filter(isValidFunctionMapping);
-
-        if (valid.length === 0) {
-
-          throw new Error("Keine g?ltigen Funktionszuordnungen gefunden.");
-
-        }
-
-        for (const row of valid) {
-
-          await api.updateVehicleFunction(selected.id, row.functionKey, {
-
-            name: row.name || "",
-
-            symbolKey: row.symbolKey || "",
-
-            functionType: row.functionType || "standard",
-
-            mode: row.mode || "dauer",
-
-            directionDependent: Boolean(row.directionDependent),
-
-            notes: row.notes || ""
-
-          });
-
-        }
-
-      })
-
-      .then(() => refreshSelectedVehicle(selected.id))
-
-      .catch((error: Error) => setMessage(error.message))
-
-      .finally(() => {
-
-        setSaving(false);
-
-        if (functionImportInputRef.current) {
-
-          functionImportInputRef.current.value = "";
-
-        }
-
-      });
-
-  };
-
-
-
-  const generateQr = async () => {
-
-    if (!hasQrPayloadData(selected, form)) {
-
-      setQrDialogOpen(false);
-
-      setQrSvg("");
-
-      setQrError("");
-
-      setMessage(t("vehicles.qr.missingInput"));
-
-      return;
-
-    }
-
-
-
-    setQrDialogOpen(true);
-
-    setQrSvg("");
-
-    setQrError("");
-
-    try {
-
-      setQrSvg(await buildQrSvg(selected, form));
-
-    } catch (error) {
-
-      setQrError(error instanceof Error ? error.message : "QR-Code konnte nicht erstellt werden.");
-
-    }
-
-  };
-
-
-
-  const downloadQrSvg = () => {
-
-    downloadQrSvgFile(qrSvg, form.inventoryNumber || "railkeeper");
-
-  };
-
-
-
-  const downloadQrPng = async () => {
-
-    await downloadQrPngFile(qrPayload(selected, form), form.inventoryNumber || "railkeeper");
-
-  };
-
-
-
-  const printQr = () => {
-
-    try {
-
-      printQrSvgLabel(qrSvg, form);
-
-    } catch (error) {
-
-      setQrError(error instanceof Error ? error.message : "Druckfenster konnte nicht geöffnet werden.");
-
-    }
-
-  };
-
-
-
-  const buildInventoryReportAssets = async (reportVehicles: Vehicle[], includeQRCode = reportIncludeQRCode) => {
-
-    const assets: InventoryReportAssets = {};
-
-    if (!includeQRCode) return assets;
-
-    await Promise.all(
-
-      reportVehicles.map(async (vehicle) => {
-
-        assets[vehicle.id] = {
-
-          qrCode: await buildBrandedQrPngDataUrl(qrPayload(vehicle, vehicleToForm(vehicle)), 192)
-
-        };
-
-      })
-
-    );
-
-    return assets;
-
-  };
-
-
-
-  const loadCompleteReportVehicles = async (reportVehicles: Vehicle[]) => {
-
-    return Promise.all(reportVehicles.map((vehicle) => api.vehicle(vehicle.id)));
-
-  };
-
-
-
-  const createInventoryReport = async (event?: FormEvent) => {
-
-    event?.preventDefault();
-
-    const reportVehicles = reportSelection === "selected" ? selectedVisibleVehicles : sortedVehicles;
-    const reportName = `railkeeper-inventory-${reportMode}`;
-
-    if (reportVehicles.length === 0) {
-
-      setMessage("Es gibt keine Fahrzeuge f?r den PDF-Report.");
-
-      return;
-
-    }
-
-    setReportCreating(true);
-    const reportWindow = reservePrintDocument(reportName, reportTitle.trim() || "Fahrzeugsammlung");
-
-    try {
-
-      const completeReportVehicles = await loadCompleteReportVehicles(reportVehicles);
-
-      const assets = await buildInventoryReportAssets(completeReportVehicles);
-
-      const html = inventoryReportHtml(completeReportVehicles, query, sort, {
-
+    },
+    report: {
+      state: {
+        open: reportDialogOpen,
         mode: reportMode,
-
-        title: reportTitle.trim() || "Fahrzeugsammlung",
-
+        title: reportTitle,
+        selection: reportSelection,
         includeQRCode: reportIncludeQRCode,
-
-        includeImages: reportIncludeImages
-
-      }, assets);
-
-      openPrintDocument(html, reportName, reportWindow);
-
-      setReportDialogOpen(false);
-
-    } catch (error) {
-
-      setMessage(error instanceof Error ? error.message : "Report konnte nicht erstellt werden.");
-
-    } finally {
-
-      setReportCreating(false);
-
-    }
-
-  };
-
-
-
-  const printVehicleReport = async (vehicle: Vehicle) => {
-
-    const reportName = `railkeeper-vehicle-${vehicle.id}`;
-    const reportWindow = reservePrintDocument(reportName, vehicle.name || vehicle.inventoryNumber || "Fahrzeugsammlung");
-
-    try {
-
-      const completeVehicle = await api.vehicle(vehicle.id);
-
-      const assets = await buildInventoryReportAssets([completeVehicle], true);
-
-      const html = inventoryReportHtml([completeVehicle], completeVehicle.inventoryNumber || completeVehicle.name, sort, {
-
-        mode: "details",
-
-        title: completeVehicle.name || completeVehicle.inventoryNumber || "Fahrzeugsammlung",
-
-        includeQRCode: true,
-
-        includeImages: true
-
-      }, assets);
-
-      openPrintDocument(html, reportName, reportWindow);
-
-    } catch (error) {
-
-      setMessage(error instanceof Error ? error.message : "Report konnte nicht erstellt werden.");
-
-    }
-
-  };
-
-
-
-  const updateVehicleExhibitionFlag = (vehicle: Vehicle, exhibition: boolean) => {
-
-    setMessage("");
-
-    return api
-
-      .updateVehicle(vehicle.id, { ...vehicleToForm(vehicle), exhibition })
-
-      .then((updated) => {
-
-        const nextVehicle = {
-
-          ...updated,
-
-          images: updated.images ?? vehicle.images,
-
-          attachments: updated.attachments ?? vehicle.attachments
-
-        };
-
-        setVehicles((current) => current.map((item) => (item.id === nextVehicle.id ? nextVehicle : item)));
-
-        if (selected?.id === nextVehicle.id) {
-
-          setSelectedDetail(nextVehicle);
-
-        }
-
-        return nextVehicle;
-
-      });
-
-  };
-
-
-
-  const loadAssignmentEntries = (listID: string) => {
-
-    if (!listID) {
-
-      setExhibitionAssignment((current) => current ? { ...current, selectedListID: "", entries: [], loadingEntries: false, error: "" } : current);
-
-      return;
-
-    }
-
-    setExhibitionAssignment((current) => current ? { ...current, selectedListID: listID, loadingEntries: true, error: "" } : current);
-
-    api
-
-      .exhibitionEntries(listID)
-
-      .then((entries) => {
-
-        setExhibitionAssignment((current) => current && current.selectedListID === listID ? { ...current, entries, loadingEntries: false, error: "" } : current);
-
-      })
-
-      .catch((error: Error) => {
-
-        setExhibitionAssignment((current) => current ? { ...current, entries: [], loadingEntries: false, error: error.message } : current);
-
-      });
-
-  };
-
-
-
-  const openExhibitionAssignment = (vehicle: Vehicle) => {
-
-    if (!vehicleExhibitionEligible(vehicle)) {
-
-      setMessage(t("vehicles.exhibition.requiresDecoder"));
-
-      return;
-
-    }
-
-    setMessage("");
-
-    setExhibitionAssignment({
-
-      vehicle,
-
-      lists: [],
-
-      selectedListID: "",
-
-      entries: [],
-
-      loadingEntries: true,
-
-      saving: false,
-
-      error: ""
-
-    });
-
-    api
-
-      .exhibitionLists()
-
-      .then((lists) => {
-
-        const availableLists = lists.filter((list) => !list.locked);
-
-        const firstListID = availableLists[0]?.id || "";
-
-        setExhibitionAssignment((current) => current ? {
-
-          ...current,
-
-          lists: availableLists,
-
-          selectedListID: firstListID,
-
-          loadingEntries: Boolean(firstListID),
-
-          error: firstListID ? "" : t("vehicles.exhibition.noOpenLists")
-
-        } : current);
-
-        if (firstListID) {
-
-          return api.exhibitionEntries(firstListID).then((entries) => {
-
-            setExhibitionAssignment((current) => current && current.selectedListID === firstListID ? { ...current, entries, loadingEntries: false, error: "" } : current);
-
-          });
-
-        }
-
-        return undefined;
-
-      })
-
-      .catch((error: Error) => {
-
-        setExhibitionAssignment((current) => current ? { ...current, loadingEntries: false, error: error.message } : current);
-
-      });
-
-  };
-
-
-
-  const duplicateAssignmentVehicle = exhibitionAssignment
-
-    ? exhibitionAssignment.entries.find((entry) =>
-
-      normalizedText(entry.owner) === normalizedText(username) &&
-
-      normalizedText(entry.locomotiveName) === normalizedText(exhibitionAssignment.vehicle.name)
-
-    )
-
-    : undefined;
-
-  const duplicateAssignmentDecoder = exhibitionAssignment?.vehicle.digitalDecoderNumber
-
-    ? exhibitionAssignment.entries.find((entry) => normalizedText(entry.decoderNumber) === normalizedText(exhibitionAssignment.vehicle.digitalDecoderNumber))
-
-    : undefined;
-
-
-
-  const saveExhibitionAssignment = () => {
-
-    if (!exhibitionAssignment || !exhibitionAssignment.selectedListID || duplicateAssignmentVehicle || duplicateAssignmentDecoder) return;
-
-    setExhibitionAssignment((current) => current ? { ...current, saving: true, error: "" } : current);
-
-    api
-
-      .vehicle(exhibitionAssignment.vehicle.id)
-
-      .then((detail) => api.createExhibitionEntry(exhibitionAssignment.selectedListID, vehicleToExhibitionEntry(detail, username)).then(() => detail))
-
-      .then((detail) => updateVehicleExhibitionFlag(detail, true))
-
-      .then(() => {
-
-        setExhibitionAssignment(null);
-
-        setMessage(t("vehicles.exhibition.assigned"));
-
-      })
-
-      .catch((error: Error) => {
-
-        setExhibitionAssignment((current) => current ? { ...current, saving: false, error: error.message } : current);
-
-      });
-
-  };
-
-
-
-  const toggleVehicleExhibition = (vehicle: Vehicle, checked: boolean) => {
-
-    if (checked) {
-
-      openExhibitionAssignment(vehicle);
-
-      return;
-
-    }
-
-    updateVehicleExhibitionFlag(vehicle, false)
-
-      .then(() => setMessage(t("vehicles.exhibition.disabled")))
-
-      .catch((error: Error) => setMessage(error.message));
-
-  };
-
-
-
-  const openQrForVehicle = (vehicle: Vehicle) => {
-
-    setQrSvg("");
-
-    setQrError("");
-
-    api
-
-      .vehicle(vehicle.id)
-
-      .then(async (detail) => {
-
-        setSelectedDetail(detail);
-
-        setQrDialogOpen(true);
-
-        setQrSvg(await buildQrSvg(detail, vehicleToForm(detail)));
-
-      })
-
-      .catch((error: Error) => setQrError(error.message));
-
-  };
-
-
-
-  const markECoSImportSessionSaved = (draft: ECoSVehicleDraftPayload, vehicleId: string) => {
-
-    if (!draft.returnToEcos) return;
-
-    try {
-
-      const rawSession = window.sessionStorage.getItem(ecosImportSessionStorageKey);
-
-      if (!rawSession) return;
-
-      const session = JSON.parse(rawSession) as {
-
-        id?: string;
-
-        statuses?: Record<string, { status: string; vehicleId?: string; updatedAt?: string }>;
-
-        updatedAt?: string;
-
-      };
-
-      if (session.id !== draft.returnToEcos.sessionId) return;
-
-      const key = String(draft.returnToEcos.objectId);
-
-      const now = new Date().toISOString();
-
-      const nextSession = {
-
-        ...session,
-
-        updatedAt: now,
-
-        statuses: {
-
-          ...(session.statuses || {}),
-
-          [key]: {
-
-            ...(session.statuses || {})[key],
-
-            status: "saved",
-
-            vehicleId,
-
-            updatedAt: now
-
-          }
-
-        }
-
-      };
-
-      window.sessionStorage.setItem(ecosImportSessionStorageKey, JSON.stringify(nextSession));
-
-    } catch {
-
-      window.sessionStorage.removeItem(ecosImportSessionStorageKey);
-
-    }
-
-  };
-
-
-
-  const returnToECoSImportSession = () => {
-
-    window.history.pushState(null, "", "/import-export?source=ecos");
-
-    window.dispatchEvent(new PopStateEvent("popstate"));
-
-  };
-
-  const isRemotePendingImage = (image: PendingArticleImage) => !image.persisted && /^https?:\/\//i.test(image.url);
-
-
-
-  const submit = async (event: FormEvent) => {
-
-    event.preventDefault();
-    setSaveAttempted(true);
-
-    if (missingRequiredModelFields.length > 0) {
-
-      setActiveTab("model");
-
-      setOpenSections((current) => ({ ...current, model: true }));
-
-      setMessage(t("vehicles.requiredMissing", { fields: missingRequiredModelFields.map((field) => field.label).join(", ") }));
-
-      return;
-
-    }
-
-    if (ecosDraft && ecosUnclearFields.size > 0) {
-
-      setMessage(t("vehicles.ecosDraft.unresolved", { count: ecosUnclearFields.size }));
-
-      return;
-
-    }
-
-
-
-    setSaving(true);
-
-    setMessage("");
-
-
-
-    try {
-
-      const sparePartsToImport = selectedFoundSparePartInputs();
-
-      const remoteImages = pendingArticleImages.filter(isRemotePendingImage);
-
-      const images = pendingArticleImages.filter((image) => !isRemotePendingImage(image)).map((image, index) => ({
-
-        id: image.persisted ? image.id : undefined,
-
-        url: image.url,
-
-        title: image.title,
-
-        sourceUrl: image.source,
-
-        maintenanceId: image.maintenanceId || "",
-
-        isPrimary: Boolean(image.isPrimary),
-
-        sortOrder: index
-
-      }));
-
-      const payload = { ...form, images };
-
-      let vehicle = mode === "edit" && selected
-
-        ? await api.updateVehicle(selected.id, payload)
-
-        : await api.createVehicle(payload);
-
-      if (remoteImages.length > 0) {
-
-        for (const [imageIndex, image] of remoteImages.entries()) {
-
-          await api.importVehicleImageFromUrl(vehicle.id, {
-
-            url: image.url,
-
-            title: image.title || "",
-
-            sourceUrl: image.source || image.url,
-
-            maintenanceId: image.maintenanceId || "",
-
-            isPrimary: Boolean(image.isPrimary),
-
-            sortOrder: images.length + imageIndex
-
-          });
-
-        }
-
-        vehicle = await api.vehicle(vehicle.id);
-
+        includeImages: reportIncludeImages,
+        creating: reportCreating
+      },
+      setters: {
+        setOpen: setReportDialogOpen,
+        setMode: setReportMode,
+        setTitle: setReportTitle,
+        setSelection: setReportSelection,
+        setIncludeQRCode: setReportIncludeQRCode,
+        setIncludeImages: setReportIncludeImages
+      },
+      commands: { create: createInventoryReport, printVehicle: printVehicleReport }
+    },
+    exhibition: {
+      state: {
+        assignment: exhibitionAssignment,
+        duplicateVehicle: duplicateAssignmentVehicle,
+        duplicateDecoder: duplicateAssignmentDecoder
+      },
+      commands: {
+        close: closeExhibitionAssignment,
+        loadEntries: loadAssignmentEntries,
+        save: saveExhibitionAssignment,
+        toggle: toggleVehicleExhibition
       }
-
-      if (sparePartsToImport.length > 0) {
-
-        for (const part of sparePartsToImport) {
-
-          await api.createVehicleSparePart(vehicle.id, part);
-
-        }
-
-        clearSelectedFoundSpareParts();
-
-        vehicle = await api.vehicle(vehicle.id);
-
-      }
-
-
-
-      if (ecosDraft && (mode === "create" || mode === "edit")) {
-
-        await api.upsertVehicleExternalMapping(vehicle.id, ecosDraft.externalMapping);
-
-        const detailBeforeECoSValues = await api.vehicle(vehicle.id);
-
-        for (const cvValue of ecosDraft.cvValues) {
-
-          const existing = (detailBeforeECoSValues.cvValues || []).find((entry) => cvValueKey(entry) === cvValueKey(cvValue));
-
-          if (existing) {
-
-            await api.updateVehicleCVValue(vehicle.id, existing.id, cvValue);
-
-          } else {
-
-            await api.createVehicleCVValue(vehicle.id, cvValue);
-
-          }
-
-        }
-
-        for (const functionKey of configuredFunctionKeys) {
-
-          const edit = functionEdit(functionKey);
-
-          if (!edit.name?.trim() && !edit.symbolKey && !edit.notes?.trim()) {
-
-            continue;
-
-          }
-
-          await api.updateVehicleFunction(vehicle.id, functionKey, {
-
-            name: edit.name || "",
-
-            symbolKey: edit.symbolKey || "",
-
-            functionType: edit.functionType || "standard",
-
-            mode: edit.mode || "dauer",
-
-            directionDependent: Boolean(edit.directionDependent),
-
-            notes: edit.notes || ""
-
-          });
-
-        }
-
-        markECoSImportSessionSaved(ecosDraft, vehicle.id);
-
-        vehicle = await api.vehicle(vehicle.id);
-
-        setEcosDraft(null);
-
-        setEcosUnclearFields(new Set());
-
-        if (ecosDraft.returnToEcos) {
-
-          load();
-
-          closeModal();
-
-          returnToECoSImportSession();
-
-          return;
-
-        }
-
-      }
-
-
-
-      vehicle = await api.vehicle(vehicle.id);
-
-      setSelectedDetail(vehicle);
-
-      setMode("edit");
-
-      setSaveAttempted(false);
-
-      load();
-
-      if (mode === "create") {
-
-        setMessage(t("vehicles.createdContinue"));
-
-      } else if (sparePartsToImport.length > 0) {
-
-        setMessage(t("vehicles.spareParts.importedCount", { count: sparePartsToImport.length }));
-
-      }
-
-    } catch (error) {
-
-      setMessage(error instanceof Error ? error.message : String(error));
-
-    } finally {
-
-      setSaving(false);
-
     }
-
-  };
-
-
-
-  const confirmDelete = () => {
-
-    if (!deleteCandidate) return;
-
-
-
-    api
-
-      .deleteVehicle(deleteCandidate.id)
-
-      .then(() => {
-
-        if (selected?.id === deleteCandidate.id) {
-
-          closeModal();
-
-        }
-
-        setDeleteCandidate(null);
-
-        load();
-
-      })
-
-      .catch((error: Error) => setMessage(error.message));
-
-  };
-
-
-
-  const sortHeader = (key: SortKey) => (
-
-    <button
-
-      type="button"
-
-      className={`sort-button ${sort.key === key ? "active" : ""}`}
-
-      onClick={() => toggleSort(key)}
-
-      title={t("common.sort", { label: t(`vehicle.field.${key}`) })}
-
-    >
-
-      {t(`vehicle.field.${key}`)}
-
-      {sort.key === key
-
-        ? sort.direction === "asc"
-
-          ? <ChevronUp size={14} />
-
-          : <ChevronDown size={14} />
-
-        : <ArrowUpDown size={13} />}
-
-    </button>
-
-  );
-
-
-
-  const vehicleQuickMenu = (vehicle: Vehicle) => (
-
-    <div className="quick-menu-wrap">
-
-      <button
-
-        type="button"
-
-        className={quickMenuVehicleID === vehicle.id ? "icon-button active" : "icon-button"}
-
-        onClick={() => setQuickMenuVehicleID((current) => current === vehicle.id ? "" : vehicle.id)}
-
-        aria-label={t("vehicles.quickMenu")}
-
-        title={t("vehicles.quickMenu")}
-
-      >
-
-        <MoreVertical size={16} />
-
-      </button>
-
-      {quickMenuVehicleID === vehicle.id && (
-
-        <div className="quick-menu" role="menu">
-
-          <button type="button" role="menuitem" onClick={() => { setQuickMenuVehicleID(""); openDetail(vehicle); }}><Eye size={14} />{t("vehicles.view")}</button>
-
-          <button type="button" role="menuitem" onClick={() => { setQuickMenuVehicleID(""); openEdit(vehicle); }}><Pencil size={14} />{t("vehicles.edit")}</button>
-
-          <span className="quick-menu-separator" role="separator" />
-
-          <button type="button" role="menuitem" onClick={() => { setQuickMenuVehicleID(""); openQrForVehicle(vehicle); }}><QrCode size={14} />QR-Code</button>
-
-          <button type="button" role="menuitem" onClick={() => { setQuickMenuVehicleID(""); printVehicleReport(vehicle); }}><Printer size={14} />{t("overview.print")}</button>
-
-          <button type="button" role="menuitem" onClick={() => { setQuickMenuVehicleID(""); openEdit(vehicle, "uploads"); }}><Upload size={14} />Uploads</button>
-
-          <button type="button" role="menuitem" onClick={() => { setQuickMenuVehicleID(""); openEdit(vehicle, "maintenance"); }}><Wrench size={14} />{t("vehicles.maintenance")}</button>
-
-          <button type="button" role="menuitem" onClick={() => { setQuickMenuVehicleID(""); openEdit(vehicle, "spareParts"); }}><PackageSearch size={14} />{t("vehicles.tab.spareParts")}</button>
-
-          <span className="quick-menu-separator" role="separator" />
-
-          <button type="button" role="menuitem" className="danger" onClick={() => { setQuickMenuVehicleID(""); setDeleteCandidate(vehicle); }}><Trash2 size={14} />{t("vehicles.delete")}</button>
-
-        </div>
-
-      )}
-
-    </div>
-
-  );
-
-
-
-  const selectOptions = (items: MasterDataEntry[], emptyLabel = "Keine Auswahl") => (
-
-    <>
-
-      <option value="">{emptyLabel}</option>
-
-      {items.map((entry) => (
-
-        <option key={entry.key} value={optionValue(entry)}>
-
-          {entry.label}
-
-        </option>
-
-      ))}
-
-    </>
-
-  );
-
-
-
-  const maintenanceEntries = selected?.maintenance || [];
-
-  const maintenanceSummary = {
-
-    due: maintenanceEntries.filter(maintenanceIsDue).length,
-
-    planned: maintenanceEntries.filter((entry) => entry.status !== "erledigt").length,
-
-    done: maintenanceEntries.filter((entry) => entry.status === "erledigt").length
-
-  };
-
-  const configuredFunctionKeys = functionKeys.filter((functionKey) => {
-
-    const edit = functionEdit(functionKey);
-
-    return Boolean(edit.persisted || edit.name || edit.symbolKey || edit.notes);
-
+  } = useVehicleOutputController({
+    username,
+    form,
+    selected,
+    query,
+    sort,
+    sortedVehicles,
+    selectedVisibleVehicles,
+    setVehicles,
+    setSelectedDetail,
+    onMessage: setMessage,
+    t
   });
 
-  const visibleFunctionKeys = showConfiguredFunctionsOnly ? configuredFunctionKeys : functionKeys;
+  useEffect(() => {
+    load();
+  }, [load]);
 
-  const functionSummary = {
+  useEffect(() => {
+    const reloadVisible = () => {
+      if (!document.hidden) {
+        load();
+      }
+    };
+    window.addEventListener("focus", reloadVisible);
+    window.addEventListener("online", reloadVisible);
+    document.addEventListener("visibilitychange", reloadVisible);
+    return () => {
+      window.removeEventListener("focus", reloadVisible);
+      window.removeEventListener("online", reloadVisible);
+      document.removeEventListener("visibilitychange", reloadVisible);
+    };
+  }, [load]);
 
-    configured: configuredFunctionKeys.length,
+  useEffect(() => {
+    Promise.all([
+      api.masterDataAll(true),
+      api.masterDataRelations("vehicle_category", "vehicle_gattung")
+    ])
+      .then(([entriesByType, categoryRelations]) => {
+        setOptions({
+          manufacturers: entriesByType.manufacturer || [],
+          gauges: entriesByType.gauge || [],
+          epochs: entriesByType.epoch || [],
+          railwayCompanies: entriesByType.railway_company || [],
+          categories: entriesByType.vehicle_category || [],
+          gattungen: entriesByType.vehicle_gattung || [],
+          symbols: entriesByType.symbols || [],
+          categoryRelations
+        });
+      })
+      .catch((error: Error) => setMessage(error.message));
+  }, []);
 
-    sound: configuredFunctionKeys.filter((functionKey) => functionEdit(functionKey).functionType === "sound").length,
+  const {
+    state: { draft: ecosDraft, unclearFields: ecosUnclearFields },
+    setters: { setDraft: setEcosDraft, setUnclearFields: setEcosUnclearFields },
+    commands: {
+      clear: clearECoSDraft,
+      syncUnclearFields: syncECoSUnclearFields,
+      fieldClass: ecosFieldClass,
+      markImportSessionSaved: markECoSImportSessionSaved,
+      returnToImportSession: returnToECoSImportSession
+    }
+  } = useVehicleECoSDraftController({
+    onOpenCreate: (prepared) => {
+      setSelected(null);
+      setMode("create");
+      setForm(prepared.form);
+      setPendingArticleImages(prepared.mergeImages([]));
+      setAttachmentEdits({});
+      setImageUploadMaintenanceID("");
+      setAttachmentUploadCategory("");
+      setAttachmentUploadDescription("");
+      setAttachmentDragActive(false);
+      setAttachmentDeleteCandidate(null);
+      setSaveAttempted(false);
+      setFunctionEdits(prepared.functionEdits);
+    },
+    onOpenUpdate: (detail, prepared) => {
+      setSelectedDetail(detail);
+      setPendingArticleImages((current) => prepared.mergeImages(current));
+      setMode("edit");
+      setForm(prepared.form);
+      mergeFunctionEdits(detail.functions, prepared.functionEdits);
+    },
+    onFinishOpen: (draft) => {
+      resetMaintenanceForm();
+      resetSparePartForm();
+      resetSparePartSearch();
+      resetUploadDocumentSearch();
+      resetCVController();
+      resetDecoderFiles();
+      setShowConfiguredFunctionsOnly((draft.functionValues || []).length > 0);
+      setActiveTab("model");
+      setOpenSections({ model: true, details: false, vehicle: false });
+      setModalOpen(true);
+      setMessage(draft.mode === "update" ? t("vehicles.ecosDraft.loadedUpdate") : t("vehicles.ecosDraft.loaded"));
+    },
+    onMessage: setMessage,
+    t
+  });
 
-    light: configuredFunctionKeys.filter((functionKey) => functionEdit(functionKey).functionType === "licht").length
+  useEffect(() => {
+    if (!quickMenuVehicleID) return;
+    const closeOnPointerDown = (event: PointerEvent) => {
+      if (event.target instanceof Element && event.target.closest(".quick-menu-wrap")) {
+        return;
+      }
+      setQuickMenuVehicleID("");
+    };
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setQuickMenuVehicleID("");
+      }
+    };
+    window.addEventListener("pointerdown", closeOnPointerDown);
+    window.addEventListener("keydown", closeOnEscape);
+    return () => {
+      window.removeEventListener("pointerdown", closeOnPointerDown);
+      window.removeEventListener("keydown", closeOnEscape);
+    };
+  }, [quickMenuVehicleID]);
 
+  const canRunArticleSearch = hasArticleSearchCriteria(form);
+  const canGenerateQr = hasQrPayloadData(selected, form);
+  const missingRequiredModelFields = missingVehicleModelFieldLabels(form, t);
+  const showRequiredErrors = saveAttempted || Boolean(ecosDraft);
+  const { inventoryFilters, maintenanceFilters } = createVehicleFilterDefinitions({
+    vehicleCount: vehicles.length,
+    counts: inventoryFilterCounts,
+    t
+  });
+  const filteredGattungen = gattungenForCategory(options, form.category);
+
+  const refreshSelectedVehicle = (vehicleID = selected?.id) => {
+    if (!vehicleID) return Promise.resolve();
+    return api
+      .vehicle(vehicleID)
+      .then((detail) => {
+        setSelectedDetail(detail);
+        load();
+      })
+      .catch((error: Error) => setMessage(error.message));
+  };
+  const { submit, confirmDelete } = createVehicleMutationCommands({
+    editor: {
+      form,
+      selected,
+      mode,
+      setSaving,
+      setSelectedDetail,
+      setMode,
+      setSaveAttempted,
+      setActiveTab,
+      openModelSection: () => setOpenSections((current) => ({ ...current, model: true })),
+      close: closeModal
+    },
+    validation: {
+      missingRequiredLabels: missingRequiredModelFields
+    },
+    media: { pendingImages: pendingArticleImages },
+    spareParts: {
+      selectedInputs: selectedFoundSparePartInputs,
+      clearSelected: clearSelectedFoundSpareParts
+    },
+    functions: {
+      configuredKeys: configuredFunctionKeys,
+      edit: functionEdit
+    },
+    ecos: {
+      draft: ecosDraft,
+      unclearFieldCount: ecosUnclearFields.size,
+      markSaved: markECoSImportSessionSaved,
+      clear: clearECoSDraft,
+      returnToSession: returnToECoSImportSession
+    },
+    deletion: {
+      candidate: deleteCandidate,
+      setCandidate: setDeleteCandidate
+    },
+    reloadVehicles: load,
+    onMessage: setMessage,
+    t
+  });
+  const { sortHeader, vehicleQuickMenu, selectOptions } = createVehicleInventoryRenderers({
+    sort,
+    quickMenuVehicleID,
+    setQuickMenuVehicleID,
+    toggleSort,
+    openDetail,
+    openEdit,
+    openQr: openQrForVehicle,
+    printVehicle: printVehicleReport,
+    setDeleteCandidate,
+    t
+  });
+  const maintenanceEntries = selected?.maintenance || [];
+  const maintenanceSummary = {
+    due: maintenanceEntries.filter(maintenanceIsDue).length,
+    planned: maintenanceEntries.filter((entry) => entry.status !== "erledigt").length,
+    done: maintenanceEntries.filter((entry) => entry.status === "erledigt").length
   };
 
   return (
-
     <>
-
       <VehicleInventoryPanel
-
         vehicles={vehicles}
-
         sortedVehicles={sortedVehicles}
-
         loading={loading}
-
         message={message}
-
         query={query}
-
         inventoryView={inventoryView}
-
         inventoryFilter={inventoryFilter}
-
         maintenanceFilter={maintenanceFilter}
-
         qualityFilter={qualityFilter}
-
         manufacturerFilter={manufacturerFilter}
-
         categoryFilter={categoryFilter}
-
         gattungFilter={gattungFilter}
-
         exhibitionReadyFilter={exhibitionReadyFilter}
-
         inventorySummary={inventorySummary}
-
         maintenanceReminderSummary={maintenanceReminderSummary}
-
         nextMaintenanceReminder={nextMaintenanceReminder}
-
         inventoryFilters={inventoryFilters}
-
         maintenanceFilters={maintenanceFilters}
-
         inventoryFilterOptions={inventoryFilterOptions}
-
         hasActiveInventoryFilters={hasActiveInventoryFilters}
-
         allVisibleSelected={allVisibleSelected}
-
         selectedVehicleIDs={selectedVehicleIDs}
-
         onCreate={openCreate}
-
         onReload={load}
-
         onOpenReport={() => setReportDialogOpen(true)}
-
         onQueryChange={setQuery}
-
         onInventoryViewChange={setInventoryViewMode}
-
         onInventoryFilterChange={setInventoryFilter}
-
         onMaintenanceFilterChange={setMaintenanceFilter}
-
         onQualityFilterChange={setQualityFilter}
-
         onManufacturerFilterChange={setManufacturerFilter}
-
         onCategoryFilterChange={setCategoryFilter}
-
         onGattungFilterChange={setGattungFilter}
-
         onExhibitionReadyFilterChange={setExhibitionReadyFilter}
-
         onResetFilters={resetInventoryFilters}
-
         onOpenDetail={openDetail}
-
         onOpenEdit={openEdit}
-
         onDelete={setDeleteCandidate}
-
         onToggleSelection={toggleVehicleSelection}
-
         onToggleAllVisibleSelection={toggleAllVisibleSelection}
-
         onToggleExhibition={toggleVehicleExhibition}
-
         renderSortHeader={sortHeader}
-
         renderQuickMenu={vehicleQuickMenu}
-
       />
-
       {reportDialogOpen && (
-
         <ReportDialog
-
           reportMode={reportMode}
-
           reportTitle={reportTitle}
-
           reportSelection={reportSelection}
-
           reportIncludeQRCode={reportIncludeQRCode}
-
           reportIncludeImages={reportIncludeImages}
-
           selectedCount={selectedVisibleVehicles.length}
-
           canUseSelected={someVisibleSelected}
-
           creating={reportCreating}
-
           onReportModeChange={setReportMode}
-
           onReportTitleChange={setReportTitle}
-
           onReportSelectionChange={setReportSelection}
-
           onReportIncludeQRCodeChange={setReportIncludeQRCode}
-
           onReportIncludeImagesChange={setReportIncludeImages}
-
           onClose={() => setReportDialogOpen(false)}
-
           onSubmit={createInventoryReport}
-
         />
-
       )}
-
-
-
       {modalOpen && (
-
-        <div className="modal-layer" role="dialog" aria-modal="true" aria-label={t("vehicles.modal.aria")}>
-
-          <form key={`${mode}-${selected?.id || "new"}`} className={mode === "view" ? "vehicle-modal vehicle-read-modal-shell" : "vehicle-modal"} onSubmit={submit}>
-
-            <header className="modal-head">
-
-              <h2>{mode === "create" ? t("vehicles.modal.create") : mode === "edit" ? t("vehicles.modal.edit") : t("vehicles.modal.view")}</h2>
-
-              <button type="button" className="icon-button" onClick={closeModal} aria-label={t("vehicles.close")} title={t("vehicles.close")}>
-
-                <X size={18} />
-
-              </button>
-
-            </header>
-
-
-
-            {mode === "view" && selected ? (
-
-              <VehicleReadOnlyView
-
-                vehicle={selected}
-
-                onEdit={() => openEdit(selected)}
-
-                onPrint={() => printVehicleReport(selected)}
-
-                onQr={generateQr}
-
-                onPreviewImage={setPreviewImage}
-
-              />
-
-            ) : (
-
-              <>
-
-            <nav className="modal-tabs" aria-label={t("vehicles.modal.aria")}>
-
-              <button type="button" className={activeTab === "model" ? "active" : ""} onClick={() => setActiveTab("model")}>
-
-                {t("vehicles.tab.model")}
-
-              </button>
-
-              <button type="button" className={activeTab === "control" ? "active" : ""} onClick={() => setActiveTab("control")}>
-
-                {t("vehicles.tab.control")}
-
-              </button>
-
-              <button type="button" className={activeTab === "speedCurve" ? "active" : ""} onClick={() => setActiveTab("speedCurve")}>
-
-                {t("vehicles.tab.speedCurve")}
-
-              </button>
-
-              <button type="button" className={activeTab === "cv" ? "active" : ""} onClick={() => setActiveTab("cv")}>
-
-                CV
-
-              </button>
-
-              <button type="button" className={activeTab === "uploads" ? "active" : ""} onClick={() => setActiveTab("uploads")}>
-
-                {t("vehicles.tab.uploads")}
-
-              </button>
-
-              <button type="button" className={activeTab === "maintenance" ? "active" : ""} onClick={() => setActiveTab("maintenance")}>
-
-                {t("vehicles.tab.maintenance")}
-
-              </button>
-
-              <button type="button" className={activeTab === "spareParts" ? "active" : ""} onClick={() => setActiveTab("spareParts")}>
-
-                {t("vehicles.tab.spareParts")}
-
-              </button>
-
-            </nav>
-
-
-
-            <div className="modal-body">
-
-              {activeTab === "model" && (
-
-                <VehicleModelTab
-
-                  form={form}
-
-                  externalMappings={selected?.externalMappings || []}
-
-                  readonly={readonly}
-
-                  articleSearchLoading={articleSearchLoading}
-
-                  canRunArticleSearch={canRunArticleSearch}
-
-                  showRequiredErrors={showRequiredErrors}
-
-                  options={options}
-
-                  filteredGattungen={filteredGattungen}
-
-                  openSections={openSections}
-
-                  selectOptions={selectOptions}
-
-                  ecosFieldClass={ecosFieldClass}
-
-                  onToggleSection={toggleSection}
-
-                  onOpenBarcodeSearch={openBarcodeSearch}
-
-                  onRunArticleSearch={() => runArticleSearch()}
-
-                  onUpdate={update}
-
-                  onUpdateCategory={updateCategory}
-
-                  onOpenQr={generateQr}
-
-                  canOpenQr={canGenerateQr}
-
-                  onUpdateCouplingFront={updateCouplingFront}
-
-                  onUpdateCouplingSame={updateCouplingSame}
-
-                />
-
-              )}
-
-              {activeTab === "control" && (
-
-                <VehicleFunctionsTab
-
-                  selected={selected}
-
-                  draftMode={Boolean(ecosDraft)}
-
-                  readonly={readonly}
-
-                  saving={saving}
-
-                  functionImportInputRef={functionImportInputRef}
-
-                  configuredFunctionKeys={configuredFunctionKeys}
-
-                  functionSummary={functionSummary}
-
-                  showConfiguredFunctionsOnly={showConfiguredFunctionsOnly}
-
-                  visibleFunctionKeys={visibleFunctionKeys}
-
-                  symbols={options.symbols}
-
-                  onImportFunctions={importFunctions}
-
-                  onExportFunctions={exportFunctions}
-
-                  onShowConfiguredFunctionsOnlyChange={setShowConfiguredFunctionsOnly}
-
-                  functionEdit={functionEdit}
-
-                  updateFunctionEdit={updateFunctionEdit}
-
-                  inferFunctionTypeFromSymbol={inferFunctionTypeFromSymbol}
-
-                  saveFunction={saveFunction}
-
-                  deleteFunction={deleteFunction}
-
-                />
-
-              )}
-
-              {activeTab === "speedCurve" && (
-
-                <VehicleSpeedCurveTab
-
-                  selected={selected}
-
-                  ecosDraft={ecosDraft}
-
-                />
-
-              )}
-
-              {activeTab === "cv" && (
-
-                <VehicleCVTab
-
-                  selected={selected}
-
-                  ecosDraft={ecosDraft}
-
-                  readonly={readonly}
-
-                  saving={saving}
-
-                  cvImportInputRef={cvImportInputRef}
-
-                  cvFileInputRef={cvFileInputRef}
-
-                  cvSummary={cvSummary}
-
-                  cvImportPreview={cvImportPreview}
-
-                  cvImportStats={cvImportStats}
-
-                  cvForm={cvForm}
-
-                  editingCVID={editingCVID}
-
-                  decoderProfileOptions={decoderProfileOptions}
-
-                  storedDecoderProfiles={storedDecoderProfiles}
-
-                  cvFileProfile={cvFileProfile}
-
-                  cvFileDescription={cvFileDescription}
-
-                  cvFileUploadPreview={cvFileUploadPreview}
-
-                  cvFilePreviewStats={cvFilePreviewStats}
-
-                  importCVValues={importCVValues}
-
-                  exportCVValues={exportCVValues}
-
-                  selectCVImportRows={selectCVImportRows}
-
-                  applyCVImportPreview={applyCVImportPreview}
-
-                  discardCVImportPreview={discardCVImportPreview}
-
-                  toggleCVImportRow={toggleCVImportRow}
-
-                  updateCVForm={updateCVForm}
-
-                  resetCVForm={resetCVForm}
-
-                  saveCVValue={saveCVValue}
-
-                  editCVValue={editCVValue}
-
-                  deleteCVValue={deleteCVValue}
-
-                  uploadCVFiles={uploadCVFiles}
-
-                  setCVFileProfile={setCVFileProfile}
-
-                  setCVFileDescription={setCVFileDescription}
-
-                  applyFirstCVFileSuggestion={applyFirstCVFileSuggestion}
-
-                  previewCVFileValuesForImport={previewCVFileValuesForImport}
-
-                  applyCVFileFunctionSuggestions={applyCVFileFunctionSuggestions}
-
-                  confirmCVFileUpload={confirmCVFileUpload}
-
-                  discardCVFileUploadPreview={discardCVFileUploadPreview}
-
-                  deleteCVFile={deleteCVFile}
-
-                />
-
-              )}
-
-              {activeTab === "uploads" && (
-
-                <VehicleUploadsTab
-
-                  selected={selected}
-
-                  readonly={readonly}
-
-                  saving={saving}
-
-                  imageInputRef={imageInputRef}
-
-                  attachmentInputRef={attachmentInputRef}
-
-                  maintenanceEntries={maintenanceEntries}
-
-                  imageUploadMaintenanceID={imageUploadMaintenanceID}
-
-                  pendingArticleImages={pendingArticleImages}
-
-                  attachmentDragActive={attachmentDragActive}
-
-                  attachmentUploadCategory={attachmentUploadCategory}
-
-                  attachmentUploadDescription={attachmentUploadDescription}
-
-                  attachmentEdits={attachmentEdits}
-
-                  documentSearchLoading={documentSearchLoading}
-
-                  documentSearchError={documentSearchError}
-
-                  documentSearchRan={documentSearchRan}
-
-                  foundDocuments={foundUploadDocuments}
-
-                  selectedDocuments={selectedUploadDocuments}
-
-                  onImageUploadMaintenanceIDChange={setImageUploadMaintenanceID}
-
-                  onUploadImages={uploadImages}
-
-                  onPreviewImage={setPreviewImage}
-
-                  onUpdatePendingImageTitle={updatePendingImageTitle}
-
-                  onUpdatePendingImageMaintenance={updatePendingImageMaintenance}
-
-                  onMovePendingImage={movePendingImage}
-
-                  onSetPrimaryPendingImage={setPrimaryPendingImage}
-
-                  onRemovePendingImage={removePendingImage}
-
-                  onUploadAttachment={uploadAttachment}
-
-                  onAttachmentDrag={onAttachmentDrag}
-
-                  onAttachmentDrop={onAttachmentDrop}
-
-                  onAttachmentUploadCategoryChange={setAttachmentUploadCategory}
-
-                  onAttachmentUploadDescriptionChange={setAttachmentUploadDescription}
-
-                  onUpdateAttachmentEdit={updateAttachmentEdit}
-
-                  onSaveAttachment={saveAttachment}
-
-                  onExtractAttachmentSpareParts={extractAttachmentSpareParts}
-
-                  onDeleteAttachment={setAttachmentDeleteCandidate}
-
-                  onSearchDocuments={runUploadDocumentSearch}
-
-                  onImportDocument={importFoundDocument}
-
-                  onImportSelectedDocuments={importSelectedFoundDocuments}
-
-                  onToggleDocument={toggleFoundDocument}
-
-                  onToggleAllDocuments={toggleAllFoundDocuments}
-
-                />
-
-              )}
-
-              {activeTab === "maintenance" && (
-
-                <VehicleMaintenanceTab
-
-                  selected={selected}
-
-                  pendingArticleImages={pendingArticleImages}
-
-                  readonly={readonly}
-
-                  saving={saving}
-
-                  maintenanceForm={maintenanceForm}
-
-                  editingMaintenanceID={editingMaintenanceID}
-
-                  maintenanceSummary={maintenanceSummary}
-
-                  onUpdateMaintenanceForm={updateMaintenanceForm}
-
-                  onResetMaintenanceForm={resetMaintenanceForm}
-
-                  onSaveMaintenance={saveMaintenance}
-
-                  onCompleteMaintenance={completeMaintenance}
-
-                  onEditMaintenance={editMaintenance}
-
-                  onDeleteMaintenance={deleteMaintenance}
-
-                />
-
-              )}
-
-              {activeTab === "spareParts" && (
-
-                <VehicleSparePartsTab
-
-                  selected={selected}
-
-                  readonly={readonly}
-
-                  saving={saving}
-
-                  sparePartForm={sparePartForm}
-
-                  editingSparePartID={editingSparePartID}
-
-                  sparePartLookupLoadingID={sparePartLookupLoadingID}
-
-                  sparePartLookupErrors={sparePartLookupErrors}
-
-                  sparePartLookupResults={sparePartLookupResults}
-
-                  sparePartStatusLoading={sparePartStatusLoading}
-
-                  sparePartStatuses={sparePartStatuses}
-
-                  importAllSparePartsLoading={importAllSparePartsLoading}
-
-                  canImportAllSpareParts={canImportAllAvailableSpareParts}
-
-                  importAllSparePartsTitle={importAllAvailableSparePartsTitle}
-
-                  onUpdateSparePartForm={updateSparePartForm}
-
-                  onResetSparePartForm={resetSparePartForm}
-
-                  onSaveSparePart={saveSparePart}
-
-                  onEditSparePart={editSparePart}
-
-                  onDeleteSparePart={deleteSparePart}
-
-                  onSearchSparePart={searchSingleSparePart}
-
-                  onApplySparePartLookup={applySparePartLookup}
-
-                  onImportAllSpareParts={importAllAvailableSpareParts}
-
-                  sparePartSort={sparePartSort}
-
-                  onToggleSparePartSort={toggleSparePartSort}
-
-                />
-
-              )}            </div>
-
-
-
-            <footer className="modal-actions">
-
-              {message && <p className="form-message">{message}</p>}
-
-              <button type="button" className="secondary-button" onClick={closeModal}>
-
-                {t("vehicles.cancel")}
-
-              </button>
-
-              <button className="primary-button" disabled={saving}>
-
-                {saving ? t("vehicles.saving") : mode === "create" ? t("vehicles.createAndContinue") : t("vehicles.saveChanges")}
-
-              </button>
-
-            </footer>
-
-              </>
-
-            )}
-
-          </form>
-
-        </div>
-
+        <VehicleEditorDialog
+          mode={mode}
+          selected={selected}
+          activeTab={activeTab}
+          saving={saving}
+          message={message}
+          onSubmit={submit}
+          onClose={closeModal}
+          onTabChange={setActiveTab}
+          onEdit={() => {
+            if (selected) openEdit(selected);
+          }}
+          onPrint={() => {
+            if (selected) printVehicleReport(selected);
+          }}
+          onQr={generateQr}
+          onPreviewImage={setPreviewImage}
+          tabs={{
+            model: {
+              form,
+              externalMappings: selected?.externalMappings || [],
+              readonly,
+              articleSearchLoading,
+              canRunArticleSearch,
+              showRequiredErrors,
+              options,
+              filteredGattungen,
+              openSections,
+              selectOptions,
+              ecosFieldClass,
+              onToggleSection: toggleSection,
+              onOpenBarcodeSearch: openBarcodeSearch,
+              onRunArticleSearch: () => runArticleSearch(),
+              onUpdate: update,
+              onUpdateCategory: updateCategory,
+              onOpenQr: generateQr,
+              canOpenQr: canGenerateQr,
+              onUpdateCouplingFront: updateCouplingFront,
+              onUpdateCouplingSame: updateCouplingSame
+            },
+            functions: {
+              selected,
+              draftMode: Boolean(ecosDraft),
+              readonly,
+              saving,
+              functionImportInputRef,
+              configuredFunctionKeys,
+              functionSummary,
+              showConfiguredFunctionsOnly,
+              visibleFunctionKeys,
+              symbols: options.symbols,
+              onImportFunctions: importFunctions,
+              onExportFunctions: exportFunctions,
+              onShowConfiguredFunctionsOnlyChange: setShowConfiguredFunctionsOnly,
+              functionEdit,
+              updateFunctionEdit,
+              inferFunctionTypeFromSymbol,
+              saveFunction,
+              deleteFunction
+            },
+            speedCurve: { selected, ecosDraft },
+            cv: {
+              selected,
+              ecosDraft,
+              readonly,
+              saving,
+              cvImportInputRef,
+              cvFileInputRef,
+              cvSummary,
+              cvImportPreview,
+              cvImportStats,
+              cvForm,
+              editingCVID,
+              decoderProfileOptions,
+              storedDecoderProfiles,
+              cvFileProfile,
+              cvFileDescription,
+              cvFileUploadPreview,
+              cvFilePreviewStats,
+              importCVValues,
+              exportCVValues,
+              selectCVImportRows,
+              applyCVImportPreview,
+              discardCVImportPreview,
+              toggleCVImportRow,
+              updateCVForm,
+              resetCVForm,
+              saveCVValue,
+              editCVValue,
+              deleteCVValue,
+              uploadCVFiles,
+              setCVFileProfile,
+              setCVFileDescription,
+              applyFirstCVFileSuggestion,
+              previewCVFileValuesForImport,
+              applyCVFileFunctionSuggestions,
+              confirmCVFileUpload,
+              discardCVFileUploadPreview,
+              deleteCVFile
+            },
+            uploads: {
+              selected,
+              readonly,
+              saving,
+              imageInputRef,
+              attachmentInputRef,
+              maintenanceEntries,
+              imageUploadMaintenanceID,
+              pendingArticleImages,
+              attachmentDragActive,
+              attachmentUploadCategory,
+              attachmentUploadDescription,
+              attachmentEdits,
+              documentSearchLoading,
+              documentSearchError,
+              documentSearchRan,
+              foundDocuments: foundUploadDocuments,
+              selectedDocuments: selectedUploadDocuments,
+              onImageUploadMaintenanceIDChange: setImageUploadMaintenanceID,
+              onUploadImages: uploadImages,
+              onPreviewImage: setPreviewImage,
+              onUpdatePendingImageTitle: updatePendingImageTitle,
+              onUpdatePendingImageMaintenance: updatePendingImageMaintenance,
+              onMovePendingImage: movePendingImage,
+              onSetPrimaryPendingImage: setPrimaryPendingImage,
+              onRemovePendingImage: removePendingImage,
+              onUploadAttachment: uploadAttachment,
+              onAttachmentDrag,
+              onAttachmentDrop,
+              onAttachmentUploadCategoryChange: setAttachmentUploadCategory,
+              onAttachmentUploadDescriptionChange: setAttachmentUploadDescription,
+              onUpdateAttachmentEdit: updateAttachmentEdit,
+              onSaveAttachment: saveAttachment,
+              onExtractAttachmentSpareParts: extractAttachmentSpareParts,
+              onDeleteAttachment: setAttachmentDeleteCandidate,
+              onSearchDocuments: runUploadDocumentSearch,
+              onImportDocument: importFoundDocument,
+              onImportSelectedDocuments: importSelectedFoundDocuments,
+              onToggleDocument: toggleFoundDocument,
+              onToggleAllDocuments: toggleAllFoundDocuments
+            },
+            maintenance: {
+              selected,
+              pendingArticleImages,
+              readonly,
+              saving,
+              maintenanceForm,
+              editingMaintenanceID,
+              maintenanceSummary,
+              onUpdateMaintenanceForm: updateMaintenanceForm,
+              onResetMaintenanceForm: resetMaintenanceForm,
+              onSaveMaintenance: saveMaintenance,
+              onCompleteMaintenance: completeMaintenance,
+              onEditMaintenance: editMaintenance,
+              onDeleteMaintenance: deleteMaintenance
+            },
+            spareParts: {
+              selected,
+              readonly,
+              saving,
+              sparePartForm,
+              editingSparePartID,
+              sparePartLookupLoadingID,
+              sparePartLookupErrors,
+              sparePartLookupResults,
+              sparePartStatusLoading,
+              sparePartStatuses,
+              importAllSparePartsLoading,
+              canImportAllSpareParts: canImportAllAvailableSpareParts,
+              importAllSparePartsTitle: importAllAvailableSparePartsTitle,
+              onUpdateSparePartForm: updateSparePartForm,
+              onResetSparePartForm: resetSparePartForm,
+              onSaveSparePart: saveSparePart,
+              onEditSparePart: editSparePart,
+              onDeleteSparePart: deleteSparePart,
+              onSearchSparePart: searchSingleSparePart,
+              onApplySparePartLookup: applySparePartLookup,
+              onImportAllSpareParts: importAllAvailableSpareParts,
+              sparePartSort,
+              onToggleSparePartSort: toggleSparePartSort
+            }
+          }}
+        />
       )}
-
-
-
       {articleSearchOpen && (
-
         <ArticleSearchDialog
-
           form={form}
-
           loading={articleSearchLoading}
-
           response={articleSearchResponse}
-
           error={articleSearchError}
-
           selectedFields={selectedArticleFields}
-
           selectedImages={selectedArticleImages}
-
           onApply={applyArticleResult}
-
           onClose={() => setArticleSearchOpen(false)}
-
           onToggleField={toggleArticleField}
-
           onToggleImage={toggleArticleImage}
-
         />
-
       )}
-
-
-
       {barcodeSearchOpen && (
-
         <BarcodeSearchDialog
-
           value={barcodeSearchValue}
-
           onValueChange={setBarcodeSearchValue}
-
           onClose={() => setBarcodeSearchOpen(false)}
-
           onSubmit={submitBarcodeSearch}
-
         />
-
       )}
-
-
-
       {qrDialogOpen && (
-
         <QrDialog
-
           form={form}
-
           qrSvg={qrSvg}
-
           error={qrError}
-
-          onClose={() => setQrDialogOpen(false)}
-
+          onClose={closeQrDialog}
           onDownloadPng={downloadQrPng}
-
           onDownloadSvg={downloadQrSvg}
-
           onPrint={printQr}
-
         />
-
       )}
-
-
-
       {previewImage && (
-
         <ImagePreviewDialog
-
           image={previewImage}
-
           onClose={() => setPreviewImage(null)}
-
         />
-
       )}
-
-
-
       {exhibitionAssignment && (
-
         <ExhibitionAssignmentDialog
-
           assignment={exhibitionAssignment}
-
           duplicateVehicle={duplicateAssignmentVehicle}
-
           duplicateDecoder={duplicateAssignmentDecoder}
-
-          onClose={() => setExhibitionAssignment(null)}
-
+          onClose={closeExhibitionAssignment}
           onListChange={loadAssignmentEntries}
-
           onSave={saveExhibitionAssignment}
-
         />
-
       )}
-
-
-
       {deleteCandidate && (
-
         <DeleteVehicleDialog
-
           vehicle={deleteCandidate}
-
           onClose={() => setDeleteCandidate(null)}
-
           onConfirm={confirmDelete}
-
         />
-
       )}
-
-
-
       {attachmentDeleteCandidate && (
-
         <DeleteAttachmentDialog
-
           attachment={attachmentDeleteCandidate}
-
           onClose={() => setAttachmentDeleteCandidate(null)}
-
           onConfirm={() => deleteAttachment(attachmentDeleteCandidate)}
-
         />
-
       )}
-
     </>
-
   );
-
 }

--- a/frontend/src/features/vehicles/useVehicleECoSDraftController.ts
+++ b/frontend/src/features/vehicles/useVehicleECoSDraftController.ts
@@ -1,0 +1,188 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { api, type CreateVehicleRequest, type Vehicle } from "../../shared/api";
+import type { FunctionEditState, PendingArticleImage } from "./vehicleTransforms";
+import { vehicleToForm } from "./vehicleTransforms";
+import {
+  compactValue,
+  ecosImportSessionStorageKey,
+  ecosRequiredFields,
+  ecosVehicleDraftStorageKey,
+  emptyVehicle,
+  type ECoSRequiredField,
+  type ECoSVehicleDraftPayload
+} from "./vehicleViewModel";
+
+type Translator = (key: string, values?: Record<string, string | number>) => string;
+
+type PreparedECoSDraft = {
+  form: CreateVehicleRequest;
+  images: PendingArticleImage[];
+  functionEdits: FunctionEditState;
+  mergeImages: (current: PendingArticleImage[]) => PendingArticleImage[];
+};
+
+type UseVehicleECoSDraftControllerOptions = {
+  onOpenCreate: (prepared: PreparedECoSDraft) => void;
+  onOpenUpdate: (detail: Vehicle, prepared: PreparedECoSDraft) => void;
+  onFinishOpen: (draft: ECoSVehicleDraftPayload) => void;
+  onMessage: (message: string) => void;
+  t: Translator;
+};
+
+export function useVehicleECoSDraftController({
+  onOpenCreate,
+  onOpenUpdate,
+  onFinishOpen,
+  onMessage,
+  t
+}: UseVehicleECoSDraftControllerOptions) {
+  const [draft, setDraft] = useState<ECoSVehicleDraftPayload | null>(null);
+  const [unclearFields, setUnclearFields] = useState<Set<ECoSRequiredField>>(() => new Set());
+
+  const clear = () => {
+    setDraft(null);
+    setUnclearFields(new Set());
+  };
+
+  const syncUnclearFields = (nextForm: CreateVehicleRequest) => {
+    if (!draft) return;
+    setUnclearFields((current) => {
+      const next = new Set(current);
+      ecosRequiredFields.forEach((field) => {
+        if (compactValue(nextForm[field])) next.delete(field);
+        else if (draft.unclearFields.includes(field)) next.add(field);
+      });
+      return next;
+    });
+  };
+
+  const fieldClass = (field: ECoSRequiredField) => (
+    draft && unclearFields.has(field) ? "ecos-unclear-field" : ""
+  );
+
+  const openDraft = useCallback((nextDraft: ECoSVehicleDraftPayload) => {
+    const images: PendingArticleImage[] = (nextDraft.imageSuggestions || []).map((image, index) => ({
+      ...image,
+      id: image.id || `ecos-${nextDraft.sourceSummary.objectId}-${index}`,
+      isPrimary: index === 0,
+      maintenanceId: ""
+    }));
+    const mergeImages = (current: PendingArticleImage[]) => {
+      if (images.length === 0) return current;
+      const existing = new Set(current.map((image) => image.url));
+      const merged = [...current, ...images.filter((image) => !existing.has(image.url))];
+      if (!merged.some((image) => image.isPrimary) && merged.length > 0) {
+        merged[0] = { ...merged[0], isPrimary: true };
+      }
+      return merged;
+    };
+    const functionEdits: FunctionEditState = Object.fromEntries((nextDraft.functionValues || []).map((item) => [
+      item.functionKey,
+      {
+        name: item.name || "",
+        symbolKey: item.symbolKey || "",
+        functionType: item.functionType || "standard",
+        mode: item.mode || "dauer",
+        directionDependent: Boolean(item.directionDependent),
+        notes: item.notes || "",
+        persisted: false
+      }
+    ]));
+    const applyDraftValues = (base: CreateVehicleRequest) => {
+      const next = { ...base };
+      const keys = nextDraft.importedKeys?.length
+        ? nextDraft.importedKeys
+        : Object.keys(nextDraft.vehicle) as (keyof CreateVehicleRequest)[];
+      keys.forEach((key) => {
+        const value = nextDraft.vehicle[key];
+        if (typeof value === "boolean" || (typeof value === "string" && value.trim() !== "")) {
+          (next as Record<string, unknown>)[key] = value;
+        }
+      });
+      return next;
+    };
+    const finish = () => {
+      setDraft(nextDraft);
+      setUnclearFields(new Set(nextDraft.unclearFields));
+      onFinishOpen(nextDraft);
+    };
+
+    if (nextDraft.mode === "update" && nextDraft.targetVehicleId) {
+      api.vehicle(nextDraft.targetVehicleId)
+        .then((detail) => {
+          onOpenUpdate(detail, {
+            form: applyDraftValues(vehicleToForm(detail)),
+            images,
+            functionEdits,
+            mergeImages
+          });
+          finish();
+        })
+        .catch((error: Error) => onMessage(error.message));
+      return;
+    }
+
+    onOpenCreate({
+      form: applyDraftValues(emptyVehicle),
+      images,
+      functionEdits,
+      mergeImages
+    });
+    finish();
+  }, [onFinishOpen, onMessage, onOpenCreate, onOpenUpdate]);
+
+  useEffect(() => {
+    const rawDraft = window.sessionStorage.getItem(ecosVehicleDraftStorageKey);
+    if (!rawDraft) return;
+
+    try {
+      const storedDraft = JSON.parse(rawDraft) as ECoSVehicleDraftPayload;
+      if (storedDraft?.source === "ecos") openDraft(storedDraft);
+    } catch {
+      onMessage(t("vehicles.ecosDraft.invalid"));
+    } finally {
+      window.sessionStorage.removeItem(ecosVehicleDraftStorageKey);
+      if (window.location.search.includes("source=ecos")) {
+        window.history.replaceState(null, "", "/vehicles");
+      }
+    }
+  }, [onMessage, openDraft, t]);
+
+  const markImportSessionSaved = (savedDraft: ECoSVehicleDraftPayload, vehicleId: string) => {
+    if (!savedDraft.returnToEcos) return;
+    try {
+      const rawSession = window.sessionStorage.getItem(ecosImportSessionStorageKey);
+      if (!rawSession) return;
+      const session = JSON.parse(rawSession) as {
+        id?: string;
+        statuses?: Record<string, { status: string; vehicleId?: string; updatedAt?: string }>;
+        updatedAt?: string;
+      };
+      if (session.id !== savedDraft.returnToEcos.sessionId) return;
+      const key = String(savedDraft.returnToEcos.objectId);
+      const now = new Date().toISOString();
+      window.sessionStorage.setItem(ecosImportSessionStorageKey, JSON.stringify({
+        ...session,
+        updatedAt: now,
+        statuses: {
+          ...(session.statuses || {}),
+          [key]: { ...(session.statuses || {})[key], status: "saved", vehicleId, updatedAt: now }
+        }
+      }));
+    } catch {
+      window.sessionStorage.removeItem(ecosImportSessionStorageKey);
+    }
+  };
+
+  const returnToImportSession = () => {
+    window.history.pushState(null, "", "/import-export?source=ecos");
+    window.dispatchEvent(new PopStateEvent("popstate"));
+  };
+
+  return {
+    state: { draft, unclearFields },
+    setters: { setDraft, setUnclearFields },
+    commands: { clear, syncUnclearFields, fieldClass, markImportSessionSaved, returnToImportSession }
+  };
+}

--- a/frontend/src/features/vehicles/useVehicleFunctionsController.ts
+++ b/frontend/src/features/vehicles/useVehicleFunctionsController.ts
@@ -1,0 +1,158 @@
+import { useRef, useState } from "react";
+
+import { api, type CreateVehicleRequest, type Vehicle, type VehicleFunction, type VehicleFunctionInput } from "../../shared/api";
+import { functionKeys, functionMappingsFromImport, isValidFunctionMapping } from "./cvImport";
+import { functionsToEditState, type FunctionEditState } from "./vehicleTransforms";
+import { emptyFunctionEdit } from "./vehicleViewModel";
+
+type UseVehicleFunctionsControllerOptions = {
+  selected: Vehicle | null;
+  form: CreateVehicleRequest;
+  setSaving: (saving: boolean) => void;
+  onMessage: (message: string) => void;
+  refreshSelectedVehicle: (vehicleId?: string) => Promise<void>;
+};
+
+export function useVehicleFunctionsController({
+  selected,
+  form,
+  setSaving,
+  onMessage,
+  refreshSelectedVehicle
+}: UseVehicleFunctionsControllerOptions) {
+  const [edits, setEdits] = useState<FunctionEditState>({});
+  const [showConfiguredOnly, setShowConfiguredOnly] = useState(false);
+  const importInputRef = useRef<HTMLInputElement | null>(null);
+
+  const functionEdit = (functionKey: string) => edits[functionKey] || emptyFunctionEdit(functionKey);
+
+  const updateFunctionEdit = (functionKey: string, patch: Partial<VehicleFunctionInput>) => {
+    setEdits((current) => ({
+      ...current,
+      [functionKey]: {
+        ...emptyFunctionEdit(functionKey),
+        ...current[functionKey],
+        ...patch
+      }
+    }));
+  };
+
+  const reset = () => setEdits({});
+  const loadDetail = (functions: VehicleFunction[] | undefined) => setEdits(functionsToEditState(functions));
+  const mergeDetail = (functions: VehicleFunction[] | undefined, overrides: FunctionEditState) => {
+    setEdits({ ...functionsToEditState(functions), ...overrides });
+  };
+
+  const save = (functionKey: string) => {
+    if (!selected) return;
+    const edit = functionEdit(functionKey);
+
+    if (!edit.persisted && !edit.name?.trim() && !edit.symbolKey && !edit.notes?.trim()) {
+      onMessage(`${functionKey}: Bitte Funktionsname, Symbol oder Notiz eintragen.`);
+      return;
+    }
+
+    setSaving(true);
+    onMessage("");
+    api.updateVehicleFunction(selected.id, functionKey, {
+      name: edit.name || "",
+      symbolKey: edit.symbolKey || "",
+      functionType: edit.functionType || "standard",
+      mode: edit.mode || "dauer",
+      directionDependent: Boolean(edit.directionDependent),
+      notes: edit.notes || ""
+    })
+      .then(() => refreshSelectedVehicle(selected.id))
+      .catch((error: Error) => onMessage(error.message))
+      .finally(() => setSaving(false));
+  };
+
+  const remove = (functionKey: string) => {
+    if (!selected) return;
+    setSaving(true);
+    onMessage("");
+    api.deleteVehicleFunction(selected.id, functionKey)
+      .then(() => refreshSelectedVehicle(selected.id))
+      .catch((error: Error) => onMessage(error.message))
+      .finally(() => setSaving(false));
+  };
+
+  const configuredKeys = functionKeys.filter((functionKey) => {
+    const edit = functionEdit(functionKey);
+    return Boolean(edit.persisted || edit.name || edit.symbolKey || edit.notes);
+  });
+  const visibleKeys = showConfiguredOnly ? configuredKeys : functionKeys;
+  const summary = {
+    configured: configuredKeys.length,
+    sound: configuredKeys.filter((functionKey) => functionEdit(functionKey).functionType === "sound").length,
+    light: configuredKeys.filter((functionKey) => functionEdit(functionKey).functionType === "licht").length
+  };
+
+  const exportValues = () => {
+    if (!selected) return;
+    const functionMappings = configuredKeys.map((functionKey) => {
+      const edit = functionEdit(functionKey);
+      return {
+        functionKey,
+        name: edit.name || "",
+        symbolKey: edit.symbolKey || "",
+        functionType: edit.functionType || "standard",
+        mode: edit.mode || "dauer",
+        directionDependent: Boolean(edit.directionDependent),
+        notes: edit.notes || ""
+      };
+    });
+    const payload = {
+      vehicle: {
+        inventoryNumber: selected.inventoryNumber,
+        name: selected.name,
+        decoder: form.digitalDecoderNumber || form.dtDecoderNumber || ""
+      },
+      functions: functionMappings
+    };
+    const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = `${selected.inventoryNumber || "railkeeper"}-funktionen.json`;
+    anchor.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const importValues = (files: FileList | null) => {
+    if (!selected || !files || files.length === 0) return;
+    const [file] = Array.from(files);
+    setSaving(true);
+    onMessage("");
+    file.text()
+      .then(functionMappingsFromImport)
+      .then(async (rows) => {
+        const valid = rows.filter(isValidFunctionMapping);
+        if (valid.length === 0) throw new Error("Keine gültigen Funktionszuordnungen gefunden.");
+
+        for (const row of valid) {
+          await api.updateVehicleFunction(selected.id, row.functionKey, {
+            name: row.name || "",
+            symbolKey: row.symbolKey || "",
+            functionType: row.functionType || "standard",
+            mode: row.mode || "dauer",
+            directionDependent: Boolean(row.directionDependent),
+            notes: row.notes || ""
+          });
+        }
+      })
+      .then(() => refreshSelectedVehicle(selected.id))
+      .catch((error: Error) => onMessage(error.message))
+      .finally(() => {
+        setSaving(false);
+        if (importInputRef.current) importInputRef.current.value = "";
+      });
+  };
+
+  return {
+    state: { edits, showConfiguredOnly, configuredKeys, visibleKeys, summary },
+    refs: { importInputRef },
+    setters: { setEdits, setShowConfiguredOnly },
+    commands: { functionEdit, updateFunctionEdit, reset, loadDetail, mergeDetail, save, remove, exportValues, importValues }
+  };
+}

--- a/frontend/src/features/vehicles/useVehicleOutputController.ts
+++ b/frontend/src/features/vehicles/useVehicleOutputController.ts
@@ -1,0 +1,329 @@
+import type { Dispatch, FormEvent, SetStateAction } from "react";
+import { useState } from "react";
+
+import { api, type CreateVehicleRequest, type ExhibitionEntry, type Vehicle } from "../../shared/api";
+import {
+  buildBrandedQrPngDataUrl,
+  buildQrSvg,
+  downloadQrPngFile,
+  downloadQrSvgFile,
+  printQrSvgLabel,
+  qrPayload
+} from "./vehicleQr";
+import {
+  type InventoryReportAssets,
+  inventoryReportHtml,
+  openPrintDocument,
+  reservePrintDocument
+} from "./vehicleReports";
+import { normalizedText, vehicleExhibitionEligible, vehicleToExhibitionEntry, vehicleToForm } from "./vehicleTransforms";
+import type {
+  ExhibitionAssignment,
+  InventoryReportMode,
+  InventoryReportSelection,
+  SortDirection,
+  SortKey
+} from "./vehicleViewModel";
+import { hasQrPayloadData } from "./vehicleViewModel";
+
+type Translator = (key: string, values?: Record<string, string | number>) => string;
+
+type UseVehicleOutputControllerOptions = {
+  username: string;
+  form: CreateVehicleRequest;
+  selected: Vehicle | null;
+  query: string;
+  sort: { key: SortKey; direction: SortDirection };
+  sortedVehicles: Vehicle[];
+  selectedVisibleVehicles: Vehicle[];
+  setVehicles: Dispatch<SetStateAction<Vehicle[]>>;
+  setSelectedDetail: (vehicle: Vehicle) => void;
+  onMessage: (message: string) => void;
+  t: Translator;
+};
+
+export function useVehicleOutputController({
+  username,
+  form,
+  selected,
+  query,
+  sort,
+  sortedVehicles,
+  selectedVisibleVehicles,
+  setVehicles,
+  setSelectedDetail,
+  onMessage,
+  t
+}: UseVehicleOutputControllerOptions) {
+  const [qrDialogOpen, setQrDialogOpen] = useState(false);
+  const [qrSvg, setQrSvg] = useState("");
+  const [qrError, setQrError] = useState("");
+  const [reportDialogOpen, setReportDialogOpen] = useState(false);
+  const [reportMode, setReportMode] = useState<InventoryReportMode>("summary");
+  const [reportTitle, setReportTitle] = useState("Fahrzeugsammlung");
+  const [reportSelection, setReportSelection] = useState<InventoryReportSelection>("all");
+  const [reportIncludeQRCode, setReportIncludeQRCode] = useState(true);
+  const [reportIncludeImages, setReportIncludeImages] = useState(true);
+  const [reportCreating, setReportCreating] = useState(false);
+  const [exhibitionAssignment, setExhibitionAssignment] = useState<ExhibitionAssignment | null>(null);
+
+  const generateQr = async () => {
+    if (!hasQrPayloadData(selected, form)) {
+      setQrDialogOpen(false);
+      setQrSvg("");
+      setQrError("");
+      onMessage(t("vehicles.qr.missingInput"));
+      return;
+    }
+
+    setQrDialogOpen(true);
+    setQrSvg("");
+    setQrError("");
+    try {
+      setQrSvg(await buildQrSvg(selected, form));
+    } catch (error) {
+      setQrError(error instanceof Error ? error.message : "QR-Code konnte nicht erstellt werden.");
+    }
+  };
+
+  const downloadQrSvg = () => {
+    downloadQrSvgFile(qrSvg, form.inventoryNumber || "railkeeper");
+  };
+
+  const downloadQrPng = async () => {
+    await downloadQrPngFile(qrPayload(selected, form), form.inventoryNumber || "railkeeper");
+  };
+
+  const printQr = () => {
+    try {
+      printQrSvgLabel(qrSvg, form);
+    } catch (error) {
+      setQrError(error instanceof Error ? error.message : "Druckfenster konnte nicht geöffnet werden.");
+    }
+  };
+
+  const buildInventoryReportAssets = async (reportVehicles: Vehicle[], includeQRCode = reportIncludeQRCode) => {
+    const assets: InventoryReportAssets = {};
+    if (!includeQRCode) return assets;
+
+    await Promise.all(
+      reportVehicles.map(async (vehicle) => {
+        assets[vehicle.id] = {
+          qrCode: await buildBrandedQrPngDataUrl(qrPayload(vehicle, vehicleToForm(vehicle)), 192)
+        };
+      })
+    );
+    return assets;
+  };
+
+  const loadCompleteReportVehicles = (reportVehicles: Vehicle[]) => {
+    return Promise.all(reportVehicles.map((vehicle) => api.vehicle(vehicle.id)));
+  };
+
+  const createInventoryReport = async (event?: FormEvent) => {
+    event?.preventDefault();
+    const reportVehicles = reportSelection === "selected" ? selectedVisibleVehicles : sortedVehicles;
+    const reportName = `railkeeper-inventory-${reportMode}`;
+
+    if (reportVehicles.length === 0) {
+      onMessage("Es gibt keine Fahrzeuge für den PDF-Report.");
+      return;
+    }
+
+    setReportCreating(true);
+    const reportWindow = reservePrintDocument(reportName, reportTitle.trim() || "Fahrzeugsammlung");
+    try {
+      const completeReportVehicles = await loadCompleteReportVehicles(reportVehicles);
+      const assets = await buildInventoryReportAssets(completeReportVehicles);
+      const html = inventoryReportHtml(completeReportVehicles, query, sort, {
+        mode: reportMode,
+        title: reportTitle.trim() || "Fahrzeugsammlung",
+        includeQRCode: reportIncludeQRCode,
+        includeImages: reportIncludeImages
+      }, assets);
+      openPrintDocument(html, reportName, reportWindow);
+      setReportDialogOpen(false);
+    } catch (error) {
+      onMessage(error instanceof Error ? error.message : "Report konnte nicht erstellt werden.");
+    } finally {
+      setReportCreating(false);
+    }
+  };
+
+  const printVehicleReport = async (vehicle: Vehicle) => {
+    const reportName = `railkeeper-vehicle-${vehicle.id}`;
+    const reportWindow = reservePrintDocument(
+      reportName,
+      vehicle.name || vehicle.inventoryNumber || "Fahrzeugsammlung"
+    );
+
+    try {
+      const completeVehicle = await api.vehicle(vehicle.id);
+      const assets = await buildInventoryReportAssets([completeVehicle], true);
+      const html = inventoryReportHtml(
+        [completeVehicle],
+        completeVehicle.inventoryNumber || completeVehicle.name,
+        sort,
+        {
+          mode: "details",
+          title: completeVehicle.name || completeVehicle.inventoryNumber || "Fahrzeugsammlung",
+          includeQRCode: true,
+          includeImages: true
+        },
+        assets
+      );
+      openPrintDocument(html, reportName, reportWindow);
+    } catch (error) {
+      onMessage(error instanceof Error ? error.message : "Report konnte nicht erstellt werden.");
+    }
+  };
+
+  const updateVehicleExhibitionFlag = (vehicle: Vehicle, exhibition: boolean) => {
+    onMessage("");
+    return api.updateVehicle(vehicle.id, { ...vehicleToForm(vehicle), exhibition }).then((updated) => {
+      const nextVehicle = {
+        ...updated,
+        images: updated.images ?? vehicle.images,
+        attachments: updated.attachments ?? vehicle.attachments
+      };
+      setVehicles((current) => current.map((item) => (item.id === nextVehicle.id ? nextVehicle : item)));
+      if (selected?.id === nextVehicle.id) setSelectedDetail(nextVehicle);
+      return nextVehicle;
+    });
+  };
+
+  const loadAssignmentEntries = (listID: string) => {
+    if (!listID) {
+      setExhibitionAssignment((current) => current
+        ? { ...current, selectedListID: "", entries: [], loadingEntries: false, error: "" }
+        : current);
+      return;
+    }
+
+    setExhibitionAssignment((current) => current
+      ? { ...current, selectedListID: listID, loadingEntries: true, error: "" }
+      : current);
+    api.exhibitionEntries(listID)
+      .then((entries) => {
+        setExhibitionAssignment((current) => current && current.selectedListID === listID
+          ? { ...current, entries, loadingEntries: false, error: "" }
+          : current);
+      })
+      .catch((error: Error) => {
+        setExhibitionAssignment((current) => current
+          ? { ...current, entries: [], loadingEntries: false, error: error.message }
+          : current);
+      });
+  };
+
+  const openExhibitionAssignment = (vehicle: Vehicle) => {
+    if (!vehicleExhibitionEligible(vehicle)) {
+      onMessage(t("vehicles.exhibition.requiresDecoder"));
+      return;
+    }
+
+    onMessage("");
+    setExhibitionAssignment({
+      vehicle,
+      lists: [],
+      selectedListID: "",
+      entries: [],
+      loadingEntries: true,
+      saving: false,
+      error: ""
+    });
+    api.exhibitionLists()
+      .then((lists) => {
+        const availableLists = lists.filter((list) => !list.locked);
+        const firstListID = availableLists[0]?.id || "";
+        setExhibitionAssignment((current) => current ? {
+          ...current,
+          lists: availableLists,
+          selectedListID: firstListID,
+          loadingEntries: Boolean(firstListID),
+          error: firstListID ? "" : t("vehicles.exhibition.noOpenLists")
+        } : current);
+        if (!firstListID) return undefined;
+        return api.exhibitionEntries(firstListID).then((entries) => {
+          setExhibitionAssignment((current) => current && current.selectedListID === firstListID
+            ? { ...current, entries, loadingEntries: false, error: "" }
+            : current);
+        });
+      })
+      .catch((error: Error) => {
+        setExhibitionAssignment((current) => current
+          ? { ...current, loadingEntries: false, error: error.message }
+          : current);
+      });
+  };
+
+  const duplicateAssignmentVehicle = exhibitionAssignment
+    ? exhibitionAssignment.entries.find((entry) =>
+        normalizedText(entry.owner) === normalizedText(username) &&
+        normalizedText(entry.locomotiveName) === normalizedText(exhibitionAssignment.vehicle.name)
+      )
+    : undefined;
+  const duplicateAssignmentDecoder: ExhibitionEntry | undefined = exhibitionAssignment?.vehicle.digitalDecoderNumber
+    ? exhibitionAssignment.entries.find((entry) =>
+        normalizedText(entry.decoderNumber) === normalizedText(exhibitionAssignment.vehicle.digitalDecoderNumber)
+      )
+    : undefined;
+
+  const saveExhibitionAssignment = () => {
+    if (!exhibitionAssignment || !exhibitionAssignment.selectedListID) return;
+    if (duplicateAssignmentVehicle || duplicateAssignmentDecoder) return;
+
+    setExhibitionAssignment((current) => current ? { ...current, saving: true, error: "" } : current);
+    api.vehicle(exhibitionAssignment.vehicle.id)
+      .then((detail) => api.createExhibitionEntry(
+        exhibitionAssignment.selectedListID,
+        vehicleToExhibitionEntry(detail, username)
+      ).then(() => detail))
+      .then((detail) => updateVehicleExhibitionFlag(detail, true))
+      .then(() => {
+        setExhibitionAssignment(null);
+        onMessage(t("vehicles.exhibition.assigned"));
+      })
+      .catch((error: Error) => {
+        setExhibitionAssignment((current) => current ? { ...current, saving: false, error: error.message } : current);
+      });
+  };
+
+  const toggleVehicleExhibition = (vehicle: Vehicle, checked: boolean) => {
+    if (checked) {
+      openExhibitionAssignment(vehicle);
+      return;
+    }
+    updateVehicleExhibitionFlag(vehicle, false)
+      .then(() => onMessage(t("vehicles.exhibition.disabled")))
+      .catch((error: Error) => onMessage(error.message));
+  };
+
+  const openQrForVehicle = (vehicle: Vehicle) => {
+    setQrSvg("");
+    setQrError("");
+    api.vehicle(vehicle.id)
+      .then(async (detail) => {
+        setSelectedDetail(detail);
+        setQrDialogOpen(true);
+        setQrSvg(await buildQrSvg(detail, vehicleToForm(detail)));
+      })
+      .catch((error: Error) => setQrError(error.message));
+  };
+
+  return {
+    qr: {
+      state: { open: qrDialogOpen, svg: qrSvg, error: qrError },
+      commands: { close: () => setQrDialogOpen(false), generate: generateQr, downloadPng: downloadQrPng, downloadSvg: downloadQrSvg, print: printQr, openForVehicle: openQrForVehicle }
+    },
+    report: {
+      state: { open: reportDialogOpen, mode: reportMode, title: reportTitle, selection: reportSelection, includeQRCode: reportIncludeQRCode, includeImages: reportIncludeImages, creating: reportCreating },
+      setters: { setOpen: setReportDialogOpen, setMode: setReportMode, setTitle: setReportTitle, setSelection: setReportSelection, setIncludeQRCode: setReportIncludeQRCode, setIncludeImages: setReportIncludeImages },
+      commands: { create: createInventoryReport, printVehicle: printVehicleReport }
+    },
+    exhibition: {
+      state: { assignment: exhibitionAssignment, duplicateVehicle: duplicateAssignmentVehicle, duplicateDecoder: duplicateAssignmentDecoder },
+      commands: { close: () => setExhibitionAssignment(null), loadEntries: loadAssignmentEntries, save: saveExhibitionAssignment, toggle: toggleVehicleExhibition }
+    }
+  };
+}

--- a/frontend/src/features/vehicles/vehicleInventoryRenderers.tsx
+++ b/frontend/src/features/vehicles/vehicleInventoryRenderers.tsx
@@ -1,0 +1,155 @@
+import type { Dispatch, ReactNode, SetStateAction } from "react";
+import {
+  ArrowUpDown,
+  ChevronDown,
+  ChevronUp,
+  Circle,
+  CircleOff,
+  Cpu,
+  Eye,
+  Image,
+  ImageOff,
+  MoreVertical,
+  PackageSearch,
+  Pencil,
+  Printer,
+  QrCode,
+  Trash2,
+  Upload,
+  Wrench
+} from "lucide-react";
+
+import type { MasterDataEntry, Vehicle } from "../../shared/api";
+import { optionValue, type ModalTab, type SortDirection, type SortKey } from "./vehicleViewModel";
+
+type Translator = (key: string, values?: Record<string, string | number>) => string;
+
+type VehicleInventoryRenderersOptions = {
+  sort: { key: SortKey; direction: SortDirection };
+  quickMenuVehicleID: string;
+  setQuickMenuVehicleID: Dispatch<SetStateAction<string>>;
+  toggleSort: (key: SortKey) => void;
+  openDetail: (vehicle: Vehicle) => void;
+  openEdit: (vehicle: Vehicle, tab?: ModalTab) => void;
+  openQr: (vehicle: Vehicle) => void;
+  printVehicle: (vehicle: Vehicle) => void;
+  setDeleteCandidate: Dispatch<SetStateAction<Vehicle | null>>;
+  t: Translator;
+};
+
+export function createVehicleFilterDefinitions({
+  vehicleCount,
+  counts,
+  t
+}: {
+  vehicleCount: number;
+  counts: {
+    all: number;
+    digital: number;
+    analog: number;
+    withImages: number;
+    withoutImages: number;
+    maintenanceDue: number;
+    withoutMaintenance: number;
+  };
+  t: Translator;
+}) {
+  return {
+    inventoryFilters: [
+      { key: "all" as const, label: t("vehicles.filter.all"), count: counts.all },
+      { key: "digital" as const, label: t("vehicles.filter.digital"), count: counts.digital, icon: <Cpu size={15} aria-hidden="true" /> },
+      { key: "analog" as const, label: t("vehicles.filter.analog"), count: counts.analog, icon: <Circle size={15} aria-hidden="true" /> },
+      { key: "withImages" as const, label: t("vehicles.filter.withImages"), count: counts.withImages, icon: <Image size={15} aria-hidden="true" /> },
+      { key: "withoutImages" as const, label: t("vehicles.filter.withoutImages"), count: counts.withoutImages, icon: <ImageOff size={15} aria-hidden="true" /> }
+    ],
+    maintenanceFilters: [
+      { key: "all" as const, label: t("vehicles.filter.all"), count: vehicleCount },
+      { key: "due" as const, label: t("vehicles.filter.maintenanceDue"), count: counts.maintenanceDue, icon: <Wrench size={15} aria-hidden="true" /> },
+      { key: "none" as const, label: t("vehicles.filter.withoutMaintenance"), count: counts.withoutMaintenance, icon: <CircleOff size={15} aria-hidden="true" /> }
+    ]
+  };
+}
+
+export function createVehicleInventoryRenderers({
+  sort,
+  quickMenuVehicleID,
+  setQuickMenuVehicleID,
+  toggleSort,
+  openDetail,
+  openEdit,
+  openQr,
+  printVehicle,
+  setDeleteCandidate,
+  t
+}: VehicleInventoryRenderersOptions) {
+  const sortHeader = (key: SortKey) => (
+    <button
+      type="button"
+      className={`sort-button ${sort.key === key ? "active" : ""}`}
+      onClick={() => toggleSort(key)}
+      title={t("common.sort", { label: t(`vehicle.field.${key}`) })}
+    >
+      {t(`vehicle.field.${key}`)}
+      {sort.key === key
+        ? sort.direction === "asc"
+          ? <ChevronUp size={14} />
+          : <ChevronDown size={14} />
+        : <ArrowUpDown size={13} />}
+    </button>
+  );
+
+  const vehicleQuickMenu = (vehicle: Vehicle) => (
+    <div className="quick-menu-wrap">
+      <button
+        type="button"
+        className={quickMenuVehicleID === vehicle.id ? "icon-button active" : "icon-button"}
+        onClick={() => setQuickMenuVehicleID((current) => current === vehicle.id ? "" : vehicle.id)}
+        aria-label={t("vehicles.quickMenu")}
+        title={t("vehicles.quickMenu")}
+      >
+        <MoreVertical size={16} />
+      </button>
+      {quickMenuVehicleID === vehicle.id && (
+        <div className="quick-menu" role="menu">
+          <button type="button" role="menuitem" onClick={() => { setQuickMenuVehicleID(""); openDetail(vehicle); }}>
+            <Eye size={14} />{t("vehicles.view")}
+          </button>
+          <button type="button" role="menuitem" onClick={() => { setQuickMenuVehicleID(""); openEdit(vehicle); }}>
+            <Pencil size={14} />{t("vehicles.edit")}
+          </button>
+          <span className="quick-menu-separator" role="separator" />
+          <button type="button" role="menuitem" onClick={() => { setQuickMenuVehicleID(""); openQr(vehicle); }}>
+            <QrCode size={14} />QR-Code
+          </button>
+          <button type="button" role="menuitem" onClick={() => { setQuickMenuVehicleID(""); printVehicle(vehicle); }}>
+            <Printer size={14} />{t("overview.print")}
+          </button>
+          <button type="button" role="menuitem" onClick={() => { setQuickMenuVehicleID(""); openEdit(vehicle, "uploads"); }}>
+            <Upload size={14} />Uploads
+          </button>
+          <button type="button" role="menuitem" onClick={() => { setQuickMenuVehicleID(""); openEdit(vehicle, "maintenance"); }}>
+            <Wrench size={14} />{t("vehicles.maintenance")}
+          </button>
+          <button type="button" role="menuitem" onClick={() => { setQuickMenuVehicleID(""); openEdit(vehicle, "spareParts"); }}>
+            <PackageSearch size={14} />{t("vehicles.tab.spareParts")}
+          </button>
+          <span className="quick-menu-separator" role="separator" />
+          <button type="button" role="menuitem" className="danger" onClick={() => { setQuickMenuVehicleID(""); setDeleteCandidate(vehicle); }}>
+            <Trash2 size={14} />{t("vehicles.delete")}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+
+  const selectOptions = (items: MasterDataEntry[], emptyLabel = "Keine Auswahl"): ReactNode => (
+    <>
+      <option value="">{emptyLabel}</option>
+      {items.map((entry) => (
+        <option key={entry.key} value={optionValue(entry)}>{entry.label}</option>
+      ))}
+    </>
+  );
+
+  return { sortHeader, vehicleQuickMenu, selectOptions };
+}

--- a/frontend/src/features/vehicles/vehicleMutationCommands.test.ts
+++ b/frontend/src/features/vehicles/vehicleMutationCommands.test.ts
@@ -1,0 +1,90 @@
+import type { FormEvent } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { api, type Vehicle } from "../../shared/api";
+import { vehicleFixture } from "../../test/fixtures/vehicles";
+import { emptyVehicle } from "./vehicleViewModel";
+import { createVehicleMutationCommands } from "./vehicleMutationCommands";
+
+function commandOptions() {
+  const selected: Vehicle | null = null;
+  return {
+    editor: {
+      form: { ...emptyVehicle, manufacturer: "Piko", name: "BR 106" },
+      selected: selected as Vehicle | null,
+      mode: "create" as const,
+      setSaving: vi.fn(),
+      setSelectedDetail: vi.fn(),
+      setMode: vi.fn(),
+      setSaveAttempted: vi.fn(),
+      setActiveTab: vi.fn(),
+      openModelSection: vi.fn(),
+      close: vi.fn()
+    },
+    validation: { missingRequiredLabels: [] as string[] },
+    media: { pendingImages: [] },
+    spareParts: { selectedInputs: vi.fn(() => []), clearSelected: vi.fn() },
+    functions: { configuredKeys: [], edit: vi.fn() },
+    ecos: {
+      draft: null,
+      unclearFieldCount: 0,
+      markSaved: vi.fn(),
+      clear: vi.fn(),
+      returnToSession: vi.fn()
+    },
+    deletion: { candidate: null as Vehicle | null, setCandidate: vi.fn() },
+    reloadVehicles: vi.fn(),
+    onMessage: vi.fn(),
+    t: (key: string) => key
+  };
+}
+
+const submitEvent = () => ({ preventDefault: vi.fn() }) as unknown as FormEvent;
+
+describe("createVehicleMutationCommands", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("stops at required model fields before writing", async () => {
+    const options = commandOptions();
+    options.validation.missingRequiredLabels = ["Spurweite"];
+    const createVehicle = vi.spyOn(api, "createVehicle");
+
+    await createVehicleMutationCommands(options).submit(submitEvent());
+
+    expect(createVehicle).not.toHaveBeenCalled();
+    expect(options.editor.setActiveTab).toHaveBeenCalledWith("model");
+    expect(options.editor.openModelSection).toHaveBeenCalledOnce();
+    expect(options.onMessage).toHaveBeenCalledWith("vehicles.requiredMissing");
+  });
+
+  it("creates and reloads a vehicle", async () => {
+    const options = commandOptions();
+    const created = vehicleFixture({ id: "created" });
+    vi.spyOn(api, "createVehicle").mockResolvedValue(created);
+    vi.spyOn(api, "vehicle").mockResolvedValue(created);
+
+    await createVehicleMutationCommands(options).submit(submitEvent());
+
+    expect(api.createVehicle).toHaveBeenCalledWith(expect.objectContaining({ name: "BR 106", images: [] }));
+    expect(options.editor.setSelectedDetail).toHaveBeenCalledWith(created);
+    expect(options.editor.setMode).toHaveBeenCalledWith("edit");
+    expect(options.reloadVehicles).toHaveBeenCalledOnce();
+    expect(options.onMessage).toHaveBeenCalledWith("vehicles.createdContinue");
+    expect(options.editor.setSaving).toHaveBeenLastCalledWith(false);
+  });
+
+  it("deletes the selected candidate and closes its editor", async () => {
+    const candidate = vehicleFixture({ id: "delete-me" });
+    const options = commandOptions();
+    options.editor.selected = candidate;
+    options.deletion.candidate = candidate;
+    vi.spyOn(api, "deleteVehicle").mockResolvedValue(undefined);
+
+    createVehicleMutationCommands(options).confirmDelete();
+    await vi.waitFor(() => expect(options.reloadVehicles).toHaveBeenCalledOnce());
+
+    expect(api.deleteVehicle).toHaveBeenCalledWith(candidate.id);
+    expect(options.editor.close).toHaveBeenCalledOnce();
+    expect(options.deletion.setCandidate).toHaveBeenCalledWith(null);
+  });
+});

--- a/frontend/src/features/vehicles/vehicleMutationCommands.ts
+++ b/frontend/src/features/vehicles/vehicleMutationCommands.ts
@@ -1,0 +1,188 @@
+import type { Dispatch, FormEvent, SetStateAction } from "react";
+
+import {
+  api,
+  type CreateVehicleRequest,
+  type Vehicle,
+  type VehicleSparePartInput
+} from "../../shared/api";
+import { cvValueKey } from "./cvImport";
+import type { FunctionEditState, PendingArticleImage } from "./vehicleTransforms";
+import type { ECoSVehicleDraftPayload, ModalMode, ModalTab } from "./vehicleViewModel";
+
+type Translator = (key: string, values?: Record<string, string | number>) => string;
+
+type VehicleMutationCommandsOptions = {
+  editor: {
+    form: CreateVehicleRequest;
+    selected: Vehicle | null;
+    mode: ModalMode;
+    setSaving: (saving: boolean) => void;
+    setSelectedDetail: (vehicle: Vehicle) => void;
+    setMode: (mode: ModalMode) => void;
+    setSaveAttempted: (attempted: boolean) => void;
+    setActiveTab: (tab: ModalTab) => void;
+    openModelSection: () => void;
+    close: () => void;
+  };
+  validation: {
+    missingRequiredLabels: string[];
+  };
+  media: {
+    pendingImages: PendingArticleImage[];
+  };
+  spareParts: {
+    selectedInputs: () => VehicleSparePartInput[];
+    clearSelected: () => void;
+  };
+  functions: {
+    configuredKeys: string[];
+    edit: (functionKey: string) => FunctionEditState[string];
+  };
+  ecos: {
+    draft: ECoSVehicleDraftPayload | null;
+    unclearFieldCount: number;
+    markSaved: (draft: ECoSVehicleDraftPayload, vehicleId: string) => void;
+    clear: () => void;
+    returnToSession: () => void;
+  };
+  deletion: {
+    candidate: Vehicle | null;
+    setCandidate: Dispatch<SetStateAction<Vehicle | null>>;
+  };
+  reloadVehicles: () => void;
+  onMessage: (message: string) => void;
+  t: Translator;
+};
+
+export function createVehicleMutationCommands({
+  editor,
+  validation,
+  media,
+  spareParts,
+  functions,
+  ecos,
+  deletion,
+  reloadVehicles,
+  onMessage,
+  t
+}: VehicleMutationCommandsOptions) {
+  const isRemotePendingImage = (image: PendingArticleImage) => !image.persisted && /^https?:\/\//i.test(image.url);
+
+  const submit = async (event: FormEvent) => {
+    event.preventDefault();
+    editor.setSaveAttempted(true);
+
+    if (validation.missingRequiredLabels.length > 0) {
+      editor.setActiveTab("model");
+      editor.openModelSection();
+      onMessage(t("vehicles.requiredMissing", { fields: validation.missingRequiredLabels.join(", ") }));
+      return;
+    }
+    if (ecos.draft && ecos.unclearFieldCount > 0) {
+      onMessage(t("vehicles.ecosDraft.unresolved", { count: ecos.unclearFieldCount }));
+      return;
+    }
+
+    editor.setSaving(true);
+    onMessage("");
+    try {
+      const sparePartsToImport = spareParts.selectedInputs();
+      const remoteImages = media.pendingImages.filter(isRemotePendingImage);
+      const images = media.pendingImages.filter((image) => !isRemotePendingImage(image)).map((image, index) => ({
+        id: image.persisted ? image.id : undefined,
+        url: image.url,
+        title: image.title,
+        sourceUrl: image.source,
+        maintenanceId: image.maintenanceId || "",
+        isPrimary: Boolean(image.isPrimary),
+        sortOrder: index
+      }));
+      const payload = { ...editor.form, images };
+      let vehicle = editor.mode === "edit" && editor.selected
+        ? await api.updateVehicle(editor.selected.id, payload)
+        : await api.createVehicle(payload);
+
+      for (const [imageIndex, image] of remoteImages.entries()) {
+        await api.importVehicleImageFromUrl(vehicle.id, {
+          url: image.url,
+          title: image.title || "",
+          sourceUrl: image.source || image.url,
+          maintenanceId: image.maintenanceId || "",
+          isPrimary: Boolean(image.isPrimary),
+          sortOrder: images.length + imageIndex
+        });
+      }
+      if (remoteImages.length > 0) vehicle = await api.vehicle(vehicle.id);
+
+      for (const part of sparePartsToImport) {
+        await api.createVehicleSparePart(vehicle.id, part);
+      }
+      if (sparePartsToImport.length > 0) {
+        spareParts.clearSelected();
+        vehicle = await api.vehicle(vehicle.id);
+      }
+
+      if (ecos.draft && (editor.mode === "create" || editor.mode === "edit")) {
+        await api.upsertVehicleExternalMapping(vehicle.id, ecos.draft.externalMapping);
+        const detailBeforeECoSValues = await api.vehicle(vehicle.id);
+        for (const cvValue of ecos.draft.cvValues) {
+          const existing = (detailBeforeECoSValues.cvValues || []).find((entry) => (
+            cvValueKey(entry) === cvValueKey(cvValue)
+          ));
+          if (existing) await api.updateVehicleCVValue(vehicle.id, existing.id, cvValue);
+          else await api.createVehicleCVValue(vehicle.id, cvValue);
+        }
+        for (const functionKey of functions.configuredKeys) {
+          const edit = functions.edit(functionKey);
+          if (!edit.name?.trim() && !edit.symbolKey && !edit.notes?.trim()) continue;
+          await api.updateVehicleFunction(vehicle.id, functionKey, {
+            name: edit.name || "",
+            symbolKey: edit.symbolKey || "",
+            functionType: edit.functionType || "standard",
+            mode: edit.mode || "dauer",
+            directionDependent: Boolean(edit.directionDependent),
+            notes: edit.notes || ""
+          });
+        }
+        ecos.markSaved(ecos.draft, vehicle.id);
+        vehicle = await api.vehicle(vehicle.id);
+        const returnToEcos = Boolean(ecos.draft.returnToEcos);
+        ecos.clear();
+        if (returnToEcos) {
+          reloadVehicles();
+          editor.close();
+          ecos.returnToSession();
+          return;
+        }
+      }
+
+      vehicle = await api.vehicle(vehicle.id);
+      editor.setSelectedDetail(vehicle);
+      editor.setMode("edit");
+      editor.setSaveAttempted(false);
+      reloadVehicles();
+      if (editor.mode === "create") onMessage(t("vehicles.createdContinue"));
+      else if (sparePartsToImport.length > 0) {
+        onMessage(t("vehicles.spareParts.importedCount", { count: sparePartsToImport.length }));
+      }
+    } catch (error) {
+      onMessage(error instanceof Error ? error.message : String(error));
+    } finally {
+      editor.setSaving(false);
+    }
+  };
+
+  const confirmDelete = () => {
+    if (!deletion.candidate) return;
+    api.deleteVehicle(deletion.candidate.id)
+      .then(() => {
+        if (editor.selected?.id === deletion.candidate?.id) editor.close();
+        deletion.setCandidate(null);
+        reloadVehicles();
+      })
+      .catch((error: Error) => onMessage(error.message));
+  };
+
+  return { submit, confirmDelete };
+}

--- a/frontend/src/features/vehicles/vehicleViewModel.ts
+++ b/frontend/src/features/vehicles/vehicleViewModel.ts
@@ -252,6 +252,32 @@ export function optionValue(entry: MasterDataEntry) {
   return entry.label;
 }
 
+export function gattungenForCategory(options: MasterDataOptions, category: string | undefined) {
+  const categoryKey = options.categories.find((entry) => optionValue(entry) === category)?.key;
+  if (!categoryKey) return options.gattungen;
+
+  const allowed = new Set(
+    options.categoryRelations
+      .filter((relation) => relation.parentKey === categoryKey)
+      .map((relation) => relation.childKey)
+  );
+  return options.gattungen.filter((entry) => allowed.has(entry.key));
+}
+
+export function missingVehicleModelFieldLabels(
+  form: CreateVehicleRequest,
+  t: (key: string) => string
+) {
+  const fields: Array<{ label: string; value: string | undefined }> = [
+    { label: t("vehicle.field.manufacturer"), value: form.manufacturer },
+    { label: t("vehicle.field.name"), value: form.name },
+    { label: t("vehicle.field.gauge"), value: form.gauge },
+    { label: t("vehicle.field.category"), value: form.category },
+    { label: t("vehicle.field.gattung"), value: form.gattung }
+  ];
+  return fields.filter((field) => !compactValue(field.value)).map((field) => field.label);
+}
+
 export function valueForSort(vehicle: Vehicle, key: SortKey) {
   return (vehicle[key] || "").toLocaleLowerCase("de-DE");
 }


### PR DESCRIPTION
## Summary
- extract the vehicle editor composition into a focused component
- move ECoS drafts, function editing, output/reporting, and mutations into dedicated modules
- extract inventory renderers and derived view-model helpers
- reduce `VehiclesView.tsx` from 2,954 to 996 lines
- add mutation regression tests

## Verification
- `go test -p 1 ./...`
- `go build -p 1 ./...`
- `npm.cmd run test:coverage` (19 files, 62 tests)
- `npm.cmd run build`
- `git diff --check`