### PR TITLE
feat(accessories): define catalog and inventory service

### DIFF
--- a/backend/internal/application/accessories.go
+++ b/backend/internal/application/accessories.go
@@ -1,0 +1,170 @@
+package application
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"railkeeper/backend/internal/domain"
+)
+
+var (
+	ErrAccessoryValidation        = errors.New("accessory validation failed")
+	ErrAccessoryNotFound          = errors.New("accessory resource not found")
+	ErrAccessoryConflict          = errors.New("accessory resource conflict")
+	ErrAccessoryInsufficientStock = errors.New("insufficient accessory stock")
+	ErrAccessoryTrackingMode      = errors.New("invalid accessory tracking mode")
+)
+
+type AccessoryProduct struct {
+	ID            string                       `json:"id"`
+	Manufacturer  string                       `json:"manufacturer"`
+	ArticleNumber string                       `json:"articleNumber,omitempty"`
+	Name          string                       `json:"name"`
+	Category      string                       `json:"category"`
+	TrackingMode  domain.AccessoryTrackingMode `json:"trackingMode"`
+	Description   string                       `json:"description,omitempty"`
+	CreatedAt     string                       `json:"createdAt"`
+	UpdatedAt     string                       `json:"updatedAt"`
+}
+
+type CreateAccessoryProductInput struct {
+	Manufacturer  string                       `json:"manufacturer"`
+	ArticleNumber string                       `json:"articleNumber"`
+	Name          string                       `json:"name"`
+	Category      string                       `json:"category"`
+	TrackingMode  domain.AccessoryTrackingMode `json:"trackingMode"`
+	Description   string                       `json:"description"`
+}
+
+type UpdateAccessoryProductInput struct {
+	CreateAccessoryProductInput
+}
+
+type StorageLocation struct {
+	ID          string `json:"id"`
+	ParentID    string `json:"parentId,omitempty"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Archived    bool   `json:"archived"`
+	CreatedAt   string `json:"createdAt"`
+	UpdatedAt   string `json:"updatedAt"`
+}
+
+type CreateStorageLocationInput struct {
+	ParentID    string `json:"parentId"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Archived    bool   `json:"archived"`
+}
+
+type UpdateStorageLocationInput struct {
+	CreateStorageLocationInput
+}
+
+type AccessoryRepository interface {
+	ListProducts(context.Context, string) ([]AccessoryProduct, error)
+	GetProduct(context.Context, string) (*AccessoryProduct, error)
+	CreateProduct(context.Context, CreateAccessoryProductInput, string) (*AccessoryProduct, error)
+	UpdateProduct(context.Context, string, UpdateAccessoryProductInput, string) (*AccessoryProduct, error)
+	ListLocations(context.Context) ([]StorageLocation, error)
+	CreateLocation(context.Context, CreateStorageLocationInput, string) (*StorageLocation, error)
+	UpdateLocation(context.Context, string, UpdateStorageLocationInput, string) (*StorageLocation, error)
+	AdjustStock(context.Context, string, StockAdjustmentInput, string) (*AccessoryStockSummary, error)
+	GetStock(context.Context, string) (*AccessoryStockSummary, error)
+	ListAssets(context.Context, string) ([]AccessoryAsset, error)
+	CreateAsset(context.Context, string, CreateAccessoryAssetInput, string) (*AccessoryAsset, error)
+	UpdateAsset(context.Context, string, UpdateAccessoryAssetInput, string) (*AccessoryAsset, error)
+}
+
+type AccessoryService struct {
+	repository AccessoryRepository
+}
+
+func NewAccessoryService(repository AccessoryRepository) *AccessoryService {
+	return &AccessoryService{repository: repository}
+}
+
+func (s *AccessoryService) ListProducts(ctx context.Context, query string) ([]AccessoryProduct, error) {
+	return s.repository.ListProducts(ctx, strings.TrimSpace(query))
+}
+
+func (s *AccessoryService) GetProduct(ctx context.Context, id string) (*AccessoryProduct, error) {
+	return s.repository.GetProduct(ctx, strings.TrimSpace(id))
+}
+
+func (s *AccessoryService) CreateProduct(
+	ctx context.Context,
+	input CreateAccessoryProductInput,
+	actor string,
+) (*AccessoryProduct, error) {
+	input = cleanAccessoryProductInput(input)
+	if !validAccessoryProductInput(input) {
+		return nil, ErrAccessoryValidation
+	}
+	return s.repository.CreateProduct(ctx, input, actor)
+}
+
+func (s *AccessoryService) UpdateProduct(
+	ctx context.Context,
+	id string,
+	input UpdateAccessoryProductInput,
+	actor string,
+) (*AccessoryProduct, error) {
+	input.CreateAccessoryProductInput = cleanAccessoryProductInput(input.CreateAccessoryProductInput)
+	id = strings.TrimSpace(id)
+	if id == "" || !validAccessoryProductInput(input.CreateAccessoryProductInput) {
+		return nil, ErrAccessoryValidation
+	}
+	return s.repository.UpdateProduct(ctx, id, input, actor)
+}
+
+func (s *AccessoryService) ListLocations(ctx context.Context) ([]StorageLocation, error) {
+	return s.repository.ListLocations(ctx)
+}
+
+func (s *AccessoryService) CreateLocation(
+	ctx context.Context,
+	input CreateStorageLocationInput,
+	actor string,
+) (*StorageLocation, error) {
+	input = cleanStorageLocationInput(input)
+	if input.Name == "" {
+		return nil, ErrAccessoryValidation
+	}
+	return s.repository.CreateLocation(ctx, input, actor)
+}
+
+func (s *AccessoryService) UpdateLocation(
+	ctx context.Context,
+	id string,
+	input UpdateStorageLocationInput,
+	actor string,
+) (*StorageLocation, error) {
+	id = strings.TrimSpace(id)
+	input.CreateStorageLocationInput = cleanStorageLocationInput(input.CreateStorageLocationInput)
+	if id == "" || input.Name == "" || input.ParentID == id {
+		return nil, ErrAccessoryValidation
+	}
+	return s.repository.UpdateLocation(ctx, id, input, actor)
+}
+
+func cleanAccessoryProductInput(input CreateAccessoryProductInput) CreateAccessoryProductInput {
+	input.Manufacturer = strings.TrimSpace(input.Manufacturer)
+	input.ArticleNumber = strings.TrimSpace(input.ArticleNumber)
+	input.Name = strings.TrimSpace(input.Name)
+	input.Category = strings.TrimSpace(input.Category)
+	input.Description = strings.TrimSpace(input.Description)
+	return input
+}
+
+func validAccessoryProductInput(input CreateAccessoryProductInput) bool {
+	return input.Manufacturer != "" && input.Name != "" && input.Category != "" && input.TrackingMode.Valid()
+}
+
+func cleanStorageLocationInput(input CreateStorageLocationInput) CreateStorageLocationInput {
+	input.ParentID = strings.TrimSpace(input.ParentID)
+	input.Name = strings.TrimSpace(input.Name)
+	input.Description = strings.TrimSpace(input.Description)
+	return input
+}

--- a/backend/internal/application/accessories_test.go
+++ b/backend/internal/application/accessories_test.go
@@ -1,0 +1,208 @@
+package application
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"railkeeper/backend/internal/domain"
+)
+
+type accessoryRepositorySpy struct {
+	AccessoryRepository
+	createdProduct  CreateAccessoryProductInput
+	updatedProduct  UpdateAccessoryProductInput
+	createdLocation CreateStorageLocationInput
+	updatedLocation UpdateStorageLocationInput
+	stockAdjustment StockAdjustmentInput
+	createdAsset    CreateAccessoryAssetInput
+	updatedAsset    UpdateAccessoryAssetInput
+}
+
+func (spy *accessoryRepositorySpy) CreateProduct(
+	_ context.Context,
+	input CreateAccessoryProductInput,
+	_ string,
+) (*AccessoryProduct, error) {
+	spy.createdProduct = input
+	return &AccessoryProduct{Name: input.Name}, nil
+}
+
+func (spy *accessoryRepositorySpy) UpdateProduct(
+	_ context.Context,
+	_ string,
+	input UpdateAccessoryProductInput,
+	_ string,
+) (*AccessoryProduct, error) {
+	spy.updatedProduct = input
+	return &AccessoryProduct{Name: input.Name}, nil
+}
+
+func (spy *accessoryRepositorySpy) CreateLocation(
+	_ context.Context,
+	input CreateStorageLocationInput,
+	_ string,
+) (*StorageLocation, error) {
+	spy.createdLocation = input
+	return &StorageLocation{Name: input.Name}, nil
+}
+
+func (spy *accessoryRepositorySpy) UpdateLocation(
+	_ context.Context,
+	_ string,
+	input UpdateStorageLocationInput,
+	_ string,
+) (*StorageLocation, error) {
+	spy.updatedLocation = input
+	return &StorageLocation{Name: input.Name}, nil
+}
+
+func (spy *accessoryRepositorySpy) AdjustStock(
+	_ context.Context,
+	_ string,
+	input StockAdjustmentInput,
+	_ string,
+) (*AccessoryStockSummary, error) {
+	spy.stockAdjustment = input
+	return &AccessoryStockSummary{}, nil
+}
+
+func (spy *accessoryRepositorySpy) CreateAsset(
+	_ context.Context,
+	_ string,
+	input CreateAccessoryAssetInput,
+	_ string,
+) (*AccessoryAsset, error) {
+	spy.createdAsset = input
+	return &AccessoryAsset{Condition: input.Condition, Lifecycle: input.Lifecycle}, nil
+}
+
+func (spy *accessoryRepositorySpy) UpdateAsset(
+	_ context.Context,
+	_ string,
+	input UpdateAccessoryAssetInput,
+	_ string,
+) (*AccessoryAsset, error) {
+	spy.updatedAsset = input
+	return &AccessoryAsset{Condition: input.Condition, Lifecycle: input.Lifecycle}, nil
+}
+
+func TestAccessoryServiceNormalizesProductAndLocationInputs(t *testing.T) {
+	repository := &accessoryRepositorySpy{}
+	service := NewAccessoryService(repository)
+
+	if _, err := service.CreateProduct(t.Context(), CreateAccessoryProductInput{
+		Manufacturer: " Tillig ", ArticleNumber: " 83125 ", Name: " Weiche ", Category: " Gleismaterial ",
+		TrackingMode: domain.AccessoryTrackingModeQuantity, Description: " Rechts ",
+	}, "editor-1"); err != nil {
+		t.Fatal(err)
+	}
+	product := repository.createdProduct
+	if product.Manufacturer != "Tillig" || product.ArticleNumber != "83125" || product.Name != "Weiche" ||
+		product.Category != "Gleismaterial" || product.Description != "Rechts" {
+		t.Fatalf("unexpected normalized product: %#v", product)
+	}
+	if _, err := service.UpdateProduct(t.Context(), " product-1 ", UpdateAccessoryProductInput{
+		CreateAccessoryProductInput: CreateAccessoryProductInput{
+			Manufacturer: " Tillig ", Name: " Decoder ", Category: " Elektronik ",
+			TrackingMode: domain.AccessoryTrackingModeIndividual,
+		},
+	}, "editor-1"); err != nil {
+		t.Fatal(err)
+	}
+	if repository.updatedProduct.Name != "Decoder" || repository.updatedProduct.Category != "Elektronik" {
+		t.Fatalf("unexpected normalized product update: %#v", repository.updatedProduct)
+	}
+
+	if _, err := service.CreateLocation(t.Context(), CreateStorageLocationInput{
+		ParentID: " parent-1 ", Name: " Schublade 1 ", Description: " Gleismaterial ",
+	}, "editor-1"); err != nil {
+		t.Fatal(err)
+	}
+	location := repository.createdLocation
+	if location.ParentID != "parent-1" || location.Name != "Schublade 1" || location.Description != "Gleismaterial" {
+		t.Fatalf("unexpected normalized location: %#v", location)
+	}
+	if _, err := service.UpdateLocation(t.Context(), " location-1 ", UpdateStorageLocationInput{
+		CreateStorageLocationInput: CreateStorageLocationInput{ParentID: " parent-2 ", Name: " Fach 2 "},
+	}, "editor-1"); err != nil {
+		t.Fatal(err)
+	}
+	if repository.updatedLocation.ParentID != "parent-2" || repository.updatedLocation.Name != "Fach 2" {
+		t.Fatalf("unexpected normalized location update: %#v", repository.updatedLocation)
+	}
+	if _, err := service.AdjustStock(t.Context(), " product-1 ", StockAdjustmentInput{
+		LocationID: " location-1 ", Delta: 3,
+	}, "editor-1"); err != nil {
+		t.Fatal(err)
+	}
+	if repository.stockAdjustment.LocationID != "location-1" || repository.stockAdjustment.Delta != 3 {
+		t.Fatalf("unexpected normalized stock adjustment: %#v", repository.stockAdjustment)
+	}
+}
+
+func TestAccessoryServiceRejectsInvalidInputs(t *testing.T) {
+	service := NewAccessoryService(&accessoryRepositorySpy{})
+
+	products := []CreateAccessoryProductInput{
+		{Name: "Missing manufacturer", Category: "Track", TrackingMode: domain.AccessoryTrackingModeQuantity},
+		{Manufacturer: "Tillig", Name: "Missing category", TrackingMode: domain.AccessoryTrackingModeQuantity},
+		{Manufacturer: "Tillig", Name: "Invalid mode", Category: "Track", TrackingMode: "shared"},
+	}
+	for _, input := range products {
+		if _, err := service.CreateProduct(t.Context(), input, "editor-1"); !errors.Is(err, ErrAccessoryValidation) {
+			t.Fatalf("expected product validation error for %#v, got %v", input, err)
+		}
+	}
+	if _, err := service.UpdateLocation(t.Context(), "location-1", UpdateStorageLocationInput{
+		CreateStorageLocationInput: CreateStorageLocationInput{Name: "Self", ParentID: "location-1"},
+	}, "editor-1"); !errors.Is(err, ErrAccessoryValidation) {
+		t.Fatalf("expected self-parent validation error, got %v", err)
+	}
+	if _, err := service.CreateLocation(t.Context(), CreateStorageLocationInput{}, "editor-1"); !errors.Is(err, ErrAccessoryValidation) {
+		t.Fatalf("expected location validation error, got %v", err)
+	}
+	if _, err := service.AdjustStock(t.Context(), "product-1", StockAdjustmentInput{
+		LocationID: "location-1", Delta: 0,
+	}, "editor-1"); !errors.Is(err, ErrAccessoryValidation) {
+		t.Fatalf("expected zero adjustment validation error, got %v", err)
+	}
+}
+
+func TestAccessoryServiceDefaultsAndValidatesAssetState(t *testing.T) {
+	repository := &accessoryRepositorySpy{}
+	service := NewAccessoryService(repository)
+
+	asset, err := service.CreateAsset(t.Context(), "product-1", CreateAccessoryAssetInput{
+		InventoryNumber: " Z-0001 ", SerialNumber: " ABC ", StorageLocationID: " location-1 ",
+		PurchasePrice: " 19.99 ", Notes: " Test ",
+	}, "editor-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if asset.Condition != domain.AccessoryConditionUnknown || asset.Lifecycle != domain.AccessoryLifecycleStored {
+		t.Fatalf("unexpected default asset state: %#v", asset)
+	}
+	input := repository.createdAsset
+	if input.InventoryNumber != "Z-0001" || input.SerialNumber != "ABC" || input.StorageLocationID != "location-1" ||
+		input.PurchasePrice != "19.99" || input.Notes != "Test" {
+		t.Fatalf("unexpected normalized asset: %#v", input)
+	}
+	if _, err := service.UpdateAsset(t.Context(), "asset-1", UpdateAccessoryAssetInput{
+		CreateAccessoryAssetInput: CreateAccessoryAssetInput{Condition: "broken", Lifecycle: domain.AccessoryLifecycleStored},
+	}, "editor-1"); !errors.Is(err, ErrAccessoryValidation) {
+		t.Fatalf("expected asset state validation error, got %v", err)
+	}
+	if _, err := service.UpdateAsset(t.Context(), " asset-1 ", UpdateAccessoryAssetInput{
+		CreateAccessoryAssetInput: CreateAccessoryAssetInput{
+			InventoryNumber: " Z-0002 ", Condition: domain.AccessoryConditionReady,
+			Lifecycle: domain.AccessoryLifecycleMaintenance,
+		},
+	}, "editor-1"); err != nil {
+		t.Fatal(err)
+	}
+	if repository.updatedAsset.InventoryNumber != "Z-0002" ||
+		repository.updatedAsset.Lifecycle != domain.AccessoryLifecycleMaintenance {
+		t.Fatalf("unexpected normalized asset update: %#v", repository.updatedAsset)
+	}
+}

--- a/backend/internal/application/accessory_inventory.go
+++ b/backend/internal/application/accessory_inventory.go
@@ -1,0 +1,130 @@
+package application
+
+import (
+	"context"
+	"strings"
+
+	"railkeeper/backend/internal/domain"
+)
+
+type AccessoryStockLevel struct {
+	LocationID   string `json:"locationId"`
+	LocationName string `json:"locationName"`
+	Quantity     int    `json:"quantity"`
+	UpdatedAt    string `json:"updatedAt"`
+}
+
+type AccessoryStockSummary struct {
+	ProductID     string                       `json:"productId"`
+	TrackingMode  domain.AccessoryTrackingMode `json:"trackingMode"`
+	TotalQuantity int                          `json:"totalQuantity"`
+	Locations     []AccessoryStockLevel        `json:"locations"`
+}
+
+type StockAdjustmentInput struct {
+	LocationID string `json:"locationId"`
+	Delta      int    `json:"delta"`
+}
+
+type AccessoryAsset struct {
+	ID                string                    `json:"id"`
+	ProductID         string                    `json:"productId"`
+	InventoryNumber   string                    `json:"inventoryNumber,omitempty"`
+	SerialNumber      string                    `json:"serialNumber,omitempty"`
+	Condition         domain.AccessoryCondition `json:"condition"`
+	Lifecycle         domain.AccessoryLifecycle `json:"lifecycle"`
+	StorageLocationID string                    `json:"storageLocationId,omitempty"`
+	PurchaseDate      string                    `json:"purchaseDate,omitempty"`
+	PurchasePrice     string                    `json:"purchasePrice,omitempty"`
+	WarrantyUntil     string                    `json:"warrantyUntil,omitempty"`
+	Notes             string                    `json:"notes,omitempty"`
+	CreatedAt         string                    `json:"createdAt"`
+	UpdatedAt         string                    `json:"updatedAt"`
+}
+
+type CreateAccessoryAssetInput struct {
+	InventoryNumber   string                    `json:"inventoryNumber"`
+	SerialNumber      string                    `json:"serialNumber"`
+	Condition         domain.AccessoryCondition `json:"condition"`
+	Lifecycle         domain.AccessoryLifecycle `json:"lifecycle"`
+	StorageLocationID string                    `json:"storageLocationId"`
+	PurchaseDate      string                    `json:"purchaseDate"`
+	PurchasePrice     string                    `json:"purchasePrice"`
+	WarrantyUntil     string                    `json:"warrantyUntil"`
+	Notes             string                    `json:"notes"`
+}
+
+type UpdateAccessoryAssetInput struct {
+	CreateAccessoryAssetInput
+}
+
+func (s *AccessoryService) AdjustStock(
+	ctx context.Context,
+	productID string,
+	input StockAdjustmentInput,
+	actor string,
+) (*AccessoryStockSummary, error) {
+	productID = strings.TrimSpace(productID)
+	input.LocationID = strings.TrimSpace(input.LocationID)
+	if productID == "" || input.LocationID == "" || input.Delta == 0 {
+		return nil, ErrAccessoryValidation
+	}
+	return s.repository.AdjustStock(ctx, productID, input, actor)
+}
+
+func (s *AccessoryService) GetStock(ctx context.Context, productID string) (*AccessoryStockSummary, error) {
+	return s.repository.GetStock(ctx, strings.TrimSpace(productID))
+}
+
+func (s *AccessoryService) ListAssets(ctx context.Context, productID string) ([]AccessoryAsset, error) {
+	return s.repository.ListAssets(ctx, strings.TrimSpace(productID))
+}
+
+func (s *AccessoryService) CreateAsset(
+	ctx context.Context,
+	productID string,
+	input CreateAccessoryAssetInput,
+	actor string,
+) (*AccessoryAsset, error) {
+	productID = strings.TrimSpace(productID)
+	input = cleanAccessoryAssetInput(input)
+	if productID == "" || !validAccessoryAssetInput(input) {
+		return nil, ErrAccessoryValidation
+	}
+	return s.repository.CreateAsset(ctx, productID, input, actor)
+}
+
+func (s *AccessoryService) UpdateAsset(
+	ctx context.Context,
+	id string,
+	input UpdateAccessoryAssetInput,
+	actor string,
+) (*AccessoryAsset, error) {
+	id = strings.TrimSpace(id)
+	input.CreateAccessoryAssetInput = cleanAccessoryAssetInput(input.CreateAccessoryAssetInput)
+	if id == "" || !validAccessoryAssetInput(input.CreateAccessoryAssetInput) {
+		return nil, ErrAccessoryValidation
+	}
+	return s.repository.UpdateAsset(ctx, id, input, actor)
+}
+
+func cleanAccessoryAssetInput(input CreateAccessoryAssetInput) CreateAccessoryAssetInput {
+	input.InventoryNumber = strings.TrimSpace(input.InventoryNumber)
+	input.SerialNumber = strings.TrimSpace(input.SerialNumber)
+	input.StorageLocationID = strings.TrimSpace(input.StorageLocationID)
+	input.PurchaseDate = strings.TrimSpace(input.PurchaseDate)
+	input.PurchasePrice = strings.TrimSpace(input.PurchasePrice)
+	input.WarrantyUntil = strings.TrimSpace(input.WarrantyUntil)
+	input.Notes = strings.TrimSpace(input.Notes)
+	if input.Condition == "" {
+		input.Condition = domain.AccessoryConditionUnknown
+	}
+	if input.Lifecycle == "" {
+		input.Lifecycle = domain.AccessoryLifecycleStored
+	}
+	return input
+}
+
+func validAccessoryAssetInput(input CreateAccessoryAssetInput) bool {
+	return input.Condition.Valid() && input.Lifecycle.Valid()
+}


### PR DESCRIPTION
## Deutsch

Erster eigenständig reviewbarer Teil von #40.

### Enthalten

- definiert `AccessoryService` und den Repository-Vertrag für Produkte, Lagerorte, Bestand und Einzelobjekte
- modelliert Mengen- und Einzelverfolgung als getrennte Fachmodi
- verwendet Decimal-Strings für Kaufpreise, konsistent mit Fahrzeugen
- normalisiert alle Text- und ID-Eingaben
- validiert erforderliche Produktdaten, Trackingmodus, Zustände und Lebenszyklus
- verwirft Null-Bestandskorrekturen und direkte Selbstreferenzen bei Lagerorten
- ergänzt `UpdateLocation` im Vertrag, damit Umhängen und vollständige Zyklusprüfung möglich werden
- setzt neue Einzelobjekte standardmäßig auf `unknown` und `stored`

### Bewusst nicht enthalten

SQLite-Persistenz, HTTP-Routen und Rollenverdrahtung folgen in separaten PRs innerhalb von #40.

### Prüfung

- `go test ./internal/application`
- `go vet ./internal/application`
- `git diff --cached --check`

Refs #40

## English

First independently reviewable part of #40.

### Included

- defines `AccessoryService` and the repository contract for products, locations, stock, and individual assets
- models quantity and individual tracking as separate domain modes
- uses decimal strings for purchase prices, consistent with vehicles
- normalizes all text and identifier inputs
- validates required product data, tracking mode, condition, and lifecycle state
- rejects zero stock adjustments and direct self-references for storage locations
- adds `UpdateLocation` to the contract so reparenting and complete cycle prevention are possible
- defaults new individual assets to `unknown` and `stored`

### Intentionally excluded

SQLite persistence, HTTP routes, and role wiring follow in separate PRs within #40.

### Verification

- `go test ./internal/application`
- `go vet ./internal/application`
- `git diff --cached --check`

Refs #40