### PR TITLE
Enforce Trivy SARIF severity filter

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -64,6 +64,7 @@ jobs:
           scanners: vuln
           vuln-type: os,library
           severity: HIGH,CRITICAL
+          limit-severities-for-sarif: true
           ignore-unfixed: false
           format: sarif
           output: trivy-image.sarif

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -29,6 +29,7 @@ jobs:
           scan-ref: .
           scanners: vuln,misconfig,secret
           severity: HIGH,CRITICAL
+          limit-severities-for-sarif: true
           ignore-unfixed: true
           format: sarif
           output: trivy-repository.sarif


### PR DESCRIPTION
## Summary
- limit repository and container SARIF output to configured HIGH/CRITICAL severities
- keep the container gate strict for fixed and unfixed HIGH/CRITICAL findings

Trivy otherwise expands SARIF scans to all severities, causing an UNKNOWN no-fix advisory to fail the HIGH/CRITICAL gate.