### PR TITLE
Fix password-reset Host header poisoning

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,10 @@ RAILKEEPER_SMTP_FROM=railkeeper@example.test
 RAILKEEPER_SMTP_TLS=starttls
 ```
 
+Password-reset emails are sent only when `RAILKEEPER_PUBLIC_URL` or the public URL stored in the
+Admin UI is a valid HTTP(S) origin. RailKeeper never derives emailed reset links from the request
+`Host` header.
+
 If SMTP is not configured, password reset links are not returned to the browser. For local recovery only, the backend writes the link to the server log.
 
 ### Optional OCR for scanned spare-parts PDFs

--- a/backend/internal/api/auth_handlers.go
+++ b/backend/internal/api/auth_handlers.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -116,22 +117,26 @@ func (a *App) requestPasswordReset(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if result.ResetToken != "" {
-		resetURL := a.passwordResetURL(r, result.ResetToken)
 		mailer := a.passwordResetMailer
+		mailerBaseURL := a.publicURL
 		if a.smtpSettingsService != nil {
 			settingsMailer, publicURL, err := a.smtpSettingsService.EffectiveMailer(r.Context())
 			if err != nil {
 				a.logger.Error("smtp settings invalid", "error", err)
 			} else if settingsMailer != nil {
 				mailer = settingsMailer
-				resetURL = a.passwordResetURLWithBase(r, result.ResetToken, publicURL)
+				mailerBaseURL = publicURL
 			}
 		}
 		if mailer != nil {
-			if err := mailer.SendPasswordReset(r.Context(), input.Email, resetURL, result.ExpiresAt); err != nil {
+			resetURL, err := configuredPasswordResetURL(result.ResetToken, mailerBaseURL)
+			if err != nil {
+				a.logger.Error("password reset email disabled because public URL is invalid", "error", err)
+			} else if err := mailer.SendPasswordReset(r.Context(), input.Email, resetURL, result.ExpiresAt); err != nil {
 				a.logger.Error("password reset email failed", "error", err)
 			}
 		} else {
+			resetURL := a.passwordResetURL(r, result.ResetToken)
 			a.logger.Warn("password reset email disabled; link is available in server log for local recovery only", "reset_url", resetURL)
 		}
 	}
@@ -172,23 +177,15 @@ func (a *App) confirmPasswordReset(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *App) passwordResetURL(r *http.Request, token string) string {
-	return a.passwordResetURLWithBase(r, token, a.publicURL)
-}
-
-func (a *App) passwordResetURLWithBase(r *http.Request, token string, baseURL string) string {
-	if strings.TrimSpace(baseURL) != "" {
-		u, err := url.Parse(strings.TrimRight(strings.TrimSpace(baseURL), "/"))
-		if err == nil {
-			u.Path = "/password-reset"
-			query := u.Query()
-			query.Set("token", token)
-			u.RawQuery = query.Encode()
-			return u.String()
-		}
+	if resetURL, err := configuredPasswordResetURL(token, a.publicURL); err == nil {
+		return resetURL
 	}
+
 	scheme := "http"
 	if forwarded := strings.TrimSpace(r.Header.Get("X-Forwarded-Proto")); forwarded != "" {
-		scheme = strings.Split(forwarded, ",")[0]
+		if strings.EqualFold(strings.Split(forwarded, ",")[0], "https") {
+			scheme = "https"
+		}
 	} else if r.TLS != nil {
 		scheme = "https"
 	}
@@ -201,6 +198,28 @@ func (a *App) passwordResetURLWithBase(r *http.Request, token string, baseURL st
 	query.Set("token", token)
 	u.RawQuery = query.Encode()
 	return u.String()
+}
+
+func configuredPasswordResetURL(token, baseURL string) (string, error) {
+	baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if baseURL == "" {
+		return "", errors.New("public URL is required for password reset email")
+	}
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return "", fmt.Errorf("parse public URL: %w", err)
+	}
+	if (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" || u.User != nil {
+		return "", errors.New("public URL must be an HTTP(S) origin without credentials")
+	}
+	u.Path = "/password-reset"
+	u.RawPath = ""
+	u.RawQuery = ""
+	u.Fragment = ""
+	query := u.Query()
+	query.Set("token", token)
+	u.RawQuery = query.Encode()
+	return u.String(), nil
 }
 
 type smtpTestRequest struct {

--- a/backend/internal/api/router_test.go
+++ b/backend/internal/api/router_test.go
@@ -21,12 +21,14 @@ import (
 )
 
 type capturePasswordResetMailer struct {
+	sent      bool
 	to        string
 	resetURL  string
 	expiresAt string
 }
 
 func (m *capturePasswordResetMailer) SendPasswordReset(_ context.Context, toEmail, resetURL, expiresAt string) error {
+	m.sent = true
 	m.to = toEmail
 	m.resetURL = resetURL
 	m.expiresAt = expiresAt
@@ -351,9 +353,14 @@ func TestPasswordResetEndpointCompletesPasswordChange(t *testing.T) {
 	}
 
 	mailer := &capturePasswordResetMailer{}
-	router := NewRouter(Config{SetupService: setup, AuthService: auth, PasswordResetMailer: mailer})
+	router := NewRouter(Config{
+		SetupService:        setup,
+		AuthService:         auth,
+		PasswordResetMailer: mailer,
+		PublicURL:           "https://railkeeper.example.test",
+	})
 	resetRequest := httptest.NewRequest(http.MethodPost, "/api/v1/auth/password-reset", bytes.NewBufferString(`{"email":"admin@example.test"}`))
-	resetRequest.Host = "railkeeper.test"
+	resetRequest.Host = "attacker.example.test"
 	resetResponse := httptest.NewRecorder()
 	router.ServeHTTP(resetResponse, resetRequest)
 	if resetResponse.Code != http.StatusAccepted {
@@ -372,6 +379,9 @@ func TestPasswordResetEndpointCompletesPasswordChange(t *testing.T) {
 	resetURL, err := url.Parse(mailer.resetURL)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if resetURL.Scheme != "https" || resetURL.Host != "railkeeper.example.test" {
+		t.Fatalf("expected configured public URL, got %q", mailer.resetURL)
 	}
 	token := resetURL.Query().Get("token")
 	if token == "" {
@@ -395,6 +405,37 @@ func TestPasswordResetEndpointCompletesPasswordChange(t *testing.T) {
 	router.ServeHTTP(newLogin, httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", bytes.NewBufferString(`{"username":"admin","password":"new-secure-password"}`)))
 	if newLogin.Code != http.StatusOK {
 		t.Fatalf("expected new password to work, got %d", newLogin.Code)
+	}
+}
+
+func TestPasswordResetEmailRequiresConfiguredPublicURL(t *testing.T) {
+	db := testRouterDB(t)
+	setup := application.NewSetupService(db)
+	auth := application.NewAuthService(db)
+	if err := setup.CreateAdmin(t.Context(), application.CreateAdminInput{
+		Username: "admin",
+		Email:    "admin@example.test",
+		Password: "very-secure-password",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	mailer := &capturePasswordResetMailer{}
+	router := NewRouter(Config{SetupService: setup, AuthService: auth, PasswordResetMailer: mailer})
+	request := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/auth/password-reset",
+		bytes.NewBufferString(`{"email":"admin@example.test"}`),
+	)
+	request.Host = "attacker.example.test"
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+
+	if response.Code != http.StatusAccepted {
+		t.Fatalf("expected reset request success, got %d: %s", response.Code, response.Body.String())
+	}
+	if mailer.sent {
+		t.Fatalf("password reset email must not use an untrusted request host, got %q", mailer.resetURL)
 	}
 }
 

--- a/backend/internal/application/password_reset_mailer.go
+++ b/backend/internal/application/password_reset_mailer.go
@@ -3,6 +3,7 @@ package application
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"mime"
 	"net"
@@ -44,9 +45,11 @@ func NewSMTPPasswordResetMailer(config SMTPPasswordResetMailConfig) (*SMTPPasswo
 	if config.Host == "" || config.From == "" {
 		return nil, nil
 	}
-	if _, err := mail.ParseAddress(config.From); err != nil {
+	from, err := canonicalMailbox(config.From)
+	if err != nil {
 		return nil, fmt.Errorf("parse smtp from address: %w", err)
 	}
+	config.From = from
 	switch config.TLSMode {
 	case "starttls", "implicit", "none":
 	default:
@@ -59,8 +62,8 @@ func (m *SMTPPasswordResetMailer) SendPasswordReset(ctx context.Context, toEmail
 	if m == nil {
 		return nil
 	}
-	toEmail = strings.TrimSpace(toEmail)
-	if _, err := mail.ParseAddress(toEmail); err != nil {
+	toEmail, err := canonicalMailbox(toEmail)
+	if err != nil {
 		return fmt.Errorf("parse reset recipient: %w", err)
 	}
 
@@ -72,8 +75,8 @@ func (m *SMTPPasswordResetMailer) SendTest(ctx context.Context, toEmail string) 
 	if m == nil {
 		return nil
 	}
-	toEmail = strings.TrimSpace(toEmail)
-	if _, err := mail.ParseAddress(toEmail); err != nil {
+	toEmail, err := canonicalMailbox(toEmail)
+	if err != nil {
 		return fmt.Errorf("parse test recipient: %w", err)
 	}
 
@@ -108,6 +111,14 @@ func buildSMTPMessage(from, toEmail, subjectText, body string) string {
 		"Content-Transfer-Encoding: 8bit",
 	}
 	return strings.Join(headers, "\r\n") + "\r\n\r\n" + body
+}
+
+func canonicalMailbox(value string) (string, error) {
+	address, err := mail.ParseAddress(strings.TrimSpace(value))
+	if err != nil || address == nil || strings.ContainsAny(address.Address, "\r\n") {
+		return "", errors.New("invalid email address")
+	}
+	return address.Address, nil
 }
 
 func sendSMTP(ctx context.Context, config SMTPPasswordResetMailConfig, toEmail string, message []byte) error {

--- a/backend/internal/application/password_reset_mailer_test.go
+++ b/backend/internal/application/password_reset_mailer_test.go
@@ -1,0 +1,20 @@
+package application
+
+import "testing"
+
+func TestCanonicalMailbox(t *testing.T) {
+	mailbox, err := canonicalMailbox("RailKeeper User <user@example.test>")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mailbox != "user@example.test" {
+		t.Fatalf("expected canonical mailbox, got %q", mailbox)
+	}
+}
+
+func TestCanonicalMailboxRejectsHeaderInjection(t *testing.T) {
+	_, err := canonicalMailbox("victim@example.test\r\nBcc: attacker@example.test")
+	if err == nil {
+		t.Fatal("expected injected mail header to be rejected")
+	}
+}

--- a/docs/production-runbook.md
+++ b/docs/production-runbook.md
@@ -168,6 +168,10 @@ RAILKEEPER_SMTP_FROM=railkeeper@example.test
 RAILKEEPER_SMTP_TLS=starttls
 ```
 
+Passwort-Reset-Mails werden nur mit einer gültigen HTTP(S)-Adresse in
+`RAILKEEPER_PUBLIC_URL` beziehungsweise im Feld "Öffentliche URL" der SMTP-Einstellungen
+versendet. Der eingehende `Host`-Header wird nicht für Links in E-Mails verwendet.
+
 Prüfpunkte:
 
 - Kein Standard-Admin existiert.


### PR DESCRIPTION
## Summary
- build emailed reset links only from a validated configured public URL
- never fall back to the request `Host` header when SMTP is enabled
- add regression coverage for hostile hosts and missing public URL
- document the SMTP public URL requirement

## Verification
- `go test ./...`
- `go build ./...`
- `npm.cmd run build`
- `git diff --check`

Closes CodeQL alert #7 (`go/email-injection`).