### PR TITLE
feat(layouts): persist layouts and plan revisions

### DIFF
--- a/backend/internal/infrastructure/layout_repository.go
+++ b/backend/internal/infrastructure/layout_repository.go
@@ -1,0 +1,466 @@
+package infrastructure
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"railkeeper/backend/internal/application"
+)
+
+type LayoutRepository struct {
+	db *sql.DB
+}
+
+func NewLayoutRepository(db *sql.DB) *LayoutRepository {
+	return &LayoutRepository{db: db}
+}
+
+func (r *LayoutRepository) ListLayouts(ctx context.Context) ([]application.Layout, error) {
+	rows, err := r.db.QueryContext(ctx, layoutSelect+` ORDER BY name COLLATE NOCASE, id`)
+	if err != nil {
+		return nil, fmt.Errorf("list layouts: %w", err)
+	}
+	defer rows.Close()
+
+	layouts := []application.Layout{}
+	for rows.Next() {
+		layout, err := scanLayout(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan layout: %w", err)
+		}
+		layouts = append(layouts, *layout)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate layouts: %w", err)
+	}
+	return layouts, nil
+}
+
+func (r *LayoutRepository) GetLayout(ctx context.Context, id string) (*application.Layout, error) {
+	layout, err := scanLayout(r.db.QueryRowContext(ctx, layoutSelect+` WHERE id=?`, id))
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, application.ErrLayoutNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get layout: %w", err)
+	}
+	return layout, nil
+}
+
+func (r *LayoutRepository) CreateLayout(
+	ctx context.Context,
+	input application.CreateLayoutInput,
+	actor string,
+) (*application.Layout, error) {
+	now := timestamp()
+	layout := &application.Layout{
+		ID: randomID(), Name: input.Name, Kind: input.Kind, Gauge: input.Gauge, Scale: input.Scale,
+		Description: input.Description, Version: 1, Archived: input.Archived, CreatedAt: now, UpdatedAt: now,
+	}
+	err := r.withTx(ctx, func(tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx, `
+INSERT INTO layouts(id, name, kind, gauge, scale, description, version, archived, created_at, updated_at)
+VALUES(?, ?, ?, ?, ?, ?, 1, ?, ?, ?)`, layout.ID, layout.Name, layout.Kind, layout.Gauge, layout.Scale,
+			layout.Description, boolToInt(layout.Archived), now, now); err != nil {
+			return fmt.Errorf("insert layout: %w", err)
+		}
+		return writeLayoutAudit(ctx, tx, "LayoutCreated", "layout", layout.ID, actor, now)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return layout, nil
+}
+
+func (r *LayoutRepository) UpdateLayout(
+	ctx context.Context,
+	id string,
+	input application.UpdateLayoutInput,
+	actor string,
+) (*application.Layout, error) {
+	now := timestamp()
+	err := r.withTx(ctx, func(tx *sql.Tx) error {
+		result, err := tx.ExecContext(ctx, `
+UPDATE layouts
+SET name=?, kind=?, gauge=?, scale=?, description=?, archived=?, version=version+1, updated_at=?
+WHERE id=? AND version=?`, input.Name, input.Kind, input.Gauge, input.Scale, input.Description,
+			boolToInt(input.Archived), now, id, input.ExpectedVersion)
+		if err != nil {
+			return fmt.Errorf("update layout: %w", err)
+		}
+		if err := requireUpdated(ctx, tx, result, "layouts", id, application.ErrLayoutVersionConflict); err != nil {
+			return err
+		}
+		return writeLayoutAudit(ctx, tx, "LayoutUpdated", "layout", id, actor, now)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return r.GetLayout(ctx, id)
+}
+
+func (r *LayoutRepository) ListUnits(ctx context.Context, layoutID string) ([]application.LayoutUnit, error) {
+	rows, err := r.db.QueryContext(ctx, layoutUnitSelect+` WHERE layout_id=? ORDER BY name COLLATE NOCASE, id`, layoutID)
+	if err != nil {
+		return nil, fmt.Errorf("list layout units: %w", err)
+	}
+	defer rows.Close()
+
+	units := []application.LayoutUnit{}
+	for rows.Next() {
+		unit, err := scanLayoutUnit(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan layout unit: %w", err)
+		}
+		units = append(units, *unit)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate layout units: %w", err)
+	}
+	return units, nil
+}
+
+func (r *LayoutRepository) CreateUnit(
+	ctx context.Context,
+	layoutID string,
+	input application.CreateLayoutUnitInput,
+	actor string,
+) (*application.LayoutUnit, error) {
+	now := timestamp()
+	unit := &application.LayoutUnit{
+		ID: randomID(), LayoutID: layoutID, Name: input.Name, Kind: input.Kind, OwnerLabel: input.OwnerLabel,
+		WidthMM: input.WidthMM, HeightMM: input.HeightMM, Version: 1, Archived: input.Archived,
+		CreatedAt: now, UpdatedAt: now,
+	}
+	err := r.withTx(ctx, func(tx *sql.Tx) error {
+		exists, err := recordExists(ctx, tx, "layouts", layoutID)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return application.ErrLayoutNotFound
+		}
+		if _, err := tx.ExecContext(ctx, `
+INSERT INTO layout_units(
+  id, layout_id, name, kind, owner_label, width_mm, height_mm, version, archived, created_at, updated_at
+) VALUES(?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?)`, unit.ID, unit.LayoutID, unit.Name, unit.Kind, unit.OwnerLabel,
+			unit.WidthMM, unit.HeightMM, boolToInt(unit.Archived), now, now); err != nil {
+			return fmt.Errorf("insert layout unit: %w", err)
+		}
+		return writeLayoutAudit(ctx, tx, "LayoutUnitCreated", "layout_unit", unit.ID, actor, now)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return unit, nil
+}
+
+func (r *LayoutRepository) UpdateUnit(
+	ctx context.Context,
+	id string,
+	input application.UpdateLayoutUnitInput,
+	actor string,
+) (*application.LayoutUnit, error) {
+	now := timestamp()
+	err := r.withTx(ctx, func(tx *sql.Tx) error {
+		result, err := tx.ExecContext(ctx, `
+UPDATE layout_units
+SET name=?, kind=?, owner_label=?, width_mm=?, height_mm=?, archived=?, version=version+1, updated_at=?
+WHERE id=? AND version=?`, input.Name, input.Kind, input.OwnerLabel, input.WidthMM, input.HeightMM,
+			boolToInt(input.Archived), now, id, input.ExpectedVersion)
+		if err != nil {
+			return fmt.Errorf("update layout unit: %w", err)
+		}
+		if err := requireUpdated(ctx, tx, result, "layout_units", id, application.ErrLayoutVersionConflict); err != nil {
+			return err
+		}
+		return writeLayoutAudit(ctx, tx, "LayoutUnitUpdated", "layout_unit", id, actor, now)
+	})
+	if err != nil {
+		return nil, err
+	}
+	unit, err := scanLayoutUnit(r.db.QueryRowContext(ctx, layoutUnitSelect+` WHERE id=?`, id))
+	if err != nil {
+		return nil, fmt.Errorf("get updated layout unit: %w", err)
+	}
+	return unit, nil
+}
+
+func (r *LayoutRepository) ListConfigurations(
+	ctx context.Context,
+	layoutID string,
+) ([]application.LayoutConfiguration, error) {
+	rows, err := r.db.QueryContext(ctx, layoutConfigurationSelect+` WHERE layout_id=? ORDER BY name COLLATE NOCASE, id`, layoutID)
+	if err != nil {
+		return nil, fmt.Errorf("list layout configurations: %w", err)
+	}
+	configurations := []application.LayoutConfiguration{}
+	for rows.Next() {
+		configuration, err := scanLayoutConfiguration(rows)
+		if err != nil {
+			_ = rows.Close()
+			return nil, fmt.Errorf("scan layout configuration: %w", err)
+		}
+		configurations = append(configurations, *configuration)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return nil, fmt.Errorf("iterate layout configurations: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, fmt.Errorf("close layout configurations: %w", err)
+	}
+	for index := range configurations {
+		units, err := listConfigurationUnits(ctx, r.db, configurations[index].ID)
+		if err != nil {
+			return nil, err
+		}
+		configurations[index].Units = units
+	}
+	return configurations, nil
+}
+
+func (r *LayoutRepository) SaveConfiguration(
+	ctx context.Context,
+	layoutID string,
+	input application.SaveLayoutConfigurationInput,
+	actor string,
+) (*application.LayoutConfiguration, error) {
+	now := timestamp()
+	id := input.ID
+	if id == "" {
+		id = randomID()
+	}
+	err := r.withTx(ctx, func(tx *sql.Tx) error {
+		exists, err := recordExists(ctx, tx, "layouts", layoutID)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return application.ErrLayoutNotFound
+		}
+		for _, unit := range input.Units {
+			if err := validateConfigurationUnit(ctx, tx, layoutID, unit); err != nil {
+				return err
+			}
+		}
+		if input.ID == "" {
+			if _, err := tx.ExecContext(ctx, `
+INSERT INTO layout_configurations(id, layout_id, name, description, version, archived, created_at, updated_at)
+VALUES(?, ?, ?, ?, 1, ?, ?, ?)`, id, layoutID, input.Name, input.Description,
+				boolToInt(input.Archived), now, now); err != nil {
+				return fmt.Errorf("insert layout configuration: %w", err)
+			}
+		} else {
+			result, err := tx.ExecContext(ctx, `
+UPDATE layout_configurations
+SET name=?, description=?, archived=?, version=version+1, updated_at=?
+WHERE id=? AND layout_id=? AND version=?`, input.Name, input.Description, boolToInt(input.Archived),
+				now, id, layoutID, input.ExpectedVersion)
+			if err != nil {
+				return fmt.Errorf("update layout configuration: %w", err)
+			}
+			if err := requireUpdated(ctx, tx, result, "layout_configurations", id, application.ErrLayoutVersionConflict); err != nil {
+				return err
+			}
+			if _, err := tx.ExecContext(ctx, `DELETE FROM layout_configuration_units WHERE configuration_id=?`, id); err != nil {
+				return fmt.Errorf("replace layout configuration units: %w", err)
+			}
+		}
+		for _, unit := range input.Units {
+			if _, err := tx.ExecContext(ctx, `
+INSERT INTO layout_configuration_units(
+  configuration_id, unit_id, plan_revision_id, position_x_mm, position_y_mm, rotation_degrees, sort_order
+) VALUES(?, ?, NULLIF(?, ''), ?, ?, ?, ?)`, id, unit.UnitID, unit.PlanRevisionID, unit.PositionXMM,
+				unit.PositionYMM, unit.RotationDegrees, unit.SortOrder); err != nil {
+				return fmt.Errorf("insert layout configuration unit: %w", err)
+			}
+		}
+		return writeLayoutAudit(ctx, tx, "LayoutConfigurationSaved", "layout_configuration", id, actor, now)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return r.getConfiguration(ctx, id)
+}
+
+const layoutSelect = `SELECT id, name, kind, gauge, scale, description, version, archived, created_at, updated_at FROM layouts`
+
+const layoutUnitSelect = `SELECT id, layout_id, name, kind, owner_label, COALESCE(width_mm, 0), COALESCE(height_mm, 0), version, archived, created_at, updated_at FROM layout_units`
+
+const layoutConfigurationSelect = `SELECT id, layout_id, name, description, version, archived, created_at, updated_at FROM layout_configurations`
+
+type rowScanner interface {
+	Scan(...any) error
+}
+
+func scanLayout(scanner rowScanner) (*application.Layout, error) {
+	layout := &application.Layout{}
+	var archived int
+	err := scanner.Scan(&layout.ID, &layout.Name, &layout.Kind, &layout.Gauge, &layout.Scale, &layout.Description,
+		&layout.Version, &archived, &layout.CreatedAt, &layout.UpdatedAt)
+	layout.Archived = archived != 0
+	return layout, err
+}
+
+func scanLayoutUnit(scanner rowScanner) (*application.LayoutUnit, error) {
+	unit := &application.LayoutUnit{}
+	var archived int
+	err := scanner.Scan(&unit.ID, &unit.LayoutID, &unit.Name, &unit.Kind, &unit.OwnerLabel, &unit.WidthMM,
+		&unit.HeightMM, &unit.Version, &archived, &unit.CreatedAt, &unit.UpdatedAt)
+	unit.Archived = archived != 0
+	return unit, err
+}
+
+func scanLayoutConfiguration(scanner rowScanner) (*application.LayoutConfiguration, error) {
+	configuration := &application.LayoutConfiguration{}
+	var archived int
+	err := scanner.Scan(&configuration.ID, &configuration.LayoutID, &configuration.Name, &configuration.Description,
+		&configuration.Version, &archived, &configuration.CreatedAt, &configuration.UpdatedAt)
+	configuration.Archived = archived != 0
+	return configuration, err
+}
+
+func (r *LayoutRepository) getConfiguration(ctx context.Context, id string) (*application.LayoutConfiguration, error) {
+	configuration, err := scanLayoutConfiguration(r.db.QueryRowContext(ctx, layoutConfigurationSelect+` WHERE id=?`, id))
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, application.ErrLayoutNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get layout configuration: %w", err)
+	}
+	configuration.Units, err = listConfigurationUnits(ctx, r.db, id)
+	if err != nil {
+		return nil, err
+	}
+	return configuration, nil
+}
+
+func listConfigurationUnits(ctx context.Context, db *sql.DB, configurationID string) ([]application.ConfigurationUnit, error) {
+	rows, err := db.QueryContext(ctx, `
+SELECT unit_id, COALESCE(plan_revision_id, ''), position_x_mm, position_y_mm, rotation_degrees, sort_order
+FROM layout_configuration_units WHERE configuration_id=? ORDER BY sort_order, unit_id`, configurationID)
+	if err != nil {
+		return nil, fmt.Errorf("list layout configuration units: %w", err)
+	}
+	defer rows.Close()
+	units := []application.ConfigurationUnit{}
+	for rows.Next() {
+		unit := application.ConfigurationUnit{}
+		if err := rows.Scan(&unit.UnitID, &unit.PlanRevisionID, &unit.PositionXMM, &unit.PositionYMM,
+			&unit.RotationDegrees, &unit.SortOrder); err != nil {
+			return nil, fmt.Errorf("scan layout configuration unit: %w", err)
+		}
+		units = append(units, unit)
+	}
+	return units, rows.Err()
+}
+
+func validateConfigurationUnit(
+	ctx context.Context,
+	tx *sql.Tx,
+	layoutID string,
+	unit application.ConfigurationUnit,
+) error {
+	var count int
+	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM layout_units WHERE id=? AND layout_id=?`,
+		unit.UnitID, layoutID).Scan(&count); err != nil {
+		return fmt.Errorf("validate layout configuration unit: %w", err)
+	}
+	if count == 0 {
+		return application.ErrLayoutValidation
+	}
+	if unit.PlanRevisionID == "" {
+		return nil
+	}
+	if err := tx.QueryRowContext(ctx, `
+SELECT COUNT(*)
+FROM plan_revisions revision
+JOIN plan_variants variant ON variant.id=revision.variant_id
+WHERE revision.id=? AND variant.layout_unit_id=? AND revision.status IN ('published', 'archived')`,
+		unit.PlanRevisionID, unit.UnitID).Scan(&count); err != nil {
+		return fmt.Errorf("validate configuration plan revision: %w", err)
+	}
+	if count == 0 {
+		return application.ErrLayoutValidation
+	}
+	return nil
+}
+
+func (r *LayoutRepository) withTx(ctx context.Context, work func(*sql.Tx) error) error {
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin layout transaction: %w", err)
+	}
+	if err := work(tx); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit layout transaction: %w", err)
+	}
+	return nil
+}
+
+func requireUpdated(
+	ctx context.Context,
+	tx *sql.Tx,
+	result sql.Result,
+	table string,
+	id string,
+	conflict error,
+) error {
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("read layout update result: %w", err)
+	}
+	if affected > 0 {
+		return nil
+	}
+	exists, err := recordExists(ctx, tx, table, id)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return application.ErrLayoutNotFound
+	}
+	return conflict
+}
+
+func recordExists(ctx context.Context, tx *sql.Tx, table, id string) (bool, error) {
+	query := map[string]string{
+		"layouts":               `SELECT COUNT(*) FROM layouts WHERE id=?`,
+		"layout_units":          `SELECT COUNT(*) FROM layout_units WHERE id=?`,
+		"layout_configurations": `SELECT COUNT(*) FROM layout_configurations WHERE id=?`,
+	}[table]
+	if query == "" {
+		return false, fmt.Errorf("unsupported layout table %q", table)
+	}
+	var count int
+	if err := tx.QueryRowContext(ctx, query, id).Scan(&count); err != nil {
+		return false, fmt.Errorf("check %s record: %w", table, err)
+	}
+	return count > 0, nil
+}
+
+func writeLayoutAudit(
+	ctx context.Context,
+	tx *sql.Tx,
+	action, targetType, targetID, actor, createdAt string,
+) error {
+	if _, err := tx.ExecContext(ctx, `
+INSERT INTO audit_logs(id, actor_user_id, action, target_type, target_id, created_at, details_json)
+VALUES(?, NULLIF(?, ''), ?, ?, ?, ?, '{}')`, randomID(), actor, action, targetType, targetID, createdAt); err != nil {
+		return fmt.Errorf("write layout audit log: %w", err)
+	}
+	return nil
+}
+
+func timestamp() string {
+	return time.Now().UTC().Format(time.RFC3339)
+}
+
+var _ application.LayoutRepository = (*LayoutRepository)(nil)

--- a/backend/internal/infrastructure/layout_repository.go
+++ b/backend/internal/infrastructure/layout_repository.go
@@ -23,7 +23,7 @@ func (r *LayoutRepository) ListLayouts(ctx context.Context) ([]application.Layou
 	if err != nil {
 		return nil, fmt.Errorf("list layouts: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	layouts := []application.Layout{}
 	for rows.Next() {
@@ -107,7 +107,7 @@ func (r *LayoutRepository) ListUnits(ctx context.Context, layoutID string) ([]ap
 	if err != nil {
 		return nil, fmt.Errorf("list layout units: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	units := []application.LayoutUnit{}
 	for rows.Next() {
@@ -346,7 +346,7 @@ FROM layout_configuration_units WHERE configuration_id=? ORDER BY sort_order, un
 	if err != nil {
 		return nil, fmt.Errorf("list layout configuration units: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	units := []application.ConfigurationUnit{}
 	for rows.Next() {
 		unit := application.ConfigurationUnit{}

--- a/backend/internal/infrastructure/layout_repository_test.go
+++ b/backend/internal/infrastructure/layout_repository_test.go
@@ -1,0 +1,183 @@
+package infrastructure_test
+
+import (
+	"errors"
+	"math"
+	"path/filepath"
+	"testing"
+
+	"railkeeper/backend/internal/application"
+	"railkeeper/backend/internal/domain"
+	"railkeeper/backend/internal/infrastructure"
+)
+
+func TestLayoutServicePersistsStructureAndRejectsStaleUpdates(t *testing.T) {
+	service := testLayoutService(t)
+	ctx := t.Context()
+
+	if _, err := service.CreateLayout(ctx, application.CreateLayoutInput{
+		Name: "Incomplete",
+		Kind: domain.LayoutKindPrivate,
+	}, "admin-1"); !errors.Is(err, application.ErrLayoutValidation) {
+		t.Fatalf("expected validation error, got %v", err)
+	}
+
+	privateLayout, err := service.CreateLayout(ctx, application.CreateLayoutInput{
+		Name: "  Heimanlage  ", Kind: domain.LayoutKindPrivate, Gauge: " TT ", Scale: " 1:120 ",
+	}, "admin-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	clubLayout, err := service.CreateLayout(ctx, application.CreateLayoutInput{
+		Name: "Clubanlage", Kind: domain.LayoutKindClub, Gauge: "TT", Scale: "1:120",
+	}, "admin-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if privateLayout.Name != "Heimanlage" || privateLayout.Gauge != "TT" || privateLayout.Version != 1 {
+		t.Fatalf("unexpected normalized layout: %#v", privateLayout)
+	}
+
+	updated, err := service.UpdateLayout(ctx, privateLayout.ID, application.UpdateLayoutInput{
+		CreateLayoutInput: application.CreateLayoutInput{
+			Name: "Heimanlage erweitert", Kind: domain.LayoutKindPrivate, Gauge: "TT", Scale: "1:120",
+		},
+		ExpectedVersion: 1,
+	}, "planner-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Version != 2 {
+		t.Fatalf("expected version 2, got %d", updated.Version)
+	}
+	if _, err := service.UpdateLayout(ctx, privateLayout.ID, application.UpdateLayoutInput{
+		CreateLayoutInput: application.CreateLayoutInput{
+			Name: "Stale", Kind: domain.LayoutKindPrivate, Gauge: "TT", Scale: "1:120",
+		},
+		ExpectedVersion: 1,
+	}, "planner-1"); !errors.Is(err, application.ErrLayoutVersionConflict) {
+		t.Fatalf("expected version conflict, got %v", err)
+	}
+	layouts, err := service.ListLayouts(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(layouts) != 2 || layouts[0].ID != clubLayout.ID || layouts[1].ID != privateLayout.ID {
+		t.Fatalf("unexpected layout list: %#v", layouts)
+	}
+	storedLayout, err := service.GetLayout(ctx, privateLayout.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if storedLayout.Name != "Heimanlage erweitert" || storedLayout.Version != 2 {
+		t.Fatalf("unexpected stored layout: %#v", storedLayout)
+	}
+
+	for _, kind := range []domain.LayoutUnitKind{
+		domain.LayoutUnitKindBaseboard,
+		domain.LayoutUnitKindModule,
+		domain.LayoutUnitKindSegment,
+		domain.LayoutUnitKindArea,
+	} {
+		if _, err := service.CreateUnit(ctx, clubLayout.ID, application.CreateLayoutUnitInput{
+			Name: string(kind), Kind: kind, WidthMM: 1000, HeightMM: 500,
+		}, "planner-1"); err != nil {
+			t.Fatalf("create %s unit: %v", kind, err)
+		}
+	}
+	if _, err := service.CreateUnit(ctx, clubLayout.ID, application.CreateLayoutUnitInput{
+		Name: "Invalid", Kind: domain.LayoutUnitKindModule, WidthMM: -1,
+	}, "planner-1"); !errors.Is(err, application.ErrLayoutValidation) {
+		t.Fatalf("expected invalid dimension error, got %v", err)
+	}
+
+	units, err := service.ListUnits(ctx, clubLayout.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	updatedUnit, err := service.UpdateUnit(ctx, units[0].ID, application.UpdateLayoutUnitInput{
+		CreateLayoutUnitInput: application.CreateLayoutUnitInput{
+			Name: "Updated unit", Kind: units[0].Kind, WidthMM: 1200, HeightMM: 600,
+		},
+		ExpectedVersion: units[0].Version,
+	}, "planner-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updatedUnit.Version != 2 || updatedUnit.WidthMM != 1200 {
+		t.Fatalf("unexpected updated unit: %#v", updatedUnit)
+	}
+	if _, err := service.UpdateUnit(ctx, units[0].ID, application.UpdateLayoutUnitInput{
+		CreateLayoutUnitInput: application.CreateLayoutUnitInput{Name: "Stale unit", Kind: units[0].Kind},
+		ExpectedVersion:       units[0].Version,
+	}, "planner-1"); !errors.Is(err, application.ErrLayoutVersionConflict) {
+		t.Fatalf("expected unit version conflict, got %v", err)
+	}
+	privateUnit, err := service.CreateUnit(ctx, privateLayout.ID, application.CreateLayoutUnitInput{
+		Name: "Private segment", Kind: domain.LayoutUnitKindSegment,
+	}, "planner-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := service.SaveConfiguration(ctx, clubLayout.ID, application.SaveLayoutConfigurationInput{
+		Name: "Wrong membership", Units: []application.ConfigurationUnitInput{{UnitID: privateUnit.ID}},
+	}, "planner-1"); !errors.Is(err, application.ErrLayoutValidation) {
+		t.Fatalf("expected configuration membership validation error, got %v", err)
+	}
+	if _, err := service.SaveConfiguration(ctx, clubLayout.ID, application.SaveLayoutConfigurationInput{
+		Name:  "Invalid coordinates",
+		Units: []application.ConfigurationUnitInput{{UnitID: units[0].ID, PositionXMM: math.NaN()}},
+	}, "planner-1"); !errors.Is(err, application.ErrLayoutValidation) {
+		t.Fatalf("expected finite coordinate validation error, got %v", err)
+	}
+	configuration, err := service.SaveConfiguration(ctx, clubLayout.ID, application.SaveLayoutConfigurationInput{
+		Name: "Ausstellung",
+		Units: []application.ConfigurationUnitInput{
+			{UnitID: units[0].ID, PositionXMM: 100, RotationDegrees: -30},
+			{UnitID: units[1].ID, PositionXMM: 1100, RotationDegrees: 725},
+		},
+	}, "planner-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(configuration.Units) != 2 || configuration.Units[0].RotationDegrees != 330 ||
+		configuration.Units[1].RotationDegrees != 5 {
+		t.Fatalf("unexpected normalized configuration: %#v", configuration.Units)
+	}
+	configurations, err := service.ListConfigurations(ctx, clubLayout.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(configurations) != 1 || configurations[0].ID != configuration.ID {
+		t.Fatalf("unexpected configuration list: %#v", configurations)
+	}
+	updatedConfiguration, err := service.SaveConfiguration(ctx, clubLayout.ID, application.SaveLayoutConfigurationInput{
+		ID: configuration.ID, Name: "Ausstellung erweitert", ExpectedVersion: configuration.Version,
+		Units: configuration.Units,
+	}, "planner-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updatedConfiguration.Version != 2 || updatedConfiguration.Name != "Ausstellung erweitert" {
+		t.Fatalf("unexpected updated configuration: %#v", updatedConfiguration)
+	}
+	if _, err := service.SaveConfiguration(ctx, clubLayout.ID, application.SaveLayoutConfigurationInput{
+		ID: configuration.ID, Name: "Stale setup", ExpectedVersion: configuration.Version,
+		Units: configuration.Units,
+	}, "planner-1"); !errors.Is(err, application.ErrLayoutVersionConflict) {
+		t.Fatalf("expected configuration version conflict, got %v", err)
+	}
+}
+
+func testLayoutService(t *testing.T) *application.LayoutService {
+	t.Helper()
+	db, err := infrastructure.OpenSQLite(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := infrastructure.Migrate(db, filepath.Join("..", "..", "migrations")); err != nil {
+		t.Fatal(err)
+	}
+	return application.NewLayoutService(infrastructure.NewLayoutRepository(db))
+}

--- a/backend/internal/infrastructure/layout_revision_repository.go
+++ b/backend/internal/infrastructure/layout_revision_repository.go
@@ -234,7 +234,7 @@ func (r *LayoutRepository) listPlanRevisions(ctx context.Context, variantID stri
 	if err != nil {
 		return nil, fmt.Errorf("list plan revisions: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	revisions := []application.PlanRevision{}
 	for rows.Next() {
 		revision, err := scanPlanRevision(rows)

--- a/backend/internal/infrastructure/layout_revision_repository.go
+++ b/backend/internal/infrastructure/layout_revision_repository.go
@@ -1,0 +1,278 @@
+package infrastructure
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"railkeeper/backend/internal/application"
+	"railkeeper/backend/internal/domain"
+)
+
+func (r *LayoutRepository) ListVariants(ctx context.Context, unitID string) ([]application.PlanVariant, error) {
+	rows, err := r.db.QueryContext(ctx, planVariantSelect+` WHERE layout_unit_id=? ORDER BY name COLLATE NOCASE, id`, unitID)
+	if err != nil {
+		return nil, fmt.Errorf("list plan variants: %w", err)
+	}
+	variants := []application.PlanVariant{}
+	for rows.Next() {
+		variant, err := scanPlanVariant(rows)
+		if err != nil {
+			_ = rows.Close()
+			return nil, fmt.Errorf("scan plan variant: %w", err)
+		}
+		variants = append(variants, *variant)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return nil, fmt.Errorf("iterate plan variants: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, fmt.Errorf("close plan variants: %w", err)
+	}
+	for index := range variants {
+		revisions, err := r.listPlanRevisions(ctx, variants[index].ID)
+		if err != nil {
+			return nil, err
+		}
+		variants[index].Revisions = revisions
+	}
+	return variants, nil
+}
+
+func (r *LayoutRepository) CreateVariant(
+	ctx context.Context,
+	unitID string,
+	input application.CreatePlanVariantInput,
+	actor string,
+) (*application.PlanVariant, error) {
+	now := timestamp()
+	variant := &application.PlanVariant{
+		ID: randomID(), LayoutUnitID: unitID, Name: input.Name, Description: input.Description,
+		Revisions: []application.PlanRevision{}, CreatedAt: now, UpdatedAt: now,
+	}
+	err := r.withTx(ctx, func(tx *sql.Tx) error {
+		exists, err := recordExists(ctx, tx, "layout_units", unitID)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return application.ErrLayoutNotFound
+		}
+		if _, err := tx.ExecContext(ctx, `
+INSERT INTO plan_variants(id, layout_unit_id, name, description, archived, created_at, updated_at)
+VALUES(?, ?, ?, ?, 0, ?, ?)`, variant.ID, unitID, variant.Name, variant.Description, now, now); err != nil {
+			return fmt.Errorf("insert plan variant: %w", err)
+		}
+		return writeLayoutAudit(ctx, tx, "PlanVariantCreated", "plan_variant", variant.ID, actor, now)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return variant, nil
+}
+
+func (r *LayoutRepository) CreateDraft(
+	ctx context.Context,
+	variantID string,
+	input application.CreatePlanRevisionInput,
+	actor string,
+) (*application.PlanRevision, error) {
+	now := timestamp()
+	revision := &application.PlanRevision{
+		ID: randomID(), VariantID: variantID, Status: domain.PlanRevisionDraft,
+		BaseRevisionID: input.BaseRevisionID, Version: 1, CreatedBy: actor, CreatedAt: now, UpdatedAt: now,
+	}
+	err := r.withTx(ctx, func(tx *sql.Tx) error {
+		exists, err := planVariantExists(ctx, tx, variantID)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return application.ErrLayoutNotFound
+		}
+		if input.BaseRevisionID != "" {
+			var status domain.PlanRevisionStatus
+			err := tx.QueryRowContext(ctx, `
+SELECT status FROM plan_revisions WHERE id=? AND variant_id=?`, input.BaseRevisionID, variantID).Scan(&status)
+			if errors.Is(err, sql.ErrNoRows) || (err == nil && status != domain.PlanRevisionPublished && status != domain.PlanRevisionArchived) {
+				return application.ErrLayoutValidation
+			}
+			if err != nil {
+				return fmt.Errorf("validate base plan revision: %w", err)
+			}
+		}
+		if err := tx.QueryRowContext(ctx, `
+SELECT COALESCE(MAX(revision_number), 0) + 1 FROM plan_revisions WHERE variant_id=?`, variantID).
+			Scan(&revision.RevisionNumber); err != nil {
+			return fmt.Errorf("allocate plan revision number: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, `
+INSERT INTO plan_revisions(
+  id, variant_id, revision_number, status, base_revision_id, version, created_by,
+  published_by, published_at, created_at, updated_at
+) VALUES(?, ?, ?, ?, NULLIF(?, ''), 1, ?, NULL, NULL, ?, ?)`, revision.ID, variantID,
+			revision.RevisionNumber, revision.Status, revision.BaseRevisionID, actor, now, now); err != nil {
+			return fmt.Errorf("insert plan draft: %w", err)
+		}
+		return writeLayoutAudit(ctx, tx, "PlanDraftCreated", "plan_revision", revision.ID, actor, now)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return revision, nil
+}
+
+func (r *LayoutRepository) SubmitRevision(
+	ctx context.Context,
+	id string,
+	expectedVersion int,
+	actor string,
+) (*application.PlanRevision, error) {
+	now := timestamp()
+	err := r.withTx(ctx, func(tx *sql.Tx) error {
+		status, version, err := revisionState(ctx, tx, id)
+		if err != nil {
+			return err
+		}
+		if status == domain.PlanRevisionPublished || status == domain.PlanRevisionArchived {
+			return application.ErrPlanRevisionImmutable
+		}
+		if version != expectedVersion {
+			return application.ErrPlanRevisionConflict
+		}
+		if status != domain.PlanRevisionDraft {
+			return application.ErrPlanRevisionConflict
+		}
+		if _, err := tx.ExecContext(ctx, `
+UPDATE plan_revisions SET status='review', version=version+1, updated_at=? WHERE id=? AND version=?`,
+			now, id, expectedVersion); err != nil {
+			return fmt.Errorf("submit plan revision: %w", err)
+		}
+		return writeLayoutAudit(ctx, tx, "PlanRevisionSubmitted", "plan_revision", id, actor, now)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return r.getPlanRevision(ctx, id)
+}
+
+func (r *LayoutRepository) PublishRevision(
+	ctx context.Context,
+	id string,
+	expectedVersion int,
+	actor string,
+) (*application.PlanRevision, error) {
+	now := timestamp()
+	err := r.withTx(ctx, func(tx *sql.Tx) error {
+		status, version, err := revisionState(ctx, tx, id)
+		if err != nil {
+			return err
+		}
+		if status == domain.PlanRevisionPublished || status == domain.PlanRevisionArchived {
+			return application.ErrPlanRevisionImmutable
+		}
+		if version != expectedVersion {
+			return application.ErrPlanRevisionConflict
+		}
+		var variantID string
+		if err := tx.QueryRowContext(ctx, `SELECT variant_id FROM plan_revisions WHERE id=?`, id).Scan(&variantID); err != nil {
+			return fmt.Errorf("read plan revision variant: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, `
+UPDATE plan_revisions
+SET status='archived', version=version+1, updated_at=?
+WHERE variant_id=? AND status='published' AND id<>?`, now, variantID, id); err != nil {
+			return fmt.Errorf("archive published plan revision: %w", err)
+		}
+		result, err := tx.ExecContext(ctx, `
+UPDATE plan_revisions
+SET status='published', published_by=?, published_at=?, version=version+1, updated_at=?
+WHERE id=? AND version=? AND status IN ('draft', 'review')`, actor, now, now, id, expectedVersion)
+		if err != nil {
+			return fmt.Errorf("publish plan revision: %w", err)
+		}
+		affected, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("read publish result: %w", err)
+		}
+		if affected != 1 {
+			return application.ErrPlanRevisionConflict
+		}
+		return writeLayoutAudit(ctx, tx, "PlanRevisionPublished", "plan_revision", id, actor, now)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return r.getPlanRevision(ctx, id)
+}
+
+const planVariantSelect = `SELECT id, layout_unit_id, name, description, archived, created_at, updated_at FROM plan_variants`
+
+const planRevisionSelect = `SELECT id, variant_id, revision_number, status, COALESCE(base_revision_id, ''), version, created_by, COALESCE(published_by, ''), COALESCE(published_at, ''), created_at, updated_at FROM plan_revisions`
+
+func scanPlanVariant(scanner rowScanner) (*application.PlanVariant, error) {
+	variant := &application.PlanVariant{}
+	var archived int
+	err := scanner.Scan(&variant.ID, &variant.LayoutUnitID, &variant.Name, &variant.Description, &archived,
+		&variant.CreatedAt, &variant.UpdatedAt)
+	variant.Archived = archived != 0
+	return variant, err
+}
+
+func scanPlanRevision(scanner rowScanner) (*application.PlanRevision, error) {
+	revision := &application.PlanRevision{}
+	err := scanner.Scan(&revision.ID, &revision.VariantID, &revision.RevisionNumber, &revision.Status,
+		&revision.BaseRevisionID, &revision.Version, &revision.CreatedBy, &revision.PublishedBy,
+		&revision.PublishedAt, &revision.CreatedAt, &revision.UpdatedAt)
+	return revision, err
+}
+
+func (r *LayoutRepository) listPlanRevisions(ctx context.Context, variantID string) ([]application.PlanRevision, error) {
+	rows, err := r.db.QueryContext(ctx, planRevisionSelect+` WHERE variant_id=? ORDER BY revision_number, id`, variantID)
+	if err != nil {
+		return nil, fmt.Errorf("list plan revisions: %w", err)
+	}
+	defer rows.Close()
+	revisions := []application.PlanRevision{}
+	for rows.Next() {
+		revision, err := scanPlanRevision(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan plan revision: %w", err)
+		}
+		revisions = append(revisions, *revision)
+	}
+	return revisions, rows.Err()
+}
+
+func (r *LayoutRepository) getPlanRevision(ctx context.Context, id string) (*application.PlanRevision, error) {
+	revision, err := scanPlanRevision(r.db.QueryRowContext(ctx, planRevisionSelect+` WHERE id=?`, id))
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, application.ErrLayoutNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get plan revision: %w", err)
+	}
+	return revision, nil
+}
+
+func planVariantExists(ctx context.Context, tx *sql.Tx, id string) (bool, error) {
+	var count int
+	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM plan_variants WHERE id=?`, id).Scan(&count); err != nil {
+		return false, fmt.Errorf("check plan variant: %w", err)
+	}
+	return count > 0, nil
+}
+
+func revisionState(ctx context.Context, tx *sql.Tx, id string) (domain.PlanRevisionStatus, int, error) {
+	var status domain.PlanRevisionStatus
+	var version int
+	if err := tx.QueryRowContext(ctx, `SELECT status, version FROM plan_revisions WHERE id=?`, id).
+		Scan(&status, &version); errors.Is(err, sql.ErrNoRows) {
+		return "", 0, application.ErrLayoutNotFound
+	} else if err != nil {
+		return "", 0, fmt.Errorf("read plan revision state: %w", err)
+	}
+	return status, version, nil
+}

--- a/backend/internal/infrastructure/layout_revision_repository_test.go
+++ b/backend/internal/infrastructure/layout_revision_repository_test.go
@@ -78,8 +78,7 @@ func TestLayoutServicePublishesImmutableRevisionHistory(t *testing.T) {
 	if _, err := service.PublishRevision(ctx, second.ID, second.Version+1, "planner-1"); !errors.Is(err, application.ErrPlanRevisionConflict) {
 		t.Fatalf("expected plan revision conflict, got %v", err)
 	}
-	second, err = service.PublishRevision(ctx, second.ID, second.Version, "planner-1")
-	if err != nil {
+	if _, err := service.PublishRevision(ctx, second.ID, second.Version, "planner-1"); err != nil {
 		t.Fatal(err)
 	}
 	variants, err := service.ListVariants(ctx, unit.ID)
@@ -147,7 +146,7 @@ func TestLayoutServiceWritesAuditTrail(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	actions := []string{}
 	for rows.Next() {
 		var action string

--- a/backend/internal/infrastructure/layout_revision_repository_test.go
+++ b/backend/internal/infrastructure/layout_revision_repository_test.go
@@ -1,0 +1,184 @@
+package infrastructure_test
+
+import (
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"railkeeper/backend/internal/application"
+	"railkeeper/backend/internal/domain"
+	"railkeeper/backend/internal/infrastructure"
+)
+
+func TestLayoutServicePublishesImmutableRevisionHistory(t *testing.T) {
+	service, _ := testRevisionServiceWithDB(t)
+	ctx := t.Context()
+	layout, err := service.CreateLayout(ctx, application.CreateLayoutInput{
+		Name: "Heimanlage", Kind: domain.LayoutKindPrivate, Gauge: "TT", Scale: "1:120",
+	}, "admin-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	unit, err := service.CreateUnit(ctx, layout.ID, application.CreateLayoutUnitInput{
+		Name: "Grundplatte", Kind: domain.LayoutUnitKindBaseboard, WidthMM: 2000, HeightMM: 1000,
+	}, "planner-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	variant, err := service.CreateVariant(ctx, unit.ID, application.CreatePlanVariantInput{Name: "Standard"}, "planner-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	first, err := service.CreateDraft(ctx, variant.ID, application.CreatePlanRevisionInput{}, "planner-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.RevisionNumber != 1 || first.Status != domain.PlanRevisionDraft {
+		t.Fatalf("unexpected first draft: %#v", first)
+	}
+	first, err = service.SubmitRevision(ctx, first.ID, first.Version, "planner-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err = service.PublishRevision(ctx, first.ID, first.Version, "planner-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Status != domain.PlanRevisionPublished {
+		t.Fatalf("expected published revision, got %#v", first)
+	}
+	if _, err := service.SubmitRevision(ctx, first.ID, first.Version, "planner-1"); !errors.Is(err, application.ErrPlanRevisionImmutable) {
+		t.Fatalf("expected immutable revision error, got %v", err)
+	}
+	configuration, err := service.SaveConfiguration(ctx, layout.ID, application.SaveLayoutConfigurationInput{
+		Name:  "Published setup",
+		Units: []application.ConfigurationUnitInput{{UnitID: unit.ID, PlanRevisionID: first.ID}},
+	}, "planner-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	second, err := service.CreateDraft(ctx, variant.ID, application.CreatePlanRevisionInput{
+		BaseRevisionID: first.ID,
+	}, "planner-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.RevisionNumber != 2 || second.BaseRevisionID != first.ID {
+		t.Fatalf("unexpected second draft: %#v", second)
+	}
+	if _, err := service.SaveConfiguration(ctx, layout.ID, application.SaveLayoutConfigurationInput{
+		Name:  "Draft setup",
+		Units: []application.ConfigurationUnitInput{{UnitID: unit.ID, PlanRevisionID: second.ID}},
+	}, "planner-1"); !errors.Is(err, application.ErrLayoutValidation) {
+		t.Fatalf("expected unpublished revision validation error, got %v", err)
+	}
+	if _, err := service.PublishRevision(ctx, second.ID, second.Version+1, "planner-1"); !errors.Is(err, application.ErrPlanRevisionConflict) {
+		t.Fatalf("expected plan revision conflict, got %v", err)
+	}
+	second, err = service.PublishRevision(ctx, second.ID, second.Version, "planner-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	variants, err := service.ListVariants(ctx, unit.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(variants) != 1 || len(variants[0].Revisions) != 2 {
+		t.Fatalf("unexpected revision history: %#v", variants)
+	}
+	if variants[0].Revisions[0].Status != domain.PlanRevisionArchived ||
+		variants[0].Revisions[1].Status != domain.PlanRevisionPublished {
+		t.Fatalf("unexpected revision statuses: %#v", variants[0].Revisions)
+	}
+	configuration, err = service.SaveConfiguration(ctx, layout.ID, application.SaveLayoutConfigurationInput{
+		ID: configuration.ID, Name: configuration.Name, ExpectedVersion: configuration.Version,
+		Units: configuration.Units,
+	}, "planner-1")
+	if err != nil {
+		t.Fatalf("archived published revision must remain usable in an existing setup: %v", err)
+	}
+	if configuration.Version != 2 {
+		t.Fatalf("expected configuration version 2, got %d", configuration.Version)
+	}
+}
+
+func TestLayoutServiceWritesAuditTrail(t *testing.T) {
+	service, db := testRevisionServiceWithDB(t)
+	ctx := t.Context()
+	layout, err := service.CreateLayout(ctx, application.CreateLayoutInput{
+		Name: "Audit layout", Kind: domain.LayoutKindPrivate, Gauge: "TT", Scale: "1:120",
+	}, "admin-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	unit, err := service.CreateUnit(ctx, layout.ID, application.CreateLayoutUnitInput{
+		Name: "Audit module", Kind: domain.LayoutUnitKindModule,
+	}, "planner-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	variant, err := service.CreateVariant(ctx, unit.ID, application.CreatePlanVariantInput{Name: "Audit plan"}, "planner-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	revision, err := service.CreateDraft(ctx, variant.ID, application.CreatePlanRevisionInput{}, "planner-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	revision, err = service.SubmitRevision(ctx, revision.ID, revision.Version, "planner-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	revision, err = service.PublishRevision(ctx, revision.ID, revision.Version, "planner-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := service.SaveConfiguration(ctx, layout.ID, application.SaveLayoutConfigurationInput{
+		Name:  "Audit setup",
+		Units: []application.ConfigurationUnitInput{{UnitID: unit.ID, PlanRevisionID: revision.ID}},
+	}, "planner-1"); err != nil {
+		t.Fatal(err)
+	}
+
+	rows, err := db.QueryContext(ctx, `SELECT action FROM audit_logs ORDER BY rowid`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	actions := []string{}
+	for rows.Next() {
+		var action string
+		if err := rows.Scan(&action); err != nil {
+			t.Fatal(err)
+		}
+		actions = append(actions, action)
+	}
+	want := []string{
+		"LayoutCreated", "LayoutUnitCreated", "PlanVariantCreated", "PlanDraftCreated",
+		"PlanRevisionSubmitted", "PlanRevisionPublished", "LayoutConfigurationSaved",
+	}
+	if len(actions) != len(want) {
+		t.Fatalf("unexpected audit actions: %#v", actions)
+	}
+	for index := range want {
+		if actions[index] != want[index] {
+			t.Fatalf("unexpected audit action %d: got %q, want %q", index, actions[index], want[index])
+		}
+	}
+}
+
+func testRevisionServiceWithDB(t *testing.T) (*application.LayoutService, *sql.DB) {
+	t.Helper()
+	db, err := infrastructure.OpenSQLite(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := infrastructure.Migrate(db, filepath.Join("..", "..", "migrations")); err != nil {
+		t.Fatal(err)
+	}
+	return application.NewLayoutService(infrastructure.NewLayoutRepository(db)), db
+}


### PR DESCRIPTION
## Deutsch

Zweiter eigenständig reviewbarer Teil von #38. Baut auf dem in #46 gemergten Application-Vertrag auf.

### Enthalten

- persistiert private Anlagen und Clubanlagen mit optimistischer Versionierung
- verwaltet Grundplatten, Module, Segmente und Bereiche
- speichert Anlagenaufbauten samt Position, Drehung, Reihenfolge und optionaler Planrevision
- prüft, dass Einheiten und Planrevisionen zum jeweiligen Aufbau gehören
- verwaltet Planvarianten und monoton steigende Revisionsnummern
- unterstützt `draft -> review -> published` und archiviert die vorher veröffentlichte Revision atomar
- hält veröffentlichte und archivierte Revisionen unveränderlich
- lässt bestehende Aufbauten weiterhin auf eine ehemals veröffentlichte, inzwischen archivierte Revision zeigen
- schreibt alle relevanten Änderungen transaktional in den Audit-Trail

### Prüfung

- `go test ./...`
- `go vet ./...`
- `git diff --cached --check`

HTTP-Routen und Rollenverdrahtung folgen als letzter Teil von #38.

Refs #38

## English

Second independently reviewable part of #38. Builds on the application contract merged in #46.

### Included

- persists private and club layouts with optimistic versioning
- manages baseboards, modules, segments, and areas
- stores layout configurations with position, rotation, ordering, and an optional plan revision
- verifies that units and plan revisions belong to the relevant configuration
- manages plan variants and monotonically increasing revision numbers
- supports `draft -> review -> published` and atomically archives the previously published revision
- keeps published and archived revisions immutable
- preserves existing configurations that reference a previously published, now archived revision
- writes all relevant changes to the audit trail in the same transaction

### Verification

- `go test ./...`
- `go vet ./...`
- `git diff --cached --check`

HTTP routes and role wiring follow as the final part of #38.

Refs #38