### PR TITLE
feat(accessories): define allocation lifecycle

### DIFF
--- a/backend/internal/application/accessory_allocations.go
+++ b/backend/internal/application/accessory_allocations.go
@@ -126,7 +126,7 @@ func (s *AccessoryAllocationService) CreateReservation(
 ) (*AccessoryReservation, error) {
 	input = cleanReservationInput(input)
 	if input.ProductID == "" || input.LocationID == "" || input.Quantity <= 0 ||
-		!input.AllocationTargetInput.valid() || (input.AssetID != "" && input.Quantity != 1) {
+		!input.valid() || (input.AssetID != "" && input.Quantity != 1) {
 		return nil, ErrAccessoryValidation
 	}
 	return s.repository.CreateReservation(ctx, input, actor)
@@ -161,7 +161,7 @@ func (s *AccessoryAllocationService) Install(
 		input.Condition = domain.AccessoryConditionUnknown
 	}
 	if input.ProductID == "" || input.SourceLocationID == "" || input.Quantity <= 0 ||
-		!input.AllocationTargetInput.valid() || !input.Condition.Valid() ||
+		!input.valid() || !input.Condition.Valid() ||
 		(input.AssetID != "" && input.Quantity != 1) {
 		return nil, ErrAccessoryValidation
 	}
@@ -212,7 +212,7 @@ func cleanReservationInput(input CreateAccessoryReservationInput) CreateAccessor
 	input.ProductID = strings.TrimSpace(input.ProductID)
 	input.AssetID = strings.TrimSpace(input.AssetID)
 	input.LocationID = strings.TrimSpace(input.LocationID)
-	input.AllocationTargetInput = input.AllocationTargetInput.clean()
+	input.AllocationTargetInput = input.clean()
 	input.Note = strings.TrimSpace(input.Note)
 	return input
 }
@@ -222,7 +222,7 @@ func cleanInstallationInput(input CreateAccessoryInstallationInput) CreateAccess
 	input.ProductID = strings.TrimSpace(input.ProductID)
 	input.AssetID = strings.TrimSpace(input.AssetID)
 	input.SourceLocationID = strings.TrimSpace(input.SourceLocationID)
-	input.AllocationTargetInput = input.AllocationTargetInput.clean()
+	input.AllocationTargetInput = input.clean()
 	input.Notes = strings.TrimSpace(input.Notes)
 	return input
 }

--- a/backend/internal/application/accessory_allocations.go
+++ b/backend/internal/application/accessory_allocations.go
@@ -1,0 +1,245 @@
+package application
+
+import (
+	"context"
+	"strings"
+
+	"railkeeper/backend/internal/domain"
+)
+
+type AllocationTargetInput struct {
+	VehicleID    string `json:"vehicleId,omitempty"`
+	LayoutID     string `json:"layoutId,omitempty"`
+	LayoutUnitID string `json:"layoutUnitId,omitempty"`
+}
+
+type AccessoryReservation struct {
+	ID         string `json:"id"`
+	ProductID  string `json:"productId"`
+	AssetID    string `json:"assetId,omitempty"`
+	LocationID string `json:"locationId"`
+	Quantity   int    `json:"quantity"`
+	AllocationTargetInput
+	Status    domain.AccessoryReservationStatus `json:"status"`
+	Note      string                            `json:"note,omitempty"`
+	CreatedBy string                            `json:"createdBy"`
+	CreatedAt string                            `json:"createdAt"`
+	UpdatedAt string                            `json:"updatedAt"`
+}
+
+type CreateAccessoryReservationInput struct {
+	ProductID  string `json:"productId"`
+	AssetID    string `json:"assetId,omitempty"`
+	LocationID string `json:"locationId"`
+	Quantity   int    `json:"quantity"`
+	AllocationTargetInput
+	Note string `json:"note,omitempty"`
+}
+
+type AccessoryInstallation struct {
+	ID               string `json:"id"`
+	ProductID        string `json:"productId"`
+	AssetID          string `json:"assetId,omitempty"`
+	SourceLocationID string `json:"sourceLocationId"`
+	Quantity         int    `json:"quantity"`
+	AllocationTargetInput
+	Condition          domain.AccessoryCondition          `json:"condition"`
+	InstalledBy        string                             `json:"installedBy"`
+	InstalledAt        string                             `json:"installedAt"`
+	RemovedBy          string                             `json:"removedBy,omitempty"`
+	RemovedAt          string                             `json:"removedAt,omitempty"`
+	RemovalDisposition domain.AccessoryRemovalDisposition `json:"removalDisposition,omitempty"`
+	Notes              string                             `json:"notes,omitempty"`
+}
+
+type CreateAccessoryInstallationInput struct {
+	ReservationID    string `json:"reservationId,omitempty"`
+	ProductID        string `json:"productId"`
+	AssetID          string `json:"assetId,omitempty"`
+	SourceLocationID string `json:"sourceLocationId"`
+	Quantity         int    `json:"quantity"`
+	AllocationTargetInput
+	Condition domain.AccessoryCondition `json:"condition"`
+	Notes     string                    `json:"notes,omitempty"`
+}
+
+type RemoveAccessoryInstallationInput struct {
+	Disposition       domain.AccessoryRemovalDisposition `json:"disposition"`
+	StorageLocationID string                             `json:"storageLocationId,omitempty"`
+	Notes             string                             `json:"notes,omitempty"`
+}
+
+type UpdateAccessoryInstallationConditionInput struct {
+	Condition domain.AccessoryCondition `json:"condition"`
+}
+
+type AccessoryAllocationSummary struct {
+	ProductID string `json:"productId"`
+	Owned     int    `json:"owned"`
+	Stored    int    `json:"stored"`
+	Reserved  int    `json:"reserved"`
+	Installed int    `json:"installed"`
+	Available int    `json:"available"`
+	Missing   int    `json:"missing"`
+}
+
+type AccessoryAllocationRepository interface {
+	ListReservations(context.Context, string) ([]AccessoryReservation, error)
+	CreateReservation(context.Context, CreateAccessoryReservationInput, string) (*AccessoryReservation, error)
+	CancelReservation(context.Context, string, string) (*AccessoryReservation, error)
+	ListInstallations(context.Context, string) ([]AccessoryInstallation, error)
+	Install(context.Context, CreateAccessoryInstallationInput, string) (*AccessoryInstallation, error)
+	RemoveInstallation(
+		context.Context,
+		string,
+		RemoveAccessoryInstallationInput,
+		string,
+	) (*AccessoryInstallation, error)
+	UpdateInstallationCondition(
+		context.Context,
+		string,
+		UpdateAccessoryInstallationConditionInput,
+		string,
+	) (*AccessoryInstallation, error)
+	GetAllocationSummary(context.Context, string) (*AccessoryAllocationSummary, error)
+}
+
+type AccessoryAllocationService struct {
+	repository AccessoryAllocationRepository
+}
+
+func NewAccessoryAllocationService(repository AccessoryAllocationRepository) *AccessoryAllocationService {
+	return &AccessoryAllocationService{repository: repository}
+}
+
+func (s *AccessoryAllocationService) ListReservations(
+	ctx context.Context,
+	productID string,
+) ([]AccessoryReservation, error) {
+	return s.repository.ListReservations(ctx, strings.TrimSpace(productID))
+}
+
+func (s *AccessoryAllocationService) CreateReservation(
+	ctx context.Context,
+	input CreateAccessoryReservationInput,
+	actor string,
+) (*AccessoryReservation, error) {
+	input = cleanReservationInput(input)
+	if input.ProductID == "" || input.LocationID == "" || input.Quantity <= 0 ||
+		!input.AllocationTargetInput.valid() || (input.AssetID != "" && input.Quantity != 1) {
+		return nil, ErrAccessoryValidation
+	}
+	return s.repository.CreateReservation(ctx, input, actor)
+}
+
+func (s *AccessoryAllocationService) CancelReservation(
+	ctx context.Context,
+	id string,
+	actor string,
+) (*AccessoryReservation, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return nil, ErrAccessoryValidation
+	}
+	return s.repository.CancelReservation(ctx, id, actor)
+}
+
+func (s *AccessoryAllocationService) ListInstallations(
+	ctx context.Context,
+	productID string,
+) ([]AccessoryInstallation, error) {
+	return s.repository.ListInstallations(ctx, strings.TrimSpace(productID))
+}
+
+func (s *AccessoryAllocationService) Install(
+	ctx context.Context,
+	input CreateAccessoryInstallationInput,
+	actor string,
+) (*AccessoryInstallation, error) {
+	input = cleanInstallationInput(input)
+	if input.Condition == "" {
+		input.Condition = domain.AccessoryConditionUnknown
+	}
+	if input.ProductID == "" || input.SourceLocationID == "" || input.Quantity <= 0 ||
+		!input.AllocationTargetInput.valid() || !input.Condition.Valid() ||
+		(input.AssetID != "" && input.Quantity != 1) {
+		return nil, ErrAccessoryValidation
+	}
+	return s.repository.Install(ctx, input, actor)
+}
+
+func (s *AccessoryAllocationService) RemoveInstallation(
+	ctx context.Context,
+	id string,
+	input RemoveAccessoryInstallationInput,
+	actor string,
+) (*AccessoryInstallation, error) {
+	id = strings.TrimSpace(id)
+	input.StorageLocationID = strings.TrimSpace(input.StorageLocationID)
+	input.Notes = strings.TrimSpace(input.Notes)
+	stored := input.Disposition == domain.AccessoryRemovalStored
+	if id == "" || !input.Disposition.Valid() || stored != (input.StorageLocationID != "") {
+		return nil, ErrAccessoryValidation
+	}
+	return s.repository.RemoveInstallation(ctx, id, input, actor)
+}
+
+func (s *AccessoryAllocationService) UpdateInstallationCondition(
+	ctx context.Context,
+	id string,
+	input UpdateAccessoryInstallationConditionInput,
+	actor string,
+) (*AccessoryInstallation, error) {
+	id = strings.TrimSpace(id)
+	if id == "" || !input.Condition.Valid() {
+		return nil, ErrAccessoryValidation
+	}
+	return s.repository.UpdateInstallationCondition(ctx, id, input, actor)
+}
+
+func (s *AccessoryAllocationService) GetAllocationSummary(
+	ctx context.Context,
+	productID string,
+) (*AccessoryAllocationSummary, error) {
+	productID = strings.TrimSpace(productID)
+	if productID == "" {
+		return nil, ErrAccessoryValidation
+	}
+	return s.repository.GetAllocationSummary(ctx, productID)
+}
+
+func cleanReservationInput(input CreateAccessoryReservationInput) CreateAccessoryReservationInput {
+	input.ProductID = strings.TrimSpace(input.ProductID)
+	input.AssetID = strings.TrimSpace(input.AssetID)
+	input.LocationID = strings.TrimSpace(input.LocationID)
+	input.AllocationTargetInput = input.AllocationTargetInput.clean()
+	input.Note = strings.TrimSpace(input.Note)
+	return input
+}
+
+func cleanInstallationInput(input CreateAccessoryInstallationInput) CreateAccessoryInstallationInput {
+	input.ReservationID = strings.TrimSpace(input.ReservationID)
+	input.ProductID = strings.TrimSpace(input.ProductID)
+	input.AssetID = strings.TrimSpace(input.AssetID)
+	input.SourceLocationID = strings.TrimSpace(input.SourceLocationID)
+	input.AllocationTargetInput = input.AllocationTargetInput.clean()
+	input.Notes = strings.TrimSpace(input.Notes)
+	return input
+}
+
+func (target AllocationTargetInput) clean() AllocationTargetInput {
+	target.VehicleID = strings.TrimSpace(target.VehicleID)
+	target.LayoutID = strings.TrimSpace(target.LayoutID)
+	target.LayoutUnitID = strings.TrimSpace(target.LayoutUnitID)
+	return target
+}
+
+func (target AllocationTargetInput) valid() bool {
+	count := 0
+	for _, id := range []string{target.VehicleID, target.LayoutID, target.LayoutUnitID} {
+		if id != "" {
+			count++
+		}
+	}
+	return count == 1
+}

--- a/backend/internal/application/accessory_allocations_test.go
+++ b/backend/internal/application/accessory_allocations_test.go
@@ -1,0 +1,215 @@
+package application
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"railkeeper/backend/internal/domain"
+)
+
+type accessoryAllocationRepositorySpy struct {
+	createdReservation   CreateAccessoryReservationInput
+	cancelledReservation string
+	installed            CreateAccessoryInstallationInput
+	removedID            string
+	removed              RemoveAccessoryInstallationInput
+	conditionID          string
+	condition            UpdateAccessoryInstallationConditionInput
+}
+
+func (s *accessoryAllocationRepositorySpy) ListReservations(
+	context.Context,
+	string,
+) ([]AccessoryReservation, error) {
+	return []AccessoryReservation{}, nil
+}
+
+func (s *accessoryAllocationRepositorySpy) CreateReservation(
+	_ context.Context,
+	input CreateAccessoryReservationInput,
+	_ string,
+) (*AccessoryReservation, error) {
+	s.createdReservation = input
+	return &AccessoryReservation{ProductID: input.ProductID, Quantity: input.Quantity}, nil
+}
+
+func (s *accessoryAllocationRepositorySpy) CancelReservation(
+	_ context.Context,
+	id string,
+	_ string,
+) (*AccessoryReservation, error) {
+	s.cancelledReservation = id
+	return &AccessoryReservation{ID: id}, nil
+}
+
+func (s *accessoryAllocationRepositorySpy) ListInstallations(
+	context.Context,
+	string,
+) ([]AccessoryInstallation, error) {
+	return []AccessoryInstallation{}, nil
+}
+
+func (s *accessoryAllocationRepositorySpy) Install(
+	_ context.Context,
+	input CreateAccessoryInstallationInput,
+	_ string,
+) (*AccessoryInstallation, error) {
+	s.installed = input
+	return &AccessoryInstallation{ProductID: input.ProductID, Condition: input.Condition}, nil
+}
+
+func (s *accessoryAllocationRepositorySpy) RemoveInstallation(
+	_ context.Context,
+	id string,
+	input RemoveAccessoryInstallationInput,
+	_ string,
+) (*AccessoryInstallation, error) {
+	s.removedID = id
+	s.removed = input
+	return &AccessoryInstallation{ID: id, RemovalDisposition: input.Disposition}, nil
+}
+
+func (s *accessoryAllocationRepositorySpy) UpdateInstallationCondition(
+	_ context.Context,
+	id string,
+	input UpdateAccessoryInstallationConditionInput,
+	_ string,
+) (*AccessoryInstallation, error) {
+	s.conditionID = id
+	s.condition = input
+	return &AccessoryInstallation{ID: id, Condition: input.Condition}, nil
+}
+
+func (s *accessoryAllocationRepositorySpy) GetAllocationSummary(
+	context.Context,
+	string,
+) (*AccessoryAllocationSummary, error) {
+	return &AccessoryAllocationSummary{}, nil
+}
+
+func TestAccessoryAllocationServiceRequiresExactlyOneTarget(t *testing.T) {
+	service := NewAccessoryAllocationService(&accessoryAllocationRepositorySpy{})
+	validTargets := []AllocationTargetInput{
+		{VehicleID: "vehicle-1"},
+		{LayoutID: "layout-1"},
+		{LayoutUnitID: "unit-1"},
+	}
+	for _, target := range validTargets {
+		if _, err := service.CreateReservation(t.Context(), CreateAccessoryReservationInput{
+			ProductID: "product-1", LocationID: "location-1", Quantity: 1, AllocationTargetInput: target,
+		}, "planner-1"); err != nil {
+			t.Fatalf("valid target %#v rejected: %v", target, err)
+		}
+	}
+	invalidTargets := []AllocationTargetInput{
+		{},
+		{VehicleID: "vehicle-1", LayoutID: "layout-1"},
+		{LayoutID: "layout-1", LayoutUnitID: "unit-1"},
+	}
+	for _, target := range invalidTargets {
+		if _, err := service.CreateReservation(t.Context(), CreateAccessoryReservationInput{
+			ProductID: "product-1", LocationID: "location-1", Quantity: 1, AllocationTargetInput: target,
+		}, "planner-1"); !errors.Is(err, ErrAccessoryValidation) {
+			t.Fatalf("target %#v: expected validation error, got %v", target, err)
+		}
+	}
+}
+
+func TestAccessoryAllocationServiceNormalizesReservationAndInstallation(t *testing.T) {
+	repository := &accessoryAllocationRepositorySpy{}
+	service := NewAccessoryAllocationService(repository)
+
+	if _, err := service.CreateReservation(t.Context(), CreateAccessoryReservationInput{
+		ProductID: " product-1 ", AssetID: " asset-1 ", LocationID: " location-1 ", Quantity: 1,
+		AllocationTargetInput: AllocationTargetInput{LayoutUnitID: " unit-1 "}, Note: " planned ",
+	}, "planner-1"); err != nil {
+		t.Fatal(err)
+	}
+	reservation := repository.createdReservation
+	if reservation.ProductID != "product-1" || reservation.AssetID != "asset-1" ||
+		reservation.LocationID != "location-1" || reservation.LayoutUnitID != "unit-1" ||
+		reservation.Note != "planned" {
+		t.Fatalf("reservation was not normalized: %#v", reservation)
+	}
+
+	installation, err := service.Install(t.Context(), CreateAccessoryInstallationInput{
+		ReservationID: " reservation-1 ", ProductID: " product-1 ", SourceLocationID: " location-1 ",
+		Quantity: 2, AllocationTargetInput: AllocationTargetInput{LayoutID: " layout-1 "}, Notes: " installed ",
+	}, "editor-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if installation.Condition != domain.AccessoryConditionUnknown ||
+		repository.installed.ReservationID != "reservation-1" || repository.installed.LayoutID != "layout-1" ||
+		repository.installed.Notes != "installed" {
+		t.Fatalf("installation was not normalized and defaulted: %#v", repository.installed)
+	}
+}
+
+func TestAccessoryAllocationServiceRejectsInvalidQuantitiesAndIdentifiers(t *testing.T) {
+	service := NewAccessoryAllocationService(&accessoryAllocationRepositorySpy{})
+	validTarget := AllocationTargetInput{LayoutID: "layout-1"}
+	reservations := []CreateAccessoryReservationInput{
+		{LocationID: "location-1", Quantity: 1, AllocationTargetInput: validTarget},
+		{ProductID: "product-1", Quantity: 1, AllocationTargetInput: validTarget},
+		{ProductID: "product-1", LocationID: "location-1", Quantity: 0, AllocationTargetInput: validTarget},
+		{ProductID: "product-1", AssetID: "asset-1", LocationID: "location-1", Quantity: 2,
+			AllocationTargetInput: validTarget},
+	}
+	for _, input := range reservations {
+		if _, err := service.CreateReservation(t.Context(), input, "planner-1"); !errors.Is(err, ErrAccessoryValidation) {
+			t.Fatalf("reservation %#v: expected validation error, got %v", input, err)
+		}
+	}
+	if _, err := service.CancelReservation(t.Context(), " ", "planner-1"); !errors.Is(err, ErrAccessoryValidation) {
+		t.Fatalf("expected empty cancellation id to fail, got %v", err)
+	}
+	if _, err := service.Install(t.Context(), CreateAccessoryInstallationInput{
+		ProductID: "product-1", AssetID: "asset-1", SourceLocationID: "location-1", Quantity: 2,
+		AllocationTargetInput: validTarget,
+	}, "editor-1"); !errors.Is(err, ErrAccessoryValidation) {
+		t.Fatalf("expected individual quantity to fail, got %v", err)
+	}
+	if _, err := service.GetAllocationSummary(t.Context(), " "); !errors.Is(err, ErrAccessoryValidation) {
+		t.Fatalf("expected empty summary product id to fail, got %v", err)
+	}
+}
+
+func TestAccessoryAllocationServiceValidatesRemovalAndConditionChanges(t *testing.T) {
+	repository := &accessoryAllocationRepositorySpy{}
+	service := NewAccessoryAllocationService(repository)
+
+	if _, err := service.RemoveInstallation(t.Context(), " installation-1 ", RemoveAccessoryInstallationInput{
+		Disposition: domain.AccessoryRemovalStored, StorageLocationID: " location-1 ", Notes: " returned ",
+	}, "editor-1"); err != nil {
+		t.Fatal(err)
+	}
+	if repository.removedID != "installation-1" || repository.removed.StorageLocationID != "location-1" ||
+		repository.removed.Notes != "returned" {
+		t.Fatalf("removal was not normalized: %#v", repository.removed)
+	}
+	invalidRemovals := []RemoveAccessoryInstallationInput{
+		{},
+		{Disposition: "sold"},
+		{Disposition: domain.AccessoryRemovalStored},
+		{Disposition: domain.AccessoryRemovalRetired, StorageLocationID: "location-1"},
+	}
+	for _, input := range invalidRemovals {
+		if _, err := service.RemoveInstallation(t.Context(), "installation-1", input, "editor-1"); !errors.Is(err, ErrAccessoryValidation) {
+			t.Fatalf("removal %#v: expected validation error, got %v", input, err)
+		}
+	}
+	if _, err := service.UpdateInstallationCondition(t.Context(), "installation-1",
+		UpdateAccessoryInstallationConditionInput{Condition: domain.AccessoryConditionDefective}, "editor-1"); err != nil {
+		t.Fatal(err)
+	}
+	if repository.conditionID != "installation-1" ||
+		repository.condition.Condition != domain.AccessoryConditionDefective {
+		t.Fatalf("condition was not passed through: %#v", repository.condition)
+	}
+	if _, err := service.UpdateInstallationCondition(t.Context(), "installation-1",
+		UpdateAccessoryInstallationConditionInput{Condition: "broken"}, "editor-1"); !errors.Is(err, ErrAccessoryValidation) {
+		t.Fatalf("expected invalid condition to fail, got %v", err)
+	}
+}

--- a/backend/internal/domain/accessory.go
+++ b/backend/internal/domain/accessory.go
@@ -74,6 +74,25 @@ func (status AccessoryReservationStatus) Valid() bool {
 	}
 }
 
+type AccessoryRemovalDisposition string
+
+const (
+	AccessoryRemovalStored      AccessoryRemovalDisposition = "stored"
+	AccessoryRemovalMaintenance AccessoryRemovalDisposition = "maintenance"
+	AccessoryRemovalDefective   AccessoryRemovalDisposition = "defective"
+	AccessoryRemovalRetired     AccessoryRemovalDisposition = "retired"
+)
+
+func (disposition AccessoryRemovalDisposition) Valid() bool {
+	switch disposition {
+	case AccessoryRemovalStored, AccessoryRemovalMaintenance, AccessoryRemovalDefective,
+		AccessoryRemovalRetired:
+		return true
+	default:
+		return false
+	}
+}
+
 type AllocationTarget struct {
 	VehicleID    string
 	LayoutID     string

--- a/backend/internal/domain/accessory_test.go
+++ b/backend/internal/domain/accessory_test.go
@@ -30,6 +30,11 @@ func TestAccessoryEnumsAcceptOnlyDefinedValues(t *testing.T) {
 		{"reservation fulfilled", domain.AccessoryReservationFulfilled.Valid(), true},
 		{"reservation cancelled", domain.AccessoryReservationCancelled.Valid(), true},
 		{"reservation invalid", domain.AccessoryReservationStatus("closed").Valid(), false},
+		{"removal stored", domain.AccessoryRemovalStored.Valid(), true},
+		{"removal maintenance", domain.AccessoryRemovalMaintenance.Valid(), true},
+		{"removal defective", domain.AccessoryRemovalDefective.Valid(), true},
+		{"removal retired", domain.AccessoryRemovalRetired.Valid(), true},
+		{"removal invalid", domain.AccessoryRemovalDisposition("sold").Valid(), false},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Deutsch

Legt den Application-Vertrag und die Zustandsmodelle für Reservierungen, Einbau und Ausbau aus Stage 1.4 fest.

### Enthalten

- eigenständiger, schmaler Repository-Vertrag für Zubehörzuordnungen
- Reservierungsmodell mit Produkt, optionalem Einzelobjekt, Lagerort, Menge, Ziel und Status
- Installationshistorie mit Zustand, Akteuren, Zeitpunkten und Ausbauentscheidung
- genau ein Ziel aus Fahrzeug, Anlage oder Anlageneinheit
- Ausbauentscheidungen: Lager, Wartung, Defekt oder Ausmusterung
- Kennzahlenmodell für vorhanden, gelagert, reserviert, eingebaut, verfügbar und fehlend
- Normalisierung und Validierung aller öffentlichen Eingaben
- Tests für Zielkonflikte, Mengenregeln, Standardwerte und Zustandsänderungen

Die transaktionale SQLite-Umsetzung und HTTP-Routen folgen in getrennten, reviewbaren PRs.

### Verifikation

- `go test ./...`
- `go vet ./...`
- `git diff --cached --check`

## English

Defines the application contract and state models for reservations, installation, and removal in Stage 1.4.

### Included

- a focused repository contract for accessory allocations
- reservation model with product, optional asset, storage location, quantity, target, and status
- installation history with condition, actors, timestamps, and removal disposition
- exactly one target among vehicle, layout, or layout unit
- removal dispositions: stored, maintenance, defective, or retired
- summary model for owned, stored, reserved, installed, available, and missing
- normalization and validation for all public inputs
- tests for target conflicts, quantity rules, defaults, and state changes

Transactional SQLite behavior and HTTP routes follow in separate reviewable pull requests.

### Verification

- `go test ./...`
- `go vet ./...`
- `git diff --cached --check`

Refs #39