### PR TITLE
feat(accessories): persist catalogue and inventory

### DIFF
--- a/backend/internal/infrastructure/accessory_inventory_repository.go
+++ b/backend/internal/infrastructure/accessory_inventory_repository.go
@@ -1,0 +1,237 @@
+package infrastructure
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"railkeeper/backend/internal/application"
+	"railkeeper/backend/internal/domain"
+)
+
+func (r *AccessoryRepository) AdjustStock(
+	ctx context.Context,
+	productID string,
+	input application.StockAdjustmentInput,
+	actor string,
+) (*application.AccessoryStockSummary, error) {
+	now := timestamp()
+	err := r.withTx(ctx, func(tx *sql.Tx) error {
+		mode, err := accessoryTrackingMode(ctx, tx, productID)
+		if err != nil {
+			return err
+		}
+		if mode != domain.AccessoryTrackingModeQuantity {
+			return application.ErrAccessoryTrackingMode
+		}
+		if err := requireStorageLocation(ctx, tx, input.LocationID); err != nil {
+			return err
+		}
+		current := 0
+		if err := tx.QueryRowContext(ctx, `
+SELECT quantity FROM accessory_stock WHERE product_id=? AND location_id=?`, productID, input.LocationID).
+			Scan(&current); err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("read accessory stock level: %w", err)
+		}
+		if current+input.Delta < 0 {
+			return application.ErrAccessoryInsufficientStock
+		}
+		if _, err := tx.ExecContext(ctx, `
+INSERT INTO accessory_stock(product_id, location_id, quantity, updated_at)
+VALUES(?, ?, ?, ?)
+ON CONFLICT(product_id, location_id) DO UPDATE SET quantity=excluded.quantity, updated_at=excluded.updated_at`,
+			productID, input.LocationID, current+input.Delta, now); err != nil {
+			return fmt.Errorf("adjust accessory stock: %w", err)
+		}
+		details, err := json.Marshal(map[string]any{"delta": input.Delta, "locationId": input.LocationID})
+		if err != nil {
+			return fmt.Errorf("encode accessory stock audit details: %w", err)
+		}
+		return writeAccessoryAudit(ctx, tx, "AccessoryStockAdjusted", "accessory_product", productID,
+			actor, now, string(details))
+	})
+	if err != nil {
+		return nil, err
+	}
+	return r.GetStock(ctx, productID)
+}
+
+func (r *AccessoryRepository) GetStock(ctx context.Context, productID string) (*application.AccessoryStockSummary, error) {
+	mode, err := accessoryTrackingMode(ctx, r.db, productID)
+	if err != nil {
+		return nil, err
+	}
+	summary := &application.AccessoryStockSummary{
+		ProductID: productID, TrackingMode: mode, Locations: []application.AccessoryStockLevel{},
+	}
+	rows, err := r.db.QueryContext(ctx, `
+SELECT stock.location_id, location.name, stock.quantity, stock.updated_at
+FROM accessory_stock stock
+JOIN storage_locations location ON location.id=stock.location_id
+WHERE stock.product_id=?
+ORDER BY location.name COLLATE NOCASE, stock.location_id`, productID)
+	if err != nil {
+		return nil, fmt.Errorf("list accessory stock: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		level := application.AccessoryStockLevel{}
+		if err := rows.Scan(&level.LocationID, &level.LocationName, &level.Quantity, &level.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("scan accessory stock: %w", err)
+		}
+		summary.TotalQuantity += level.Quantity
+		summary.Locations = append(summary.Locations, level)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate accessory stock: %w", err)
+	}
+	return summary, nil
+}
+
+func (r *AccessoryRepository) ListAssets(ctx context.Context, productID string) ([]application.AccessoryAsset, error) {
+	mode, err := accessoryTrackingMode(ctx, r.db, productID)
+	if err != nil {
+		return nil, err
+	}
+	if mode != domain.AccessoryTrackingModeIndividual {
+		return nil, application.ErrAccessoryTrackingMode
+	}
+	rows, err := r.db.QueryContext(ctx, accessoryAssetSelect+` WHERE product_id=? ORDER BY inventory_number COLLATE NOCASE, id`,
+		productID)
+	if err != nil {
+		return nil, fmt.Errorf("list accessory assets: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	assets := []application.AccessoryAsset{}
+	for rows.Next() {
+		asset, err := scanAccessoryAsset(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan accessory asset: %w", err)
+		}
+		assets = append(assets, *asset)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate accessory assets: %w", err)
+	}
+	return assets, nil
+}
+
+func (r *AccessoryRepository) CreateAsset(
+	ctx context.Context,
+	productID string,
+	input application.CreateAccessoryAssetInput,
+	actor string,
+) (*application.AccessoryAsset, error) {
+	now := timestamp()
+	asset := &application.AccessoryAsset{
+		ID: randomID(), ProductID: productID, InventoryNumber: input.InventoryNumber,
+		SerialNumber: input.SerialNumber, Condition: input.Condition, Lifecycle: input.Lifecycle,
+		StorageLocationID: input.StorageLocationID, PurchaseDate: input.PurchaseDate,
+		PurchasePrice: input.PurchasePrice, WarrantyUntil: input.WarrantyUntil, Notes: input.Notes,
+		CreatedAt: now, UpdatedAt: now,
+	}
+	err := r.withTx(ctx, func(tx *sql.Tx) error {
+		mode, err := accessoryTrackingMode(ctx, tx, productID)
+		if err != nil {
+			return err
+		}
+		if mode != domain.AccessoryTrackingModeIndividual {
+			return application.ErrAccessoryTrackingMode
+		}
+		if err := requireStorageLocation(ctx, tx, input.StorageLocationID); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, `
+INSERT INTO accessory_assets(
+  id, product_id, inventory_number, serial_number, condition_state, lifecycle_state,
+  storage_location_id, purchase_date, purchase_price, warranty_until, notes, created_at, updated_at
+) VALUES(?, ?, NULLIF(?, ''), ?, ?, ?, NULLIF(?, ''), ?, ?, ?, ?, ?, ?)`, asset.ID, asset.ProductID,
+			asset.InventoryNumber, asset.SerialNumber, asset.Condition, asset.Lifecycle, asset.StorageLocationID,
+			asset.PurchaseDate, asset.PurchasePrice, asset.WarrantyUntil, asset.Notes, now, now); err != nil {
+			if isSQLiteConstraint(err) {
+				return application.ErrAccessoryConflict
+			}
+			return fmt.Errorf("insert accessory asset: %w", err)
+		}
+		return writeAccessoryAudit(ctx, tx, "AccessoryAssetCreated", "accessory_asset", asset.ID, actor, now, "{}")
+	})
+	if err != nil {
+		return nil, err
+	}
+	return asset, nil
+}
+
+func (r *AccessoryRepository) UpdateAsset(
+	ctx context.Context,
+	id string,
+	input application.UpdateAccessoryAssetInput,
+	actor string,
+) (*application.AccessoryAsset, error) {
+	now := timestamp()
+	err := r.withTx(ctx, func(tx *sql.Tx) error {
+		var productID string
+		if err := tx.QueryRowContext(ctx, `SELECT product_id FROM accessory_assets WHERE id=?`, id).Scan(&productID); errors.Is(err, sql.ErrNoRows) {
+			return application.ErrAccessoryNotFound
+		} else if err != nil {
+			return fmt.Errorf("read accessory asset product: %w", err)
+		}
+		if err := requireStorageLocation(ctx, tx, input.StorageLocationID); err != nil {
+			return err
+		}
+		result, err := tx.ExecContext(ctx, `
+UPDATE accessory_assets
+SET inventory_number=NULLIF(?, ''), serial_number=?, condition_state=?, lifecycle_state=?,
+    storage_location_id=NULLIF(?, ''), purchase_date=?, purchase_price=?, warranty_until=?, notes=?, updated_at=?
+WHERE id=?`, input.InventoryNumber, input.SerialNumber, input.Condition, input.Lifecycle,
+			input.StorageLocationID, input.PurchaseDate, input.PurchasePrice, input.WarrantyUntil, input.Notes, now, id)
+		if err != nil {
+			if isSQLiteConstraint(err) {
+				return application.ErrAccessoryConflict
+			}
+			return fmt.Errorf("update accessory asset: %w", err)
+		}
+		if err := requireAccessoryUpdated(result); err != nil {
+			return err
+		}
+		return writeAccessoryAudit(ctx, tx, "AccessoryAssetUpdated", "accessory_asset", id, actor, now, "{}")
+	})
+	if err != nil {
+		return nil, err
+	}
+	asset, err := scanAccessoryAsset(r.db.QueryRowContext(ctx, accessoryAssetSelect+` WHERE id=?`, id))
+	if err != nil {
+		return nil, fmt.Errorf("get updated accessory asset: %w", err)
+	}
+	return asset, nil
+}
+
+const accessoryAssetSelect = `SELECT id, product_id, COALESCE(inventory_number, ''), serial_number, condition_state, lifecycle_state, COALESCE(storage_location_id, ''), purchase_date, purchase_price, warranty_until, notes, created_at, updated_at FROM accessory_assets`
+
+func scanAccessoryAsset(scanner rowScanner) (*application.AccessoryAsset, error) {
+	asset := &application.AccessoryAsset{}
+	err := scanner.Scan(&asset.ID, &asset.ProductID, &asset.InventoryNumber, &asset.SerialNumber,
+		&asset.Condition, &asset.Lifecycle, &asset.StorageLocationID, &asset.PurchaseDate,
+		&asset.PurchasePrice, &asset.WarrantyUntil, &asset.Notes, &asset.CreatedAt, &asset.UpdatedAt)
+	return asset, err
+}
+
+type accessoryQueryer interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
+func accessoryTrackingMode(
+	ctx context.Context,
+	queryer accessoryQueryer,
+	productID string,
+) (domain.AccessoryTrackingMode, error) {
+	var mode domain.AccessoryTrackingMode
+	if err := queryer.QueryRowContext(ctx, `SELECT tracking_mode FROM accessory_products WHERE id=?`, productID).
+		Scan(&mode); errors.Is(err, sql.ErrNoRows) {
+		return "", application.ErrAccessoryNotFound
+	} else if err != nil {
+		return "", fmt.Errorf("read accessory tracking mode: %w", err)
+	}
+	return mode, nil
+}

--- a/backend/internal/infrastructure/accessory_repository.go
+++ b/backend/internal/infrastructure/accessory_repository.go
@@ -1,0 +1,341 @@
+package infrastructure
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"modernc.org/sqlite"
+	sqlite3 "modernc.org/sqlite/lib"
+
+	"railkeeper/backend/internal/application"
+	"railkeeper/backend/internal/domain"
+)
+
+type AccessoryRepository struct {
+	db *sql.DB
+}
+
+func NewAccessoryRepository(db *sql.DB) *AccessoryRepository {
+	return &AccessoryRepository{db: db}
+}
+
+func (r *AccessoryRepository) ListProducts(ctx context.Context, query string) ([]application.AccessoryProduct, error) {
+	rows, err := r.db.QueryContext(ctx, accessoryProductSelect+`
+WHERE ?='' OR manufacturer LIKE '%' || ? || '%' COLLATE NOCASE
+   OR article_number LIKE '%' || ? || '%' COLLATE NOCASE
+   OR name LIKE '%' || ? || '%' COLLATE NOCASE
+   OR category LIKE '%' || ? || '%' COLLATE NOCASE
+ORDER BY manufacturer COLLATE NOCASE, name COLLATE NOCASE, id`, query, query, query, query, query)
+	if err != nil {
+		return nil, fmt.Errorf("list accessory products: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	products := []application.AccessoryProduct{}
+	for rows.Next() {
+		product, err := scanAccessoryProduct(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan accessory product: %w", err)
+		}
+		products = append(products, *product)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate accessory products: %w", err)
+	}
+	return products, nil
+}
+
+func (r *AccessoryRepository) GetProduct(ctx context.Context, id string) (*application.AccessoryProduct, error) {
+	product, err := scanAccessoryProduct(r.db.QueryRowContext(ctx, accessoryProductSelect+` WHERE id=?`, id))
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, application.ErrAccessoryNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get accessory product: %w", err)
+	}
+	return product, nil
+}
+
+func (r *AccessoryRepository) CreateProduct(
+	ctx context.Context,
+	input application.CreateAccessoryProductInput,
+	actor string,
+) (*application.AccessoryProduct, error) {
+	now := timestamp()
+	product := &application.AccessoryProduct{
+		ID: randomID(), Manufacturer: input.Manufacturer, ArticleNumber: input.ArticleNumber,
+		Name: input.Name, Category: input.Category, TrackingMode: input.TrackingMode,
+		Description: input.Description, CreatedAt: now, UpdatedAt: now,
+	}
+	err := r.withTx(ctx, func(tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx, `
+INSERT INTO accessory_products(
+  id, manufacturer, article_number, name, category, tracking_mode, description, created_at, updated_at
+) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)`, product.ID, product.Manufacturer, product.ArticleNumber,
+			product.Name, product.Category, product.TrackingMode, product.Description, now, now); err != nil {
+			if isSQLiteConstraint(err) {
+				return application.ErrAccessoryConflict
+			}
+			return fmt.Errorf("insert accessory product: %w", err)
+		}
+		return writeAccessoryAudit(ctx, tx, "AccessoryProductCreated", "accessory_product", product.ID, actor, now, "{}")
+	})
+	if err != nil {
+		return nil, err
+	}
+	return product, nil
+}
+
+func (r *AccessoryRepository) UpdateProduct(
+	ctx context.Context,
+	id string,
+	input application.UpdateAccessoryProductInput,
+	actor string,
+) (*application.AccessoryProduct, error) {
+	now := timestamp()
+	err := r.withTx(ctx, func(tx *sql.Tx) error {
+		currentMode, err := accessoryTrackingMode(ctx, tx, id)
+		if err != nil {
+			return err
+		}
+		if currentMode != input.TrackingMode {
+			var dependentCount int
+			query := `SELECT COALESCE(SUM(quantity), 0) FROM accessory_stock WHERE product_id=?`
+			if currentMode == domain.AccessoryTrackingModeIndividual {
+				query = `SELECT COUNT(*) FROM accessory_assets WHERE product_id=?`
+			}
+			if err := tx.QueryRowContext(ctx, query, id).Scan(&dependentCount); err != nil {
+				return fmt.Errorf("check accessory tracking mode change: %w", err)
+			}
+			if dependentCount > 0 {
+				return application.ErrAccessoryConflict
+			}
+		}
+		result, err := tx.ExecContext(ctx, `
+UPDATE accessory_products
+SET manufacturer=?, article_number=?, name=?, category=?, tracking_mode=?, description=?, updated_at=?
+WHERE id=?`, input.Manufacturer, input.ArticleNumber, input.Name, input.Category, input.TrackingMode,
+			input.Description, now, id)
+		if err != nil {
+			if isSQLiteConstraint(err) {
+				return application.ErrAccessoryConflict
+			}
+			return fmt.Errorf("update accessory product: %w", err)
+		}
+		if err := requireAccessoryUpdated(result); err != nil {
+			return err
+		}
+		return writeAccessoryAudit(ctx, tx, "AccessoryProductUpdated", "accessory_product", id, actor, now, "{}")
+	})
+	if err != nil {
+		return nil, err
+	}
+	return r.GetProduct(ctx, id)
+}
+
+func (r *AccessoryRepository) ListLocations(ctx context.Context) ([]application.StorageLocation, error) {
+	rows, err := r.db.QueryContext(ctx, storageLocationSelect+` ORDER BY name COLLATE NOCASE, id`)
+	if err != nil {
+		return nil, fmt.Errorf("list storage locations: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	locations := []application.StorageLocation{}
+	for rows.Next() {
+		location, err := scanStorageLocation(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan storage location: %w", err)
+		}
+		locations = append(locations, *location)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate storage locations: %w", err)
+	}
+	return locations, nil
+}
+
+func (r *AccessoryRepository) CreateLocation(
+	ctx context.Context,
+	input application.CreateStorageLocationInput,
+	actor string,
+) (*application.StorageLocation, error) {
+	now := timestamp()
+	location := &application.StorageLocation{
+		ID: randomID(), ParentID: input.ParentID, Name: input.Name, Description: input.Description,
+		Archived: input.Archived, CreatedAt: now, UpdatedAt: now,
+	}
+	err := r.withTx(ctx, func(tx *sql.Tx) error {
+		if err := requireStorageLocation(ctx, tx, input.ParentID); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, `
+INSERT INTO storage_locations(id, parent_id, name, description, archived, created_at, updated_at)
+VALUES(?, NULLIF(?, ''), ?, ?, ?, ?, ?)`, location.ID, location.ParentID, location.Name,
+			location.Description, boolToInt(location.Archived), now, now); err != nil {
+			if isSQLiteConstraint(err) {
+				return application.ErrAccessoryConflict
+			}
+			return fmt.Errorf("insert storage location: %w", err)
+		}
+		return writeAccessoryAudit(ctx, tx, "StorageLocationCreated", "storage_location", location.ID, actor, now, "{}")
+	})
+	if err != nil {
+		return nil, err
+	}
+	return location, nil
+}
+
+func (r *AccessoryRepository) UpdateLocation(
+	ctx context.Context,
+	id string,
+	input application.UpdateStorageLocationInput,
+	actor string,
+) (*application.StorageLocation, error) {
+	now := timestamp()
+	err := r.withTx(ctx, func(tx *sql.Tx) error {
+		exists, err := accessoryRecordExists(
+			ctx,
+			tx,
+			`SELECT COUNT(*) FROM storage_locations WHERE id=?`,
+			id,
+		)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return application.ErrAccessoryNotFound
+		}
+		if err := requireStorageLocation(ctx, tx, input.ParentID); err != nil {
+			return err
+		}
+		if input.ParentID != "" {
+			var cycleCount int
+			if err := tx.QueryRowContext(ctx, `
+WITH RECURSIVE descendants(id) AS (
+  SELECT id FROM storage_locations WHERE parent_id=?
+  UNION ALL
+  SELECT location.id FROM storage_locations location JOIN descendants ON location.parent_id=descendants.id
+)
+SELECT COUNT(*) FROM descendants WHERE id=?`, id, input.ParentID).Scan(&cycleCount); err != nil {
+				return fmt.Errorf("check storage location cycle: %w", err)
+			}
+			if cycleCount > 0 {
+				return application.ErrAccessoryValidation
+			}
+		}
+		result, err := tx.ExecContext(ctx, `
+UPDATE storage_locations SET parent_id=NULLIF(?, ''), name=?, description=?, archived=?, updated_at=? WHERE id=?`,
+			input.ParentID, input.Name, input.Description, boolToInt(input.Archived), now, id)
+		if err != nil {
+			if isSQLiteConstraint(err) {
+				return application.ErrAccessoryConflict
+			}
+			return fmt.Errorf("update storage location: %w", err)
+		}
+		if err := requireAccessoryUpdated(result); err != nil {
+			return err
+		}
+		return writeAccessoryAudit(ctx, tx, "StorageLocationUpdated", "storage_location", id, actor, now, "{}")
+	})
+	if err != nil {
+		return nil, err
+	}
+	location, err := scanStorageLocation(r.db.QueryRowContext(ctx, storageLocationSelect+` WHERE id=?`, id))
+	if err != nil {
+		return nil, fmt.Errorf("get updated storage location: %w", err)
+	}
+	return location, nil
+}
+
+const accessoryProductSelect = `SELECT id, manufacturer, article_number, name, category, tracking_mode, description, created_at, updated_at FROM accessory_products`
+
+const storageLocationSelect = `SELECT id, COALESCE(parent_id, ''), name, description, archived, created_at, updated_at FROM storage_locations`
+
+func scanAccessoryProduct(scanner rowScanner) (*application.AccessoryProduct, error) {
+	product := &application.AccessoryProduct{}
+	err := scanner.Scan(&product.ID, &product.Manufacturer, &product.ArticleNumber, &product.Name,
+		&product.Category, &product.TrackingMode, &product.Description, &product.CreatedAt, &product.UpdatedAt)
+	return product, err
+}
+
+func scanStorageLocation(scanner rowScanner) (*application.StorageLocation, error) {
+	location := &application.StorageLocation{}
+	var archived int
+	err := scanner.Scan(&location.ID, &location.ParentID, &location.Name, &location.Description,
+		&archived, &location.CreatedAt, &location.UpdatedAt)
+	location.Archived = archived != 0
+	return location, err
+}
+
+func requireStorageLocation(ctx context.Context, tx *sql.Tx, id string) error {
+	if id == "" {
+		return nil
+	}
+	exists, err := accessoryRecordExists(
+		ctx,
+		tx,
+		`SELECT COUNT(*) FROM storage_locations WHERE id=?`,
+		id,
+	)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return application.ErrAccessoryNotFound
+	}
+	return nil
+}
+
+func accessoryRecordExists(ctx context.Context, tx *sql.Tx, query, id string) (bool, error) {
+	var count int
+	if err := tx.QueryRowContext(ctx, query, id).Scan(&count); err != nil {
+		return false, fmt.Errorf("check accessory record: %w", err)
+	}
+	return count > 0, nil
+}
+
+func requireAccessoryUpdated(result sql.Result) error {
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("read accessory update result: %w", err)
+	}
+	if affected == 0 {
+		return application.ErrAccessoryNotFound
+	}
+	return nil
+}
+
+func isSQLiteConstraint(err error) bool {
+	var sqliteErr *sqlite.Error
+	return errors.As(err, &sqliteErr) && sqliteErr.Code()&0xff == sqlite3.SQLITE_CONSTRAINT
+}
+
+func (r *AccessoryRepository) withTx(ctx context.Context, work func(*sql.Tx) error) error {
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin accessory transaction: %w", err)
+	}
+	if err := work(tx); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit accessory transaction: %w", err)
+	}
+	return nil
+}
+
+func writeAccessoryAudit(
+	ctx context.Context,
+	tx *sql.Tx,
+	action, targetType, targetID, actor, createdAt, details string,
+) error {
+	if _, err := tx.ExecContext(ctx, `
+INSERT INTO audit_logs(id, actor_user_id, action, target_type, target_id, created_at, details_json)
+VALUES(?, NULLIF(?, ''), ?, ?, ?, ?, ?)`, randomID(), actor, action, targetType, targetID, createdAt, details); err != nil {
+		return fmt.Errorf("write accessory audit log: %w", err)
+	}
+	return nil
+}
+
+var _ application.AccessoryRepository = (*AccessoryRepository)(nil)

--- a/backend/internal/infrastructure/accessory_repository_test.go
+++ b/backend/internal/infrastructure/accessory_repository_test.go
@@ -1,0 +1,280 @@
+package infrastructure_test
+
+import (
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"railkeeper/backend/internal/application"
+	"railkeeper/backend/internal/domain"
+	"railkeeper/backend/internal/infrastructure"
+)
+
+func TestAccessoryServicePersistsCatalogAndPreventsLocationCycles(t *testing.T) {
+	service, _ := testAccessoryService(t)
+	ctx := t.Context()
+
+	product, err := service.CreateProduct(ctx, application.CreateAccessoryProductInput{
+		Manufacturer: "Tillig", ArticleNumber: "83125", Name: "Weiche rechts", Category: "Gleismaterial",
+		TrackingMode: domain.AccessoryTrackingModeQuantity,
+	}, "editor-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := service.CreateProduct(ctx, application.CreateAccessoryProductInput{
+		Manufacturer: "tillig", ArticleNumber: "83125", Name: "Duplicate", Category: "Track",
+		TrackingMode: domain.AccessoryTrackingModeQuantity,
+	}, "editor-1"); !errors.Is(err, application.ErrAccessoryConflict) {
+		t.Fatalf("expected duplicate product conflict, got %v", err)
+	}
+	for _, name := range []string{"Unnumbered A", "Unnumbered B"} {
+		if _, err := service.CreateProduct(ctx, application.CreateAccessoryProductInput{
+			Manufacturer: "Tillig", Name: name, Category: "Zubehör",
+			TrackingMode: domain.AccessoryTrackingModeQuantity,
+		}, "editor-1"); err != nil {
+			t.Fatalf("blank article numbers must not conflict: %v", err)
+		}
+	}
+	products, err := service.ListProducts(ctx, "83125")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(products) != 1 || products[0].ID != product.ID {
+		t.Fatalf("unexpected product search: %#v", products)
+	}
+	storedProduct, err := service.GetProduct(ctx, product.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if storedProduct.Name != "Weiche rechts" {
+		t.Fatalf("unexpected stored product: %#v", storedProduct)
+	}
+	updatedProduct, err := service.UpdateProduct(ctx, product.ID, application.UpdateAccessoryProductInput{
+		CreateAccessoryProductInput: application.CreateAccessoryProductInput{
+			Manufacturer: "Tillig", ArticleNumber: "83125", Name: "Weiche rechts EW1", Category: "Gleismaterial",
+			TrackingMode: domain.AccessoryTrackingModeQuantity,
+		},
+	}, "editor-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updatedProduct.Name != "Weiche rechts EW1" {
+		t.Fatalf("unexpected updated product: %#v", updatedProduct)
+	}
+
+	root, err := service.CreateLocation(ctx, application.CreateStorageLocationInput{Name: "Werkstatt"}, "editor-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	drawer, err := service.CreateLocation(ctx, application.CreateStorageLocationInput{
+		ParentID: root.ID, Name: "Schrank A",
+	}, "editor-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	box, err := service.CreateLocation(ctx, application.CreateStorageLocationInput{
+		ParentID: drawer.ID, Name: "Schublade 1",
+	}, "editor-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := service.UpdateLocation(ctx, root.ID, application.UpdateStorageLocationInput{
+		CreateStorageLocationInput: application.CreateStorageLocationInput{ParentID: box.ID, Name: root.Name},
+	}, "editor-1"); !errors.Is(err, application.ErrAccessoryValidation) {
+		t.Fatalf("expected descendant-parent cycle rejection, got %v", err)
+	}
+	if _, err := service.CreateLocation(ctx, application.CreateStorageLocationInput{
+		ParentID: "missing", Name: "Orphan",
+	}, "editor-1"); !errors.Is(err, application.ErrAccessoryNotFound) {
+		t.Fatalf("expected missing parent error, got %v", err)
+	}
+	updatedDrawer, err := service.UpdateLocation(ctx, drawer.ID, application.UpdateStorageLocationInput{
+		CreateStorageLocationInput: application.CreateStorageLocationInput{Name: "Schrank B"},
+	}, "editor-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updatedDrawer.ParentID != "" || updatedDrawer.Name != "Schrank B" {
+		t.Fatalf("unexpected updated location: %#v", updatedDrawer)
+	}
+	locations, err := service.ListLocations(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(locations) != 3 {
+		t.Fatalf("unexpected locations: %#v", locations)
+	}
+}
+
+func TestAccessoryServiceSeparatesQuantityAndIndividualInventory(t *testing.T) {
+	service, _ := testAccessoryService(t)
+	ctx := t.Context()
+	location, err := service.CreateLocation(ctx, application.CreateStorageLocationInput{Name: "Lager"}, "editor-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	quantityProduct, err := service.CreateProduct(ctx, application.CreateAccessoryProductInput{
+		Manufacturer: "Tillig", ArticleNumber: "83501", Name: "Schienenverbinder", Category: "Gleismaterial",
+		TrackingMode: domain.AccessoryTrackingModeQuantity,
+	}, "editor-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	individualProduct, err := service.CreateProduct(ctx, application.CreateAccessoryProductInput{
+		Manufacturer: "Lenz", ArticleNumber: "LS150", Name: "Schaltdecoder", Category: "Decoder",
+		TrackingMode: domain.AccessoryTrackingModeIndividual,
+	}, "editor-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stock, err := service.AdjustStock(ctx, quantityProduct.ID, application.StockAdjustmentInput{
+		LocationID: location.ID, Delta: 5,
+	}, "editor-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	stock, err = service.AdjustStock(ctx, quantityProduct.ID, application.StockAdjustmentInput{
+		LocationID: location.ID, Delta: -2,
+	}, "editor-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stock.TotalQuantity != 3 || len(stock.Locations) != 1 || stock.Locations[0].Quantity != 3 {
+		t.Fatalf("unexpected stock summary: %#v", stock)
+	}
+	if _, err := service.UpdateProduct(ctx, quantityProduct.ID, application.UpdateAccessoryProductInput{
+		CreateAccessoryProductInput: application.CreateAccessoryProductInput{
+			Manufacturer: quantityProduct.Manufacturer, ArticleNumber: quantityProduct.ArticleNumber,
+			Name: quantityProduct.Name, Category: quantityProduct.Category,
+			TrackingMode: domain.AccessoryTrackingModeIndividual,
+		},
+	}, "editor-1"); !errors.Is(err, application.ErrAccessoryConflict) {
+		t.Fatalf("expected tracking mode conflict for stocked product, got %v", err)
+	}
+	if _, err := service.AdjustStock(ctx, quantityProduct.ID, application.StockAdjustmentInput{
+		LocationID: location.ID, Delta: -4,
+	}, "editor-1"); !errors.Is(err, application.ErrAccessoryInsufficientStock) {
+		t.Fatalf("expected insufficient stock error, got %v", err)
+	}
+	if _, err := service.AdjustStock(ctx, individualProduct.ID, application.StockAdjustmentInput{
+		LocationID: location.ID, Delta: 1,
+	}, "editor-1"); !errors.Is(err, application.ErrAccessoryTrackingMode) {
+		t.Fatalf("expected individual stock tracking rejection, got %v", err)
+	}
+	if _, err := service.CreateAsset(ctx, quantityProduct.ID, application.CreateAccessoryAssetInput{
+		InventoryNumber: "Z-0001",
+	}, "editor-1"); !errors.Is(err, application.ErrAccessoryTrackingMode) {
+		t.Fatalf("expected quantity asset rejection, got %v", err)
+	}
+
+	asset, err := service.CreateAsset(ctx, individualProduct.ID, application.CreateAccessoryAssetInput{
+		InventoryNumber: "Z-0001", SerialNumber: "ABC", StorageLocationID: location.ID,
+		Condition: domain.AccessoryConditionReady, Lifecycle: domain.AccessoryLifecycleStored,
+		PurchasePrice: "49.95",
+	}, "editor-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := service.CreateAsset(ctx, individualProduct.ID, application.CreateAccessoryAssetInput{
+		InventoryNumber: "z-0001",
+	}, "editor-1"); !errors.Is(err, application.ErrAccessoryConflict) {
+		t.Fatalf("expected inventory number conflict, got %v", err)
+	}
+	if _, err := service.UpdateProduct(ctx, individualProduct.ID, application.UpdateAccessoryProductInput{
+		CreateAccessoryProductInput: application.CreateAccessoryProductInput{
+			Manufacturer: individualProduct.Manufacturer, ArticleNumber: individualProduct.ArticleNumber,
+			Name: individualProduct.Name, Category: individualProduct.Category,
+			TrackingMode: domain.AccessoryTrackingModeQuantity,
+		},
+	}, "editor-1"); !errors.Is(err, application.ErrAccessoryConflict) {
+		t.Fatalf("expected tracking mode conflict for product with assets, got %v", err)
+	}
+	asset, err = service.UpdateAsset(ctx, asset.ID, application.UpdateAccessoryAssetInput{
+		CreateAccessoryAssetInput: application.CreateAccessoryAssetInput{
+			InventoryNumber: asset.InventoryNumber, SerialNumber: asset.SerialNumber,
+			Condition: domain.AccessoryConditionMaintenanceDue, Lifecycle: domain.AccessoryLifecycleMaintenance,
+			StorageLocationID: location.ID, PurchasePrice: asset.PurchasePrice,
+		},
+	}, "editor-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if asset.Condition != domain.AccessoryConditionMaintenanceDue ||
+		asset.Lifecycle != domain.AccessoryLifecycleMaintenance {
+		t.Fatalf("unexpected updated asset: %#v", asset)
+	}
+	assets, err := service.ListAssets(ctx, individualProduct.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(assets) != 1 || assets[0].ID != asset.ID {
+		t.Fatalf("unexpected assets: %#v", assets)
+	}
+}
+
+func TestAccessoryServiceWritesMinimalAuditDetails(t *testing.T) {
+	service, db := testAccessoryService(t)
+	ctx := t.Context()
+	location, err := service.CreateLocation(ctx, application.CreateStorageLocationInput{Name: "Audit Lager"}, "editor-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	product, err := service.CreateProduct(ctx, application.CreateAccessoryProductInput{
+		Manufacturer: "Tillig", Name: "Audit product", Category: "Track",
+		TrackingMode: domain.AccessoryTrackingModeIndividual,
+	}, "editor-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	asset, err := service.CreateAsset(ctx, product.ID, application.CreateAccessoryAssetInput{
+		InventoryNumber: "AUDIT-1", StorageLocationID: location.ID, Notes: "private workshop note",
+	}, "editor-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := service.UpdateAsset(ctx, asset.ID, application.UpdateAccessoryAssetInput{
+		CreateAccessoryAssetInput: application.CreateAccessoryAssetInput{
+			InventoryNumber: asset.InventoryNumber, StorageLocationID: location.ID,
+			Condition: domain.AccessoryConditionDefective, Lifecycle: domain.AccessoryLifecycleMaintenance,
+			Notes: "another private note",
+		},
+	}, "editor-1"); err != nil {
+		t.Fatal(err)
+	}
+
+	rows, err := db.QueryContext(ctx, `SELECT action, COALESCE(details_json, '{}') FROM audit_logs ORDER BY rowid`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = rows.Close() }()
+	count := 0
+	for rows.Next() {
+		var action, details string
+		if err := rows.Scan(&action, &details); err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(details, "private") {
+			t.Fatalf("audit action %s leaked free-text notes: %s", action, details)
+		}
+		count++
+	}
+	if count != 4 {
+		t.Fatalf("expected 4 audit entries, got %d", count)
+	}
+}
+
+func testAccessoryService(t *testing.T) (*application.AccessoryService, *sql.DB) {
+	t.Helper()
+	db, err := infrastructure.OpenSQLite(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := infrastructure.Migrate(db, filepath.Join("..", "..", "migrations")); err != nil {
+		t.Fatal(err)
+	}
+	return application.NewAccessoryService(infrastructure.NewAccessoryRepository(db)), db
+}

--- a/backend/internal/infrastructure/accessory_repository_test.go
+++ b/backend/internal/infrastructure/accessory_repository_test.go
@@ -130,13 +130,13 @@ func TestAccessoryServiceSeparatesQuantityAndIndividualInventory(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	stock, err := service.AdjustStock(ctx, quantityProduct.ID, application.StockAdjustmentInput{
+	_, err = service.AdjustStock(ctx, quantityProduct.ID, application.StockAdjustmentInput{
 		LocationID: location.ID, Delta: 5,
 	}, "editor-1")
 	if err != nil {
 		t.Fatal(err)
 	}
-	stock, err = service.AdjustStock(ctx, quantityProduct.ID, application.StockAdjustmentInput{
+	stock, err := service.AdjustStock(ctx, quantityProduct.ID, application.StockAdjustmentInput{
 		LocationID: location.ID, Delta: -2,
 	}, "editor-1")
 	if err != nil {


### PR DESCRIPTION
## Deutsch

Setzt die SQLite-Persistenz für den Zubehörkatalog und den Zubehörbestand aus Stage 1.3 um.

### Enthalten

- Zubehörprodukte suchen, lesen, anlegen und bearbeiten
- Mengenbestand je Lagerort mit atomaren Zu- und Abbuchungen
- Schutz vor negativem Bestand
- Einzelinventar mit Inventarnummer, Zustand, Lebenszyklus, Lagerort und Kaufdaten
- hierarchische Lagerorte mit Schutz vor Eltern-Kind-Zyklen
- eindeutige Artikel- und Inventarnummern gemäß Schema
- sicherer Wechsel des Erfassungsmodus nur ohne abhängige Bestände oder Einzelobjekte
- datensparsame Audit-Einträge ohne Freitextnotizen

### Verifikation

- `go test ./...`
- `go vet ./...`
- `git diff --cached --check`

## English

Implements SQLite persistence for the accessory catalogue and inventory in Stage 1.3.

### Included

- search, read, create, and update accessory products
- quantity stock per storage location with atomic adjustments
- negative-stock protection
- individually tracked assets with inventory number, condition, lifecycle, location, and purchase data
- hierarchical storage locations with parent-child cycle prevention
- unique article and inventory numbers according to the schema
- safe tracking-mode changes only when no dependent stock or assets exist
- privacy-conscious audit records without free-text notes

### Verification

- `go test ./...`
- `go vet ./...`
- `git diff --cached --check`

Refs #40