### PR TITLE
Align Docker builder with Go 1.26

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -73,7 +73,7 @@ jobs:
           TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Docker image scan results
-        if: always()
+        if: always() && hashFiles('trivy-image.sarif') != ''
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: trivy-image.sarif

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN npm ci
 COPY frontend ./
 RUN npm run build
 
-FROM golang:1.25-alpine AS backend-build
+FROM golang:1.26-alpine AS backend-build
 WORKDIR /src/backend
 COPY backend/go.mod ./
 RUN go mod download


### PR DESCRIPTION
## Summary
- build the backend with `golang:1.26-alpine`, matching `backend/go.mod`
- upload container SARIF only when the scan report exists

## Verification
- `docker build --target backend-build -t railkeeper-backend-build:test .`