### PR TITLE
feat(accessories): persist allocation lifecycle

### DIFF
--- a/backend/internal/application/accessories_test.go
+++ b/backend/internal/application/accessories_test.go
@@ -193,6 +193,16 @@ func TestAccessoryServiceDefaultsAndValidatesAssetState(t *testing.T) {
 	}, "editor-1"); !errors.Is(err, ErrAccessoryValidation) {
 		t.Fatalf("expected asset state validation error, got %v", err)
 	}
+	for _, lifecycle := range []domain.AccessoryLifecycle{
+		domain.AccessoryLifecycleReserved,
+		domain.AccessoryLifecycleInstalled,
+	} {
+		if _, err := service.CreateAsset(t.Context(), "product-1", CreateAccessoryAssetInput{
+			Condition: domain.AccessoryConditionReady, Lifecycle: lifecycle,
+		}, "editor-1"); !errors.Is(err, ErrAccessoryValidation) {
+			t.Fatalf("expected allocation-owned lifecycle %q to be rejected, got %v", lifecycle, err)
+		}
+	}
 	if _, err := service.UpdateAsset(t.Context(), " asset-1 ", UpdateAccessoryAssetInput{
 		CreateAccessoryAssetInput: CreateAccessoryAssetInput{
 			InventoryNumber: " Z-0002 ", Condition: domain.AccessoryConditionReady,

--- a/backend/internal/application/accessory_allocations.go
+++ b/backend/internal/application/accessory_allocations.go
@@ -50,6 +50,7 @@ type AccessoryInstallation struct {
 	RemovedAt          string                             `json:"removedAt,omitempty"`
 	RemovalDisposition domain.AccessoryRemovalDisposition `json:"removalDisposition,omitempty"`
 	Notes              string                             `json:"notes,omitempty"`
+	RemovalNotes       string                             `json:"removalNotes,omitempty"`
 }
 
 type CreateAccessoryInstallationInput struct {

--- a/backend/internal/application/accessory_inventory.go
+++ b/backend/internal/application/accessory_inventory.go
@@ -126,5 +126,7 @@ func cleanAccessoryAssetInput(input CreateAccessoryAssetInput) CreateAccessoryAs
 }
 
 func validAccessoryAssetInput(input CreateAccessoryAssetInput) bool {
-	return input.Condition.Valid() && input.Lifecycle.Valid()
+	return input.Condition.Valid() && input.Lifecycle.Valid() &&
+		input.Lifecycle != domain.AccessoryLifecycleReserved &&
+		input.Lifecycle != domain.AccessoryLifecycleInstalled
 }

--- a/backend/internal/infrastructure/accessory_allocation_migration_test.go
+++ b/backend/internal/infrastructure/accessory_allocation_migration_test.go
@@ -1,0 +1,82 @@
+package infrastructure_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"railkeeper/backend/internal/infrastructure"
+)
+
+func TestAccessoryAllocationTargetMigrationPreservesLegacyReservations(t *testing.T) {
+	root := t.TempDir()
+	partialMigrations := filepath.Join(root, "migrations-through-0039")
+	if err := os.Mkdir(partialMigrations, 0700); err != nil {
+		t.Fatal(err)
+	}
+	copyMigrationsThrough(t, filepath.Join("..", "..", "migrations"), partialMigrations,
+		"0039_layout_accessory_foundation.sql")
+	db, err := infrastructure.OpenSQLite(filepath.Join(root, "data"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := infrastructure.Migrate(db, partialMigrations); err != nil {
+		t.Fatal(err)
+	}
+	statements := []string{
+		`INSERT INTO storage_locations(id, name, created_at, updated_at)
+         VALUES('location-1', 'Lager', 'now', 'now')`,
+		`INSERT INTO accessory_products(
+           id, manufacturer, name, category, tracking_mode, created_at, updated_at
+         ) VALUES('product-1', 'Tillig', 'Gleis', 'Gleismaterial', 'quantity', 'now', 'now')`,
+		`INSERT INTO layouts(id, name, kind, gauge, scale, created_at, updated_at)
+         VALUES('layout-1', 'Heimanlage', 'private', 'TT', '1:120', 'now', 'now')`,
+		`INSERT INTO accessory_reservations(
+           id, product_id, location_id, quantity, layout_id, status, note, created_by, created_at, updated_at
+         ) VALUES(
+           'reservation-1', 'product-1', 'location-1', 1, 'layout-1', 'active',
+           'legacy note', 'planner-1', 'now', 'now'
+         )`,
+	}
+	for _, statement := range statements {
+		if _, err := db.Exec(statement); err != nil {
+			t.Fatalf("seed legacy reservation: %v", err)
+		}
+	}
+	if err := infrastructure.Migrate(db, filepath.Join("..", "..", "migrations")); err != nil {
+		t.Fatal(err)
+	}
+	var productID, layoutID, vehicleID, note string
+	if err := db.QueryRow(`
+SELECT product_id, layout_id, COALESCE(vehicle_id, ''), note
+FROM accessory_reservations WHERE id='reservation-1'`).
+		Scan(&productID, &layoutID, &vehicleID, &note); err != nil {
+		t.Fatal(err)
+	}
+	if productID != "product-1" || layoutID != "layout-1" || vehicleID != "" || note != "legacy note" {
+		t.Fatalf("legacy reservation changed during migration: %q %q %q %q",
+			productID, layoutID, vehicleID, note)
+	}
+}
+
+func copyMigrationsThrough(t *testing.T, sourceDir, targetDir, lastFile string) {
+	t.Helper()
+	entries, err := os.ReadDir(sourceDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".sql") || entry.Name() > lastFile {
+			continue
+		}
+		body, err := os.ReadFile(filepath.Join(sourceDir, entry.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(targetDir, entry.Name()), body, 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/backend/internal/infrastructure/accessory_allocation_repository.go
+++ b/backend/internal/infrastructure/accessory_allocation_repository.go
@@ -1,0 +1,342 @@
+package infrastructure
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"railkeeper/backend/internal/application"
+	"railkeeper/backend/internal/domain"
+)
+
+func (r *AccessoryRepository) ListReservations(
+	ctx context.Context,
+	productID string,
+) ([]application.AccessoryReservation, error) {
+	rows, err := r.db.QueryContext(ctx, accessoryReservationSelect+`
+WHERE ?='' OR product_id=?
+ORDER BY created_at DESC, id`, productID, productID)
+	if err != nil {
+		return nil, fmt.Errorf("list accessory reservations: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	reservations := []application.AccessoryReservation{}
+	for rows.Next() {
+		reservation, err := scanAccessoryReservation(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan accessory reservation: %w", err)
+		}
+		reservations = append(reservations, *reservation)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate accessory reservations: %w", err)
+	}
+	return reservations, nil
+}
+
+func (r *AccessoryRepository) CreateReservation(
+	ctx context.Context,
+	input application.CreateAccessoryReservationInput,
+	actor string,
+) (*application.AccessoryReservation, error) {
+	now := timestamp()
+	reservationID := randomID()
+	err := r.withTx(ctx, func(tx *sql.Tx) error {
+		mode, err := accessoryTrackingMode(ctx, tx, input.ProductID)
+		if err != nil {
+			return err
+		}
+		if err := requireStorageLocation(ctx, tx, input.LocationID); err != nil {
+			return err
+		}
+		if err := requireAllocationTarget(ctx, tx, input.AllocationTargetInput); err != nil {
+			return err
+		}
+		switch mode {
+		case domain.AccessoryTrackingModeQuantity:
+			if input.AssetID != "" {
+				return application.ErrAccessoryTrackingMode
+			}
+			available, err := availableAccessoryQuantity(ctx, tx, input.ProductID, input.LocationID)
+			if err != nil {
+				return err
+			}
+			if available < input.Quantity {
+				return application.ErrAccessoryInsufficientStock
+			}
+		case domain.AccessoryTrackingModeIndividual:
+			if input.AssetID == "" {
+				return application.ErrAccessoryTrackingMode
+			}
+			if err := requireReservableAsset(ctx, tx, input); err != nil {
+				return err
+			}
+		default:
+			return application.ErrAccessoryTrackingMode
+		}
+		if _, err := tx.ExecContext(ctx, `
+INSERT INTO accessory_reservations(
+  id, product_id, asset_id, location_id, quantity, vehicle_id, layout_id, layout_unit_id,
+  status, note, created_by, created_at, updated_at
+) VALUES(?, ?, NULLIF(?, ''), ?, ?, NULLIF(?, ''), NULLIF(?, ''), NULLIF(?, ''), ?, ?, ?, ?, ?)`,
+			reservationID, input.ProductID, input.AssetID, input.LocationID, input.Quantity,
+			input.VehicleID, input.LayoutID, input.LayoutUnitID, domain.AccessoryReservationActive,
+			input.Note, actor, now, now); err != nil {
+			if isSQLiteConstraint(err) {
+				return application.ErrAccessoryConflict
+			}
+			return fmt.Errorf("insert accessory reservation: %w", err)
+		}
+		if input.AssetID != "" {
+			result, err := tx.ExecContext(ctx, `
+UPDATE accessory_assets SET lifecycle_state=?, updated_at=?
+WHERE id=? AND lifecycle_state=?`, domain.AccessoryLifecycleReserved, now, input.AssetID,
+				domain.AccessoryLifecycleStored)
+			if err != nil {
+				return fmt.Errorf("reserve accessory asset: %w", err)
+			}
+			if err := requireAccessoryConflictFreeUpdate(result); err != nil {
+				return err
+			}
+		}
+		details, err := allocationAuditDetails(input.Quantity, input.AllocationTargetInput, "")
+		if err != nil {
+			return err
+		}
+		return writeAccessoryAudit(ctx, tx, "AccessoryReservationCreated", "accessory_reservation",
+			reservationID, actor, now, details)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return r.getReservation(ctx, reservationID)
+}
+
+func (r *AccessoryRepository) CancelReservation(
+	ctx context.Context,
+	id string,
+	actor string,
+) (*application.AccessoryReservation, error) {
+	now := timestamp()
+	err := r.withTx(ctx, func(tx *sql.Tx) error {
+		reservation, err := getReservationWith(ctx, tx, id)
+		if err != nil {
+			return err
+		}
+		if reservation.Status != domain.AccessoryReservationActive {
+			return application.ErrAccessoryConflict
+		}
+		result, err := tx.ExecContext(ctx, `
+UPDATE accessory_reservations SET status=?, updated_at=? WHERE id=? AND status=?`,
+			domain.AccessoryReservationCancelled, now, id, domain.AccessoryReservationActive)
+		if err != nil {
+			return fmt.Errorf("cancel accessory reservation: %w", err)
+		}
+		if err := requireAccessoryConflictFreeUpdate(result); err != nil {
+			return err
+		}
+		if reservation.AssetID != "" {
+			result, err = tx.ExecContext(ctx, `
+UPDATE accessory_assets SET lifecycle_state=?, updated_at=? WHERE id=? AND lifecycle_state=?`,
+				domain.AccessoryLifecycleStored, now, reservation.AssetID, domain.AccessoryLifecycleReserved)
+			if err != nil {
+				return fmt.Errorf("release reserved accessory asset: %w", err)
+			}
+			if err := requireAccessoryConflictFreeUpdate(result); err != nil {
+				return err
+			}
+		}
+		return writeAccessoryAudit(ctx, tx, "AccessoryReservationCancelled", "accessory_reservation",
+			id, actor, now, "{}")
+	})
+	if err != nil {
+		return nil, err
+	}
+	return r.getReservation(ctx, id)
+}
+
+func (r *AccessoryRepository) GetAllocationSummary(
+	ctx context.Context,
+	productID string,
+) (*application.AccessoryAllocationSummary, error) {
+	mode, err := accessoryTrackingMode(ctx, r.db, productID)
+	if err != nil {
+		return nil, err
+	}
+	summary := &application.AccessoryAllocationSummary{ProductID: productID}
+	if mode == domain.AccessoryTrackingModeQuantity {
+		if err := r.db.QueryRowContext(ctx, `
+SELECT
+  COALESCE((SELECT SUM(quantity) FROM accessory_stock WHERE product_id=?), 0),
+  COALESCE((SELECT SUM(quantity) FROM accessory_reservations WHERE product_id=? AND status='active'), 0),
+  COALESCE((SELECT SUM(quantity) FROM accessory_installations WHERE product_id=? AND removed_at IS NULL), 0)`,
+			productID, productID, productID).Scan(&summary.Stored, &summary.Reserved, &summary.Installed); err != nil {
+			return nil, fmt.Errorf("summarize quantity allocations: %w", err)
+		}
+		summary.Owned = summary.Stored + summary.Installed
+	} else {
+		if err := r.db.QueryRowContext(ctx, `
+SELECT
+  COALESCE((SELECT COUNT(*) FROM accessory_assets WHERE product_id=?), 0),
+  COALESCE((SELECT COUNT(*) FROM accessory_assets
+            WHERE product_id=? AND storage_location_id IS NOT NULL
+              AND lifecycle_state IN ('stored', 'reserved')), 0),
+  COALESCE((SELECT SUM(quantity) FROM accessory_reservations WHERE product_id=? AND status='active'), 0),
+  COALESCE((SELECT SUM(quantity) FROM accessory_installations WHERE product_id=? AND removed_at IS NULL), 0)`,
+			productID, productID, productID, productID).
+			Scan(&summary.Owned, &summary.Stored, &summary.Reserved, &summary.Installed); err != nil {
+			return nil, fmt.Errorf("summarize individual allocations: %w", err)
+		}
+	}
+	summary.Available = summary.Stored - summary.Reserved
+	if summary.Available < 0 {
+		summary.Missing = -summary.Available
+		summary.Available = 0
+	}
+	return summary, nil
+}
+
+func requireReservableAsset(
+	ctx context.Context,
+	tx *sql.Tx,
+	input application.CreateAccessoryReservationInput,
+) error {
+	var productID, locationID string
+	var lifecycle domain.AccessoryLifecycle
+	err := tx.QueryRowContext(ctx, `
+SELECT product_id, COALESCE(storage_location_id, ''), lifecycle_state
+FROM accessory_assets WHERE id=?`, input.AssetID).Scan(&productID, &locationID, &lifecycle)
+	if errors.Is(err, sql.ErrNoRows) {
+		return application.ErrAccessoryNotFound
+	}
+	if err != nil {
+		return fmt.Errorf("read reservable accessory asset: %w", err)
+	}
+	if productID != input.ProductID || locationID != input.LocationID || lifecycle != domain.AccessoryLifecycleStored {
+		return application.ErrAccessoryConflict
+	}
+	var active int
+	if err := tx.QueryRowContext(ctx, `
+SELECT COUNT(*) FROM accessory_reservations WHERE asset_id=? AND status='active'`, input.AssetID).Scan(&active); err != nil {
+		return fmt.Errorf("check active asset reservation: %w", err)
+	}
+	if active > 0 {
+		return application.ErrAccessoryConflict
+	}
+	return nil
+}
+
+func availableAccessoryQuantity(ctx context.Context, tx *sql.Tx, productID, locationID string) (int, error) {
+	var available int
+	if err := tx.QueryRowContext(ctx, `
+SELECT
+  COALESCE((SELECT quantity FROM accessory_stock WHERE product_id=? AND location_id=?), 0) -
+  COALESCE((SELECT SUM(quantity) FROM accessory_reservations
+            WHERE product_id=? AND location_id=? AND status='active'), 0)`,
+		productID, locationID, productID, locationID).Scan(&available); err != nil {
+		return 0, fmt.Errorf("calculate available accessory quantity: %w", err)
+	}
+	return available, nil
+}
+
+func requireAllocationTarget(
+	ctx context.Context,
+	tx *sql.Tx,
+	target application.AllocationTargetInput,
+) error {
+	var query, id string
+	switch {
+	case target.VehicleID != "" && target.LayoutID == "" && target.LayoutUnitID == "":
+		query, id = `SELECT COUNT(*) FROM vehicles WHERE id=?`, target.VehicleID
+	case target.VehicleID == "" && target.LayoutID != "" && target.LayoutUnitID == "":
+		query, id = `SELECT COUNT(*) FROM layouts WHERE id=?`, target.LayoutID
+	case target.VehicleID == "" && target.LayoutID == "" && target.LayoutUnitID != "":
+		query, id = `SELECT COUNT(*) FROM layout_units WHERE id=?`, target.LayoutUnitID
+	default:
+		return application.ErrAccessoryValidation
+	}
+	var count int
+	if err := tx.QueryRowContext(ctx, query, id).Scan(&count); err != nil {
+		return fmt.Errorf("check allocation target: %w", err)
+	}
+	if count == 0 {
+		return application.ErrAccessoryNotFound
+	}
+	return nil
+}
+
+const accessoryReservationSelect = `SELECT id, product_id, COALESCE(asset_id, ''), location_id, quantity,
+COALESCE(vehicle_id, ''), COALESCE(layout_id, ''), COALESCE(layout_unit_id, ''),
+status, note, created_by, created_at, updated_at FROM accessory_reservations`
+
+func scanAccessoryReservation(scanner rowScanner) (*application.AccessoryReservation, error) {
+	reservation := &application.AccessoryReservation{}
+	err := scanner.Scan(&reservation.ID, &reservation.ProductID, &reservation.AssetID,
+		&reservation.LocationID, &reservation.Quantity, &reservation.VehicleID, &reservation.LayoutID,
+		&reservation.LayoutUnitID, &reservation.Status, &reservation.Note, &reservation.CreatedBy,
+		&reservation.CreatedAt, &reservation.UpdatedAt)
+	return reservation, err
+}
+
+func (r *AccessoryRepository) getReservation(
+	ctx context.Context,
+	id string,
+) (*application.AccessoryReservation, error) {
+	return getReservationWith(ctx, r.db, id)
+}
+
+func getReservationWith(
+	ctx context.Context,
+	queryer accessoryQueryer,
+	id string,
+) (*application.AccessoryReservation, error) {
+	reservation, err := scanAccessoryReservation(queryer.QueryRowContext(
+		ctx, accessoryReservationSelect+` WHERE id=?`, id,
+	))
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, application.ErrAccessoryNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get accessory reservation: %w", err)
+	}
+	return reservation, nil
+}
+
+func allocationAuditDetails(
+	quantity int,
+	target application.AllocationTargetInput,
+	disposition domain.AccessoryRemovalDisposition,
+) (string, error) {
+	details := map[string]any{"quantity": quantity}
+	switch {
+	case target.VehicleID != "":
+		details["targetType"], details["targetId"] = "vehicle", target.VehicleID
+	case target.LayoutID != "":
+		details["targetType"], details["targetId"] = "layout", target.LayoutID
+	case target.LayoutUnitID != "":
+		details["targetType"], details["targetId"] = "layout_unit", target.LayoutUnitID
+	}
+	if disposition != "" {
+		details["disposition"] = disposition
+	}
+	encoded, err := json.Marshal(details)
+	if err != nil {
+		return "", fmt.Errorf("encode accessory allocation audit details: %w", err)
+	}
+	return string(encoded), nil
+}
+
+func requireAccessoryConflictFreeUpdate(result sql.Result) error {
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("read accessory allocation update result: %w", err)
+	}
+	if affected == 0 {
+		return application.ErrAccessoryConflict
+	}
+	return nil
+}
+
+var _ application.AccessoryAllocationRepository = (*AccessoryRepository)(nil)

--- a/backend/internal/infrastructure/accessory_allocation_repository_test.go
+++ b/backend/internal/infrastructure/accessory_allocation_repository_test.go
@@ -1,0 +1,458 @@
+package infrastructure_test
+
+import (
+	"database/sql"
+	"errors"
+	"strings"
+	"testing"
+
+	"railkeeper/backend/internal/application"
+	"railkeeper/backend/internal/domain"
+	"railkeeper/backend/internal/infrastructure"
+)
+
+type allocationFixture struct {
+	db                *sql.DB
+	accessories       *application.AccessoryService
+	allocations       *application.AccessoryAllocationService
+	location          *application.StorageLocation
+	quantityProduct   *application.AccessoryProduct
+	individualProduct *application.AccessoryProduct
+	asset             *application.AccessoryAsset
+	layout            *application.Layout
+	unit              *application.LayoutUnit
+	vehicle           *application.Vehicle
+}
+
+func TestAccessoryAllocationsReserveAndInstallQuantityAtomically(t *testing.T) {
+	fixture := newAllocationFixture(t)
+	ctx := t.Context()
+	target := application.AllocationTargetInput{LayoutID: fixture.layout.ID}
+
+	reservation, err := fixture.allocations.CreateReservation(ctx, application.CreateAccessoryReservationInput{
+		ProductID: fixture.quantityProduct.ID, LocationID: fixture.location.ID, Quantity: 3,
+		AllocationTargetInput: target, Note: "Bauabschnitt West",
+	}, "planner-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	stock, err := fixture.accessories.GetStock(ctx, fixture.quantityProduct.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stock.TotalQuantity != 5 {
+		t.Fatalf("reservation changed physical stock: %#v", stock)
+	}
+	assertAllocationSummary(t, fixture.allocations, fixture.quantityProduct.ID, application.AccessoryAllocationSummary{
+		Owned: 5, Stored: 5, Reserved: 3, Installed: 0, Available: 2, Missing: 0,
+	})
+	if _, err := fixture.allocations.CreateReservation(ctx, application.CreateAccessoryReservationInput{
+		ProductID: fixture.quantityProduct.ID, LocationID: fixture.location.ID, Quantity: 3,
+		AllocationTargetInput: target,
+	}, "planner-1"); !errors.Is(err, application.ErrAccessoryInsufficientStock) {
+		t.Fatalf("expected over-reservation rejection, got %v", err)
+	}
+
+	installation, err := fixture.allocations.Install(ctx, application.CreateAccessoryInstallationInput{
+		ReservationID: reservation.ID, ProductID: fixture.quantityProduct.ID,
+		SourceLocationID: fixture.location.ID, Quantity: 3, AllocationTargetInput: target,
+		Condition: domain.AccessoryConditionReady,
+	}, "editor-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	reservations, err := fixture.allocations.ListReservations(ctx, fixture.quantityProduct.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reservations) != 1 || reservations[0].Status != domain.AccessoryReservationFulfilled {
+		t.Fatalf("reservation was not fulfilled: %#v", reservations)
+	}
+	assertAllocationSummary(t, fixture.allocations, fixture.quantityProduct.ID, application.AccessoryAllocationSummary{
+		Owned: 5, Stored: 2, Reserved: 0, Installed: 3, Available: 2, Missing: 0,
+	})
+
+	removed, err := fixture.allocations.RemoveInstallation(ctx, installation.ID,
+		application.RemoveAccessoryInstallationInput{
+			Disposition: domain.AccessoryRemovalStored, StorageLocationID: fixture.location.ID,
+			Notes: "nach Prüfung eingelagert",
+		}, "editor-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if removed.RemovalDisposition != domain.AccessoryRemovalStored || removed.RemovedAt == "" {
+		t.Fatalf("installation was not closed: %#v", removed)
+	}
+	assertAllocationSummary(t, fixture.allocations, fixture.quantityProduct.ID, application.AccessoryAllocationSummary{
+		Owned: 5, Stored: 5, Reserved: 0, Installed: 0, Available: 5, Missing: 0,
+	})
+	if _, err := fixture.allocations.RemoveInstallation(ctx, installation.ID,
+		application.RemoveAccessoryInstallationInput{
+			Disposition: domain.AccessoryRemovalStored, StorageLocationID: fixture.location.ID,
+		}, "editor-1"); !errors.Is(err, application.ErrAccessoryConflict) {
+		t.Fatalf("expected immutable closed installation, got %v", err)
+	}
+}
+
+func TestAccessoryAllocationsTrackIndividualAssetLifecycle(t *testing.T) {
+	fixture := newAllocationFixture(t)
+	ctx := t.Context()
+	target := application.AllocationTargetInput{VehicleID: fixture.vehicle.ID}
+
+	reservation, err := fixture.allocations.CreateReservation(ctx, application.CreateAccessoryReservationInput{
+		ProductID: fixture.individualProduct.ID, AssetID: fixture.asset.ID,
+		LocationID: fixture.location.ID, Quantity: 1, AllocationTargetInput: target,
+	}, "planner-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fixture.accessories.UpdateAsset(ctx, fixture.asset.ID, application.UpdateAccessoryAssetInput{
+		CreateAccessoryAssetInput: application.CreateAccessoryAssetInput{
+			InventoryNumber: fixture.asset.InventoryNumber, Condition: domain.AccessoryConditionReady,
+			Lifecycle: domain.AccessoryLifecycleStored, StorageLocationID: fixture.location.ID,
+		},
+	}, "editor-1"); !errors.Is(err, application.ErrAccessoryConflict) {
+		t.Fatalf("expected generic update of reserved asset to fail, got %v", err)
+	}
+	assertAssetState(t, fixture.accessories, fixture.individualProduct.ID, fixture.asset.ID,
+		domain.AccessoryLifecycleReserved, domain.AccessoryConditionReady, fixture.location.ID)
+	if _, err := fixture.allocations.CreateReservation(ctx, application.CreateAccessoryReservationInput{
+		ProductID: fixture.individualProduct.ID, AssetID: fixture.asset.ID,
+		LocationID: fixture.location.ID, Quantity: 1, AllocationTargetInput: target,
+	}, "planner-1"); !errors.Is(err, application.ErrAccessoryConflict) {
+		t.Fatalf("expected duplicate asset reservation conflict, got %v", err)
+	}
+
+	cancelled, err := fixture.allocations.CancelReservation(ctx, reservation.ID, "planner-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cancelled.Status != domain.AccessoryReservationCancelled {
+		t.Fatalf("unexpected cancelled reservation: %#v", cancelled)
+	}
+	assertAssetState(t, fixture.accessories, fixture.individualProduct.ID, fixture.asset.ID,
+		domain.AccessoryLifecycleStored, domain.AccessoryConditionReady, fixture.location.ID)
+
+	reservation, err = fixture.allocations.CreateReservation(ctx, application.CreateAccessoryReservationInput{
+		ProductID: fixture.individualProduct.ID, AssetID: fixture.asset.ID,
+		LocationID: fixture.location.ID, Quantity: 1, AllocationTargetInput: target,
+	}, "planner-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	installation, err := fixture.allocations.Install(ctx, application.CreateAccessoryInstallationInput{
+		ReservationID: reservation.ID, ProductID: fixture.individualProduct.ID, AssetID: fixture.asset.ID,
+		SourceLocationID: fixture.location.ID, Quantity: 1, AllocationTargetInput: target,
+		Condition: domain.AccessoryConditionReady, Notes: "Decoder eingebaut",
+	}, "editor-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAssetState(t, fixture.accessories, fixture.individualProduct.ID, fixture.asset.ID,
+		domain.AccessoryLifecycleInstalled, domain.AccessoryConditionReady, "")
+	if _, err := fixture.allocations.Install(ctx, application.CreateAccessoryInstallationInput{
+		ProductID: fixture.individualProduct.ID, AssetID: fixture.asset.ID,
+		SourceLocationID: fixture.location.ID, Quantity: 1,
+		AllocationTargetInput: application.AllocationTargetInput{LayoutUnitID: fixture.unit.ID},
+	}, "editor-1"); !errors.Is(err, application.ErrAccessoryConflict) {
+		t.Fatalf("expected active asset installation conflict, got %v", err)
+	}
+
+	installation, err = fixture.allocations.UpdateInstallationCondition(ctx, installation.ID,
+		application.UpdateAccessoryInstallationConditionInput{Condition: domain.AccessoryConditionDefective},
+		"editor-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if installation.Condition != domain.AccessoryConditionDefective {
+		t.Fatalf("installation condition not updated: %#v", installation)
+	}
+	assertAssetState(t, fixture.accessories, fixture.individualProduct.ID, fixture.asset.ID,
+		domain.AccessoryLifecycleInstalled, domain.AccessoryConditionDefective, "")
+
+	removed, err := fixture.allocations.RemoveInstallation(ctx, installation.ID,
+		application.RemoveAccessoryInstallationInput{
+			Disposition: domain.AccessoryRemovalMaintenance, Notes: "Werkstattprüfung erforderlich",
+		}, "editor-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if removed.RemovalDisposition != domain.AccessoryRemovalMaintenance {
+		t.Fatalf("unexpected removal disposition: %#v", removed)
+	}
+	assertAssetState(t, fixture.accessories, fixture.individualProduct.ID, fixture.asset.ID,
+		domain.AccessoryLifecycleMaintenance, domain.AccessoryConditionDefective, "")
+	assertAllocationSummary(t, fixture.allocations, fixture.individualProduct.ID,
+		application.AccessoryAllocationSummary{
+			Owned: 1, Stored: 0, Reserved: 0, Installed: 0, Available: 0, Missing: 0,
+		})
+	installations, err := fixture.allocations.ListInstallations(ctx, fixture.individualProduct.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(installations) != 1 || installations[0].RemovedAt == "" {
+		t.Fatalf("installation history was not retained: %#v", installations)
+	}
+}
+
+func TestAccessoryAllocationsValidateTargetsAndReservationMatch(t *testing.T) {
+	fixture := newAllocationFixture(t)
+	ctx := t.Context()
+	if _, err := fixture.allocations.CreateReservation(ctx, application.CreateAccessoryReservationInput{
+		ProductID: fixture.quantityProduct.ID, LocationID: fixture.location.ID, Quantity: 1,
+		AllocationTargetInput: application.AllocationTargetInput{VehicleID: "missing"},
+	}, "planner-1"); !errors.Is(err, application.ErrAccessoryNotFound) {
+		t.Fatalf("expected missing target error, got %v", err)
+	}
+	reservation, err := fixture.allocations.CreateReservation(ctx, application.CreateAccessoryReservationInput{
+		ProductID: fixture.quantityProduct.ID, LocationID: fixture.location.ID, Quantity: 1,
+		AllocationTargetInput: application.AllocationTargetInput{LayoutID: fixture.layout.ID},
+	}, "planner-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fixture.allocations.Install(ctx, application.CreateAccessoryInstallationInput{
+		ReservationID: reservation.ID, ProductID: fixture.quantityProduct.ID,
+		SourceLocationID: fixture.location.ID, Quantity: 1,
+		AllocationTargetInput: application.AllocationTargetInput{LayoutUnitID: fixture.unit.ID},
+	}, "editor-1"); !errors.Is(err, application.ErrAccessoryConflict) {
+		t.Fatalf("expected mismatched reservation target conflict, got %v", err)
+	}
+	stock, err := fixture.accessories.GetStock(ctx, fixture.quantityProduct.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stock.TotalQuantity != 5 {
+		t.Fatalf("failed installation changed stock: %#v", stock)
+	}
+}
+
+func TestAccessoryAllocationsProtectReservationsFromDirectInstall(t *testing.T) {
+	fixture := newAllocationFixture(t)
+	ctx := t.Context()
+	if _, err := fixture.allocations.CreateReservation(ctx, application.CreateAccessoryReservationInput{
+		ProductID: fixture.quantityProduct.ID, LocationID: fixture.location.ID, Quantity: 4,
+		AllocationTargetInput: application.AllocationTargetInput{LayoutID: fixture.layout.ID},
+	}, "planner-1"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fixture.allocations.Install(ctx, application.CreateAccessoryInstallationInput{
+		ProductID: fixture.quantityProduct.ID, SourceLocationID: fixture.location.ID, Quantity: 2,
+		AllocationTargetInput: application.AllocationTargetInput{LayoutUnitID: fixture.unit.ID},
+	}, "editor-1"); !errors.Is(err, application.ErrAccessoryInsufficientStock) {
+		t.Fatalf("expected reserved stock protection, got %v", err)
+	}
+	installation, err := fixture.allocations.Install(ctx, application.CreateAccessoryInstallationInput{
+		ProductID: fixture.quantityProduct.ID, SourceLocationID: fixture.location.ID, Quantity: 1,
+		AllocationTargetInput: application.AllocationTargetInput{LayoutUnitID: fixture.unit.ID},
+	}, "editor-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if installation.Quantity != 1 || installation.LayoutUnitID != fixture.unit.ID {
+		t.Fatalf("unexpected direct installation: %#v", installation)
+	}
+	assertAllocationSummary(t, fixture.allocations, fixture.quantityProduct.ID,
+		application.AccessoryAllocationSummary{
+			Owned: 5, Stored: 4, Reserved: 4, Installed: 1, Available: 0, Missing: 0,
+		})
+}
+
+func TestAccessoryAllocationsPreventTrackingModeChangeWithActiveInstallation(t *testing.T) {
+	fixture := newAllocationFixture(t)
+	ctx := t.Context()
+	if _, err := fixture.allocations.Install(ctx, application.CreateAccessoryInstallationInput{
+		ProductID: fixture.quantityProduct.ID, SourceLocationID: fixture.location.ID, Quantity: 5,
+		AllocationTargetInput: application.AllocationTargetInput{LayoutID: fixture.layout.ID},
+	}, "editor-1"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fixture.accessories.UpdateProduct(ctx, fixture.quantityProduct.ID,
+		application.UpdateAccessoryProductInput{CreateAccessoryProductInput: application.CreateAccessoryProductInput{
+			Manufacturer:  fixture.quantityProduct.Manufacturer,
+			ArticleNumber: fixture.quantityProduct.ArticleNumber,
+			Name:          fixture.quantityProduct.Name,
+			Category:      fixture.quantityProduct.Category,
+			TrackingMode:  domain.AccessoryTrackingModeIndividual,
+		}}, "editor-1"); !errors.Is(err, application.ErrAccessoryConflict) {
+		t.Fatalf("expected active installation to block tracking mode change, got %v", err)
+	}
+}
+
+func TestAccessoryAllocationsHandleIndividualRemovalDispositionsAndPrivateNotes(t *testing.T) {
+	fixture := newAllocationFixture(t)
+	ctx := t.Context()
+	tests := []struct {
+		name                string
+		disposition         domain.AccessoryRemovalDisposition
+		storageLocationID   string
+		wantLifecycle       domain.AccessoryLifecycle
+		wantCondition       domain.AccessoryCondition
+		wantStorageLocation string
+	}{
+		{"stored", domain.AccessoryRemovalStored, fixture.location.ID,
+			domain.AccessoryLifecycleStored, domain.AccessoryConditionReady, fixture.location.ID},
+		{"defective", domain.AccessoryRemovalDefective, "",
+			domain.AccessoryLifecycleMaintenance, domain.AccessoryConditionDefective, ""},
+		{"retired", domain.AccessoryRemovalRetired, "",
+			domain.AccessoryLifecycleRetired, domain.AccessoryConditionReady, ""},
+	}
+	for index, test := range tests {
+		asset, err := fixture.accessories.CreateAsset(ctx, fixture.individualProduct.ID,
+			application.CreateAccessoryAssetInput{
+				InventoryNumber: fixture.asset.InventoryNumber + "-" + test.name,
+				Condition:       domain.AccessoryConditionReady, Lifecycle: domain.AccessoryLifecycleStored,
+				StorageLocationID: fixture.location.ID,
+			}, "editor-1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		installation, err := fixture.allocations.Install(ctx, application.CreateAccessoryInstallationInput{
+			ProductID: fixture.individualProduct.ID, AssetID: asset.ID,
+			SourceLocationID: fixture.location.ID, Quantity: 1,
+			AllocationTargetInput: application.AllocationTargetInput{LayoutUnitID: fixture.unit.ID},
+			Condition:             domain.AccessoryConditionReady, Notes: "private install note",
+		}, "editor-1")
+		if err != nil {
+			t.Fatalf("case %d direct install: %v", index, err)
+		}
+		removed, err := fixture.allocations.RemoveInstallation(ctx, installation.ID,
+			application.RemoveAccessoryInstallationInput{
+				Disposition: test.disposition, StorageLocationID: test.storageLocationID,
+				Notes: "private removal note",
+			}, "editor-1")
+		if err != nil {
+			t.Fatalf("case %d removal: %v", index, err)
+		}
+		if removed.Notes != "private install note" || removed.RemovalNotes != "private removal note" {
+			t.Fatalf("installation notes were not preserved separately: %#v", removed)
+		}
+		assertAssetState(t, fixture.accessories, fixture.individualProduct.ID, asset.ID,
+			test.wantLifecycle, test.wantCondition, test.wantStorageLocation)
+	}
+	rows, err := fixture.db.QueryContext(ctx, `
+SELECT details_json FROM audit_logs
+WHERE action IN ('AccessoryInstalled', 'AccessoryRemoved')`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var details string
+		if err := rows.Scan(&details); err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(details, "private") {
+			t.Fatalf("allocation audit leaked private notes: %s", details)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func newAllocationFixture(t *testing.T) allocationFixture {
+	t.Helper()
+	accessories, db := testAccessoryService(t)
+	repository := infrastructure.NewAccessoryRepository(db)
+	fixture := allocationFixture{
+		db: db, accessories: accessories,
+		allocations: application.NewAccessoryAllocationService(repository),
+	}
+	ctx := t.Context()
+	var err error
+	fixture.location, err = accessories.CreateLocation(ctx,
+		application.CreateStorageLocationInput{Name: "Zentrallager"}, "editor-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixture.quantityProduct, err = accessories.CreateProduct(ctx, application.CreateAccessoryProductInput{
+		Manufacturer: "Tillig", ArticleNumber: "83501", Name: "Schienenverbinder", Category: "Gleismaterial",
+		TrackingMode: domain.AccessoryTrackingModeQuantity,
+	}, "editor-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = accessories.AdjustStock(ctx, fixture.quantityProduct.ID, application.StockAdjustmentInput{
+		LocationID: fixture.location.ID, Delta: 5,
+	}, "editor-1"); err != nil {
+		t.Fatal(err)
+	}
+	fixture.individualProduct, err = accessories.CreateProduct(ctx, application.CreateAccessoryProductInput{
+		Manufacturer: "Lenz", ArticleNumber: "LS150", Name: "Schaltdecoder", Category: "Decoder",
+		TrackingMode: domain.AccessoryTrackingModeIndividual,
+	}, "editor-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixture.asset, err = accessories.CreateAsset(ctx, fixture.individualProduct.ID,
+		application.CreateAccessoryAssetInput{
+			InventoryNumber: "RK-Z-1001", Condition: domain.AccessoryConditionReady,
+			Lifecycle: domain.AccessoryLifecycleStored, StorageLocationID: fixture.location.ID,
+		}, "editor-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	layouts := application.NewLayoutService(infrastructure.NewLayoutRepository(db))
+	fixture.layout, err = layouts.CreateLayout(ctx, application.CreateLayoutInput{
+		Name: "Testanlage", Kind: domain.LayoutKindPrivate, Gauge: "TT", Scale: "1:120",
+	}, "planner-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixture.unit, err = layouts.CreateUnit(ctx, fixture.layout.ID, application.CreateLayoutUnitInput{
+		Name: "Modul 1", Kind: domain.LayoutUnitKindModule,
+	}, "planner-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixture.vehicle, err = application.NewVehicleService(db).Create(ctx, application.CreateVehicleInput{
+		InventoryNumber: "RK-TEST-1", Manufacturer: "Tillig", Name: "Testlok", Gauge: "TT",
+		Category: "Lokomotive", Gattung: "Dampflokomotive",
+	}, "editor-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return fixture
+}
+
+func assertAllocationSummary(
+	t *testing.T,
+	service *application.AccessoryAllocationService,
+	productID string,
+	want application.AccessoryAllocationSummary,
+) {
+	t.Helper()
+	got, err := service.GetAllocationSummary(t.Context(), productID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want.ProductID = productID
+	if *got != want {
+		t.Fatalf("allocation summary: got %#v, want %#v", *got, want)
+	}
+}
+
+func assertAssetState(
+	t *testing.T,
+	service *application.AccessoryService,
+	productID, assetID string,
+	lifecycle domain.AccessoryLifecycle,
+	condition domain.AccessoryCondition,
+	locationID string,
+) {
+	t.Helper()
+	assets, err := service.ListAssets(t.Context(), productID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, asset := range assets {
+		if asset.ID == assetID {
+			if asset.Lifecycle != lifecycle || asset.Condition != condition || asset.StorageLocationID != locationID {
+				t.Fatalf("unexpected asset state: %#v", asset)
+			}
+			return
+		}
+	}
+	t.Fatalf("asset %s not found in %#v", assetID, assets)
+}

--- a/backend/internal/infrastructure/accessory_installation_repository.go
+++ b/backend/internal/infrastructure/accessory_installation_repository.go
@@ -1,0 +1,373 @@
+package infrastructure
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"railkeeper/backend/internal/application"
+	"railkeeper/backend/internal/domain"
+)
+
+func (r *AccessoryRepository) ListInstallations(
+	ctx context.Context,
+	productID string,
+) ([]application.AccessoryInstallation, error) {
+	rows, err := r.db.QueryContext(ctx, accessoryInstallationSelect+`
+WHERE ?='' OR product_id=?
+ORDER BY installed_at DESC, id`, productID, productID)
+	if err != nil {
+		return nil, fmt.Errorf("list accessory installations: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	installations := []application.AccessoryInstallation{}
+	for rows.Next() {
+		installation, err := scanAccessoryInstallation(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan accessory installation: %w", err)
+		}
+		installations = append(installations, *installation)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate accessory installations: %w", err)
+	}
+	return installations, nil
+}
+
+func (r *AccessoryRepository) Install(
+	ctx context.Context,
+	input application.CreateAccessoryInstallationInput,
+	actor string,
+) (*application.AccessoryInstallation, error) {
+	now := timestamp()
+	installationID := randomID()
+	err := r.withTx(ctx, func(tx *sql.Tx) error {
+		mode, err := accessoryTrackingMode(ctx, tx, input.ProductID)
+		if err != nil {
+			return err
+		}
+		if err := requireStorageLocation(ctx, tx, input.SourceLocationID); err != nil {
+			return err
+		}
+		if err := requireAllocationTarget(ctx, tx, input.AllocationTargetInput); err != nil {
+			return err
+		}
+		var reservation *application.AccessoryReservation
+		if input.ReservationID != "" {
+			reservation, err = getReservationWith(ctx, tx, input.ReservationID)
+			if err != nil {
+				return err
+			}
+			if !reservationMatchesInstallation(reservation, input) {
+				return application.ErrAccessoryConflict
+			}
+		}
+		switch mode {
+		case domain.AccessoryTrackingModeQuantity:
+			if input.AssetID != "" {
+				return application.ErrAccessoryTrackingMode
+			}
+			if reservation == nil {
+				available, err := availableAccessoryQuantity(ctx, tx, input.ProductID, input.SourceLocationID)
+				if err != nil {
+					return err
+				}
+				if available < input.Quantity {
+					return application.ErrAccessoryInsufficientStock
+				}
+			}
+			result, err := tx.ExecContext(ctx, `
+UPDATE accessory_stock SET quantity=quantity-?, updated_at=?
+WHERE product_id=? AND location_id=? AND quantity>=?`, input.Quantity, now, input.ProductID,
+				input.SourceLocationID, input.Quantity)
+			if err != nil {
+				return fmt.Errorf("decrement installed accessory stock: %w", err)
+			}
+			if affected, err := result.RowsAffected(); err != nil {
+				return fmt.Errorf("read installed stock result: %w", err)
+			} else if affected == 0 {
+				return application.ErrAccessoryInsufficientStock
+			}
+		case domain.AccessoryTrackingModeIndividual:
+			if input.AssetID == "" {
+				return application.ErrAccessoryTrackingMode
+			}
+			if err := installAccessoryAsset(ctx, tx, input, reservation != nil, now); err != nil {
+				return err
+			}
+		default:
+			return application.ErrAccessoryTrackingMode
+		}
+		if reservation != nil {
+			result, err := tx.ExecContext(ctx, `
+UPDATE accessory_reservations SET status=?, updated_at=? WHERE id=? AND status=?`,
+				domain.AccessoryReservationFulfilled, now, reservation.ID, domain.AccessoryReservationActive)
+			if err != nil {
+				return fmt.Errorf("fulfill accessory reservation: %w", err)
+			}
+			if err := requireAccessoryConflictFreeUpdate(result); err != nil {
+				return err
+			}
+		}
+		if _, err := tx.ExecContext(ctx, `
+INSERT INTO accessory_installations(
+  id, product_id, asset_id, source_location_id, quantity, vehicle_id, layout_id, layout_unit_id,
+  condition_state, installed_by, installed_at, notes
+) VALUES(?, ?, NULLIF(?, ''), ?, ?, NULLIF(?, ''), NULLIF(?, ''), NULLIF(?, ''), ?, ?, ?, ?)`,
+			installationID, input.ProductID, input.AssetID, input.SourceLocationID, input.Quantity,
+			input.VehicleID, input.LayoutID, input.LayoutUnitID, input.Condition, actor, now, input.Notes); err != nil {
+			if isSQLiteConstraint(err) {
+				return application.ErrAccessoryConflict
+			}
+			return fmt.Errorf("insert accessory installation: %w", err)
+		}
+		details, err := allocationAuditDetails(input.Quantity, input.AllocationTargetInput, "")
+		if err != nil {
+			return err
+		}
+		return writeAccessoryAudit(ctx, tx, "AccessoryInstalled", "accessory_installation",
+			installationID, actor, now, details)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return r.getInstallation(ctx, installationID)
+}
+
+func (r *AccessoryRepository) RemoveInstallation(
+	ctx context.Context,
+	id string,
+	input application.RemoveAccessoryInstallationInput,
+	actor string,
+) (*application.AccessoryInstallation, error) {
+	now := timestamp()
+	err := r.withTx(ctx, func(tx *sql.Tx) error {
+		installation, err := getInstallationWith(ctx, tx, id)
+		if err != nil {
+			return err
+		}
+		if installation.RemovedAt != "" {
+			return application.ErrAccessoryConflict
+		}
+		mode, err := accessoryTrackingMode(ctx, tx, installation.ProductID)
+		if err != nil {
+			return err
+		}
+		if input.Disposition == domain.AccessoryRemovalStored {
+			if err := requireStorageLocation(ctx, tx, input.StorageLocationID); err != nil {
+				return err
+			}
+		}
+		if mode == domain.AccessoryTrackingModeQuantity {
+			if input.Disposition == domain.AccessoryRemovalStored {
+				if _, err := tx.ExecContext(ctx, `
+INSERT INTO accessory_stock(product_id, location_id, quantity, updated_at)
+VALUES(?, ?, ?, ?)
+ON CONFLICT(product_id, location_id) DO UPDATE
+SET quantity=quantity+excluded.quantity, updated_at=excluded.updated_at`, installation.ProductID,
+					input.StorageLocationID, installation.Quantity, now); err != nil {
+					return fmt.Errorf("restore removed accessory stock: %w", err)
+				}
+			}
+		} else if err := removeAccessoryAsset(ctx, tx, installation, input, now); err != nil {
+			return err
+		}
+		result, err := tx.ExecContext(ctx, `
+UPDATE accessory_installations
+SET removed_by=?, removed_at=?, removal_disposition=?, removal_notes=?
+WHERE id=? AND removed_at IS NULL`, actor, now, input.Disposition, input.Notes, id)
+		if err != nil {
+			return fmt.Errorf("close accessory installation: %w", err)
+		}
+		if err := requireAccessoryConflictFreeUpdate(result); err != nil {
+			return err
+		}
+		details, err := allocationAuditDetails(installation.Quantity,
+			installation.AllocationTargetInput, input.Disposition)
+		if err != nil {
+			return err
+		}
+		return writeAccessoryAudit(ctx, tx, "AccessoryRemoved", "accessory_installation",
+			id, actor, now, details)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return r.getInstallation(ctx, id)
+}
+
+func (r *AccessoryRepository) UpdateInstallationCondition(
+	ctx context.Context,
+	id string,
+	input application.UpdateAccessoryInstallationConditionInput,
+	actor string,
+) (*application.AccessoryInstallation, error) {
+	now := timestamp()
+	err := r.withTx(ctx, func(tx *sql.Tx) error {
+		installation, err := getInstallationWith(ctx, tx, id)
+		if err != nil {
+			return err
+		}
+		if installation.RemovedAt != "" {
+			return application.ErrAccessoryConflict
+		}
+		result, err := tx.ExecContext(ctx, `
+UPDATE accessory_installations SET condition_state=? WHERE id=? AND removed_at IS NULL`, input.Condition, id)
+		if err != nil {
+			return fmt.Errorf("update installation condition: %w", err)
+		}
+		if err := requireAccessoryConflictFreeUpdate(result); err != nil {
+			return err
+		}
+		if installation.AssetID != "" {
+			result, err = tx.ExecContext(ctx, `
+UPDATE accessory_assets SET condition_state=?, updated_at=? WHERE id=?`, input.Condition, now,
+				installation.AssetID)
+			if err != nil {
+				return fmt.Errorf("update installed asset condition: %w", err)
+			}
+			if err := requireAccessoryUpdated(result); err != nil {
+				return err
+			}
+		}
+		return writeAccessoryAudit(ctx, tx, "AccessoryInstallationConditionUpdated",
+			"accessory_installation", id, actor, now, "{}")
+	})
+	if err != nil {
+		return nil, err
+	}
+	return r.getInstallation(ctx, id)
+}
+
+func installAccessoryAsset(
+	ctx context.Context,
+	tx *sql.Tx,
+	input application.CreateAccessoryInstallationInput,
+	reserved bool,
+	now string,
+) error {
+	var productID, locationID string
+	var lifecycle domain.AccessoryLifecycle
+	err := tx.QueryRowContext(ctx, `
+SELECT product_id, COALESCE(storage_location_id, ''), lifecycle_state
+FROM accessory_assets WHERE id=?`, input.AssetID).Scan(&productID, &locationID, &lifecycle)
+	if errors.Is(err, sql.ErrNoRows) {
+		return application.ErrAccessoryNotFound
+	}
+	if err != nil {
+		return fmt.Errorf("read installable accessory asset: %w", err)
+	}
+	wantLifecycle := domain.AccessoryLifecycleStored
+	if reserved {
+		wantLifecycle = domain.AccessoryLifecycleReserved
+	}
+	if productID != input.ProductID || locationID != input.SourceLocationID || lifecycle != wantLifecycle {
+		return application.ErrAccessoryConflict
+	}
+	if !reserved {
+		var active int
+		if err := tx.QueryRowContext(ctx, `
+SELECT COUNT(*) FROM accessory_reservations WHERE asset_id=? AND status='active'`, input.AssetID).Scan(&active); err != nil {
+			return fmt.Errorf("check reserved asset before installation: %w", err)
+		}
+		if active > 0 {
+			return application.ErrAccessoryConflict
+		}
+	}
+	result, err := tx.ExecContext(ctx, `
+UPDATE accessory_assets
+SET storage_location_id=NULL, lifecycle_state=?, condition_state=?, updated_at=?
+WHERE id=? AND lifecycle_state=?`, domain.AccessoryLifecycleInstalled, input.Condition, now,
+		input.AssetID, wantLifecycle)
+	if err != nil {
+		return fmt.Errorf("mark accessory asset installed: %w", err)
+	}
+	return requireAccessoryConflictFreeUpdate(result)
+}
+
+func removeAccessoryAsset(
+	ctx context.Context,
+	tx *sql.Tx,
+	installation *application.AccessoryInstallation,
+	input application.RemoveAccessoryInstallationInput,
+	now string,
+) error {
+	lifecycle := domain.AccessoryLifecycleMaintenance
+	condition := installation.Condition
+	locationID := ""
+	switch input.Disposition {
+	case domain.AccessoryRemovalStored:
+		lifecycle = domain.AccessoryLifecycleStored
+		locationID = input.StorageLocationID
+	case domain.AccessoryRemovalMaintenance:
+		lifecycle = domain.AccessoryLifecycleMaintenance
+	case domain.AccessoryRemovalDefective:
+		lifecycle = domain.AccessoryLifecycleMaintenance
+		condition = domain.AccessoryConditionDefective
+	case domain.AccessoryRemovalRetired:
+		lifecycle = domain.AccessoryLifecycleRetired
+	default:
+		return application.ErrAccessoryValidation
+	}
+	result, err := tx.ExecContext(ctx, `
+UPDATE accessory_assets
+SET storage_location_id=NULLIF(?, ''), lifecycle_state=?, condition_state=?, updated_at=?
+WHERE id=? AND lifecycle_state=?`, locationID, lifecycle, condition, now, installation.AssetID,
+		domain.AccessoryLifecycleInstalled)
+	if err != nil {
+		return fmt.Errorf("update removed accessory asset: %w", err)
+	}
+	return requireAccessoryConflictFreeUpdate(result)
+}
+
+func reservationMatchesInstallation(
+	reservation *application.AccessoryReservation,
+	input application.CreateAccessoryInstallationInput,
+) bool {
+	return reservation.Status == domain.AccessoryReservationActive &&
+		reservation.ProductID == input.ProductID && reservation.AssetID == input.AssetID &&
+		reservation.LocationID == input.SourceLocationID && reservation.Quantity == input.Quantity &&
+		reservation.VehicleID == input.VehicleID && reservation.LayoutID == input.LayoutID &&
+		reservation.LayoutUnitID == input.LayoutUnitID
+}
+
+const accessoryInstallationSelect = `SELECT id, product_id, COALESCE(asset_id, ''), source_location_id, quantity,
+COALESCE(vehicle_id, ''), COALESCE(layout_id, ''), COALESCE(layout_unit_id, ''), condition_state,
+installed_by, installed_at, COALESCE(removed_by, ''), COALESCE(removed_at, ''),
+COALESCE(removal_disposition, ''), notes, removal_notes FROM accessory_installations`
+
+func scanAccessoryInstallation(scanner rowScanner) (*application.AccessoryInstallation, error) {
+	installation := &application.AccessoryInstallation{}
+	err := scanner.Scan(&installation.ID, &installation.ProductID, &installation.AssetID,
+		&installation.SourceLocationID, &installation.Quantity, &installation.VehicleID,
+		&installation.LayoutID, &installation.LayoutUnitID, &installation.Condition,
+		&installation.InstalledBy, &installation.InstalledAt, &installation.RemovedBy,
+		&installation.RemovedAt, &installation.RemovalDisposition, &installation.Notes,
+		&installation.RemovalNotes)
+	return installation, err
+}
+
+func (r *AccessoryRepository) getInstallation(
+	ctx context.Context,
+	id string,
+) (*application.AccessoryInstallation, error) {
+	return getInstallationWith(ctx, r.db, id)
+}
+
+func getInstallationWith(
+	ctx context.Context,
+	queryer accessoryQueryer,
+	id string,
+) (*application.AccessoryInstallation, error) {
+	installation, err := scanAccessoryInstallation(queryer.QueryRowContext(
+		ctx, accessoryInstallationSelect+` WHERE id=?`, id,
+	))
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, application.ErrAccessoryNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get accessory installation: %w", err)
+	}
+	return installation, nil
+}

--- a/backend/internal/infrastructure/accessory_installation_repository.go
+++ b/backend/internal/infrastructure/accessory_installation_repository.go
@@ -293,7 +293,7 @@ func removeAccessoryAsset(
 	input application.RemoveAccessoryInstallationInput,
 	now string,
 ) error {
-	lifecycle := domain.AccessoryLifecycleMaintenance
+	var lifecycle domain.AccessoryLifecycle
 	condition := installation.Condition
 	locationID := ""
 	switch input.Disposition {

--- a/backend/internal/infrastructure/accessory_inventory_repository.go
+++ b/backend/internal/infrastructure/accessory_inventory_repository.go
@@ -171,11 +171,16 @@ func (r *AccessoryRepository) UpdateAsset(
 ) (*application.AccessoryAsset, error) {
 	now := timestamp()
 	err := r.withTx(ctx, func(tx *sql.Tx) error {
-		var productID string
-		if err := tx.QueryRowContext(ctx, `SELECT product_id FROM accessory_assets WHERE id=?`, id).Scan(&productID); errors.Is(err, sql.ErrNoRows) {
+		var currentLifecycle domain.AccessoryLifecycle
+		if err := tx.QueryRowContext(ctx, `SELECT lifecycle_state FROM accessory_assets WHERE id=?`, id).
+			Scan(&currentLifecycle); errors.Is(err, sql.ErrNoRows) {
 			return application.ErrAccessoryNotFound
 		} else if err != nil {
-			return fmt.Errorf("read accessory asset product: %w", err)
+			return fmt.Errorf("read accessory asset lifecycle: %w", err)
+		}
+		if currentLifecycle == domain.AccessoryLifecycleReserved ||
+			currentLifecycle == domain.AccessoryLifecycleInstalled {
+			return application.ErrAccessoryConflict
 		}
 		if err := requireStorageLocation(ctx, tx, input.StorageLocationID); err != nil {
 			return err

--- a/backend/internal/infrastructure/accessory_repository.go
+++ b/backend/internal/infrastructure/accessory_repository.go
@@ -101,11 +101,17 @@ func (r *AccessoryRepository) UpdateProduct(
 		}
 		if currentMode != input.TrackingMode {
 			var dependentCount int
-			query := `SELECT COALESCE(SUM(quantity), 0) FROM accessory_stock WHERE product_id=?`
+			query := `
+SELECT
+  COALESCE((SELECT SUM(quantity) FROM accessory_stock WHERE product_id=?), 0) +
+  COALESCE((SELECT SUM(quantity) FROM accessory_reservations WHERE product_id=? AND status='active'), 0) +
+  COALESCE((SELECT SUM(quantity) FROM accessory_installations WHERE product_id=? AND removed_at IS NULL), 0)`
+			args := []any{id, id, id}
 			if currentMode == domain.AccessoryTrackingModeIndividual {
 				query = `SELECT COUNT(*) FROM accessory_assets WHERE product_id=?`
+				args = []any{id}
 			}
-			if err := tx.QueryRowContext(ctx, query, id).Scan(&dependentCount); err != nil {
+			if err := tx.QueryRowContext(ctx, query, args...).Scan(&dependentCount); err != nil {
 				return fmt.Errorf("check accessory tracking mode change: %w", err)
 			}
 			if dependentCount > 0 {

--- a/backend/migrations/0040_accessory_allocation_targets.sql
+++ b/backend/migrations/0040_accessory_allocation_targets.sql
@@ -1,0 +1,53 @@
+DROP INDEX IF EXISTS ix_accessory_reservations_product;
+DROP INDEX IF EXISTS ix_accessory_reservations_asset;
+DROP INDEX IF EXISTS ix_accessory_reservations_location;
+DROP INDEX IF EXISTS ix_accessory_reservations_layout;
+DROP INDEX IF EXISTS ix_accessory_reservations_unit;
+
+ALTER TABLE accessory_reservations RENAME TO accessory_reservations_legacy;
+
+CREATE TABLE accessory_reservations (
+  id TEXT PRIMARY KEY,
+  product_id TEXT NOT NULL,
+  asset_id TEXT,
+  location_id TEXT NOT NULL,
+  quantity INTEGER NOT NULL CHECK (quantity > 0),
+  vehicle_id TEXT,
+  layout_id TEXT,
+  layout_unit_id TEXT,
+  status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'fulfilled', 'cancelled')),
+  note TEXT NOT NULL DEFAULT '',
+  created_by TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  FOREIGN KEY (product_id) REFERENCES accessory_products(id) ON DELETE RESTRICT,
+  FOREIGN KEY (asset_id) REFERENCES accessory_assets(id) ON DELETE RESTRICT,
+  FOREIGN KEY (location_id) REFERENCES storage_locations(id) ON DELETE RESTRICT,
+  FOREIGN KEY (vehicle_id) REFERENCES vehicles(id) ON DELETE RESTRICT,
+  FOREIGN KEY (layout_id) REFERENCES layouts(id) ON DELETE RESTRICT,
+  FOREIGN KEY (layout_unit_id) REFERENCES layout_units(id) ON DELETE RESTRICT,
+  CHECK ((vehicle_id IS NOT NULL) + (layout_id IS NOT NULL) + (layout_unit_id IS NOT NULL) = 1),
+  CHECK (asset_id IS NULL OR quantity = 1)
+);
+
+INSERT INTO accessory_reservations(
+  id, product_id, asset_id, location_id, quantity, layout_id, layout_unit_id,
+  status, note, created_by, created_at, updated_at
+)
+SELECT
+  id, product_id, asset_id, location_id, quantity, layout_id, layout_unit_id,
+  status, note, created_by, created_at, updated_at
+FROM accessory_reservations_legacy;
+
+DROP TABLE accessory_reservations_legacy;
+
+CREATE INDEX ix_accessory_reservations_product ON accessory_reservations(product_id);
+CREATE INDEX ix_accessory_reservations_asset ON accessory_reservations(asset_id);
+CREATE UNIQUE INDEX ux_accessory_reservations_active_asset
+  ON accessory_reservations(asset_id) WHERE asset_id IS NOT NULL AND status = 'active';
+CREATE INDEX ix_accessory_reservations_location ON accessory_reservations(location_id);
+CREATE INDEX ix_accessory_reservations_vehicle ON accessory_reservations(vehicle_id);
+CREATE INDEX ix_accessory_reservations_layout ON accessory_reservations(layout_id);
+CREATE INDEX ix_accessory_reservations_unit ON accessory_reservations(layout_unit_id);
+
+ALTER TABLE accessory_installations ADD COLUMN removal_notes TEXT NOT NULL DEFAULT '';


### PR DESCRIPTION
## Deutsch

Implementiert die transaktionale SQLite-Persistenz für Reservierungen, Einbau und Ausbau aus Stage 1.4.

### Enthalten

- Mengenreservierungen reduzieren die Verfügbarkeit, nicht den physischen Lagerbestand
- Schutz vor Überreservierung und vor Direktentnahme reservierter Mengen
- Einzelobjekt-Reservierung mit exklusivem aktivem Lock und sauberem Storno
- Einbau aus Reservierung oder als direkte, ausdrücklich bestätigte Buchung
- atomare Bestandsminderung und Erfüllung einer Reservierung
- Ausbau nach Lager, Wartung, Defekt oder Ausmusterung
- synchroner Lebenszyklus und Zustand individuell verfolgter Geräte
- unveränderliche geschlossene Einbauhistorie
- Kennzahlen für vorhanden, gelagert, reserviert, eingebaut, verfügbar und fehlend
- Zielprüfung für Fahrzeug, Anlage oder Anlageneinheit
- Vorwärtsmigration 0040 mit Erhalt vorhandener Reservierungen
- getrennte Installations- und Ausbauhinweise ohne Freitext in Audit-Metadaten
- Schutz gegen Modus- und Lebenszyklusänderungen außerhalb der Zuordnungslogik

### Verifikation

- `go test ./...`
- `go vet ./...`
- `git diff --cached --check`
- gezielte Migrations-, Transaktions-, Rollback- und Lebenszyklustests

Der lokale Race-Test ist auf diesem Windows-Laufzeitsystem nicht verfügbar, weil CGO deaktiviert ist.

## English

Implements transactional SQLite persistence for reservations, installation, and removal in Stage 1.4.

### Included

- quantity reservations reduce availability, not physical stored stock
- protection against over-reservation and direct consumption of reserved quantities
- individual asset reservations with an exclusive active lock and clean cancellation
- installation from a reservation or as a direct explicitly confirmed operation
- atomic stock decrement and reservation fulfillment
- removal to storage, maintenance, defective, or retired states
- synchronized lifecycle and condition for individually tracked assets
- immutable closed installation history
- owned, stored, reserved, installed, available, and missing summaries
- target verification for vehicles, layouts, and layout units
- forward migration 0040 preserving existing reservations
- separate installation and removal notes without free text in audit metadata
- protection against tracking-mode and lifecycle changes outside allocation logic

### Verification

- `go test ./...`
- `go vet ./...`
- `git diff --cached --check`
- targeted migration, transaction, rollback, and lifecycle tests

The local race test is unavailable in this Windows runtime because CGO is disabled.

Refs #39