### PR TITLE
feat(accessories): expose allocation lifecycle API

### DIFF
--- a/backend/cmd/railkeeper/main.go
+++ b/backend/cmd/railkeeper/main.go
@@ -124,7 +124,9 @@ func main() {
 		os.Exit(1)
 	}
 	layoutService := application.NewLayoutService(infrastructure.NewLayoutRepository(db))
-	accessoryService := application.NewAccessoryService(infrastructure.NewAccessoryRepository(db))
+	accessoryRepository := infrastructure.NewAccessoryRepository(db)
+	accessoryService := application.NewAccessoryService(accessoryRepository)
+	accessoryAllocationService := application.NewAccessoryAllocationService(accessoryRepository)
 
 	handler := api.NewRouter(api.Config{
 		Version:                     version,
@@ -147,6 +149,7 @@ func main() {
 		ExhibitionService:           application.NewExhibitionService(db),
 		LayoutService:               layoutService,
 		AccessoryService:            accessoryService,
+		AccessoryAllocationService:  accessoryAllocationService,
 		ECoSService:                 application.NewECoSService(),
 		RateLimitService:            application.NewRateLimitService(db),
 		SettingsService:             application.NewSettingsService(db),

--- a/backend/internal/api/accessory_allocation_handlers.go
+++ b/backend/internal/api/accessory_allocation_handlers.go
@@ -1,0 +1,101 @@
+package api
+
+import (
+	"net/http"
+
+	"railkeeper/backend/internal/application"
+)
+
+func (a *App) listAccessoryReservations(w http.ResponseWriter, r *http.Request) {
+	reservations, err := a.accessoryAllocationService.ListReservations(r.Context(), r.URL.Query().Get("productId"))
+	if err != nil {
+		a.accessoryError(w, err, "list accessory reservations")
+		return
+	}
+	respondJSON(w, http.StatusOK, reservations)
+}
+
+func (a *App) createAccessoryReservation(w http.ResponseWriter, r *http.Request) {
+	var input application.CreateAccessoryReservationInput
+	if !decodeAccessoryJSON(w, r, &input) {
+		return
+	}
+	reservation, err := a.accessoryAllocationService.CreateReservation(r.Context(), input, actorUserID(r))
+	if err != nil {
+		a.accessoryError(w, err, "create accessory reservation")
+		return
+	}
+	respondJSON(w, http.StatusCreated, reservation)
+}
+
+func (a *App) cancelAccessoryReservation(w http.ResponseWriter, r *http.Request) {
+	reservation, err := a.accessoryAllocationService.CancelReservation(
+		r.Context(), r.PathValue("id"), actorUserID(r),
+	)
+	if err != nil {
+		a.accessoryError(w, err, "cancel accessory reservation")
+		return
+	}
+	respondJSON(w, http.StatusOK, reservation)
+}
+
+func (a *App) listAccessoryInstallations(w http.ResponseWriter, r *http.Request) {
+	installations, err := a.accessoryAllocationService.ListInstallations(r.Context(), r.URL.Query().Get("productId"))
+	if err != nil {
+		a.accessoryError(w, err, "list accessory installations")
+		return
+	}
+	respondJSON(w, http.StatusOK, installations)
+}
+
+func (a *App) createAccessoryInstallation(w http.ResponseWriter, r *http.Request) {
+	var input application.CreateAccessoryInstallationInput
+	if !decodeAccessoryJSON(w, r, &input) {
+		return
+	}
+	installation, err := a.accessoryAllocationService.Install(r.Context(), input, actorUserID(r))
+	if err != nil {
+		a.accessoryError(w, err, "create accessory installation")
+		return
+	}
+	respondJSON(w, http.StatusCreated, installation)
+}
+
+func (a *App) removeAccessoryInstallation(w http.ResponseWriter, r *http.Request) {
+	var input application.RemoveAccessoryInstallationInput
+	if !decodeAccessoryJSON(w, r, &input) {
+		return
+	}
+	installation, err := a.accessoryAllocationService.RemoveInstallation(
+		r.Context(), r.PathValue("id"), input, actorUserID(r),
+	)
+	if err != nil {
+		a.accessoryError(w, err, "remove accessory installation")
+		return
+	}
+	respondJSON(w, http.StatusOK, installation)
+}
+
+func (a *App) updateAccessoryInstallationCondition(w http.ResponseWriter, r *http.Request) {
+	var input application.UpdateAccessoryInstallationConditionInput
+	if !decodeAccessoryJSON(w, r, &input) {
+		return
+	}
+	installation, err := a.accessoryAllocationService.UpdateInstallationCondition(
+		r.Context(), r.PathValue("id"), input, actorUserID(r),
+	)
+	if err != nil {
+		a.accessoryError(w, err, "update accessory installation condition")
+		return
+	}
+	respondJSON(w, http.StatusOK, installation)
+}
+
+func (a *App) getAccessoryAllocationSummary(w http.ResponseWriter, r *http.Request) {
+	summary, err := a.accessoryAllocationService.GetAllocationSummary(r.Context(), r.PathValue("id"))
+	if err != nil {
+		a.accessoryError(w, err, "get accessory allocation summary")
+		return
+	}
+	respondJSON(w, http.StatusOK, summary)
+}

--- a/backend/internal/api/accessory_allocation_handlers_test.go
+++ b/backend/internal/api/accessory_allocation_handlers_test.go
@@ -1,0 +1,214 @@
+package api
+
+import (
+	"net/http"
+	"testing"
+
+	"railkeeper/backend/internal/application"
+	"railkeeper/backend/internal/domain"
+	"railkeeper/backend/internal/infrastructure"
+)
+
+func TestAccessoryAllocationRoutesEnforceMixedRolesAndCSRF(t *testing.T) {
+	router, sessions, product, location, layout := accessoryAllocationRouter(t)
+
+	readPaths := []string{
+		"/api/v1/accessory-reservations",
+		"/api/v1/accessory-installations",
+		"/api/v1/accessory-products/" + product.ID + "/allocation-summary",
+	}
+	for _, path := range readPaths {
+		for role, session := range sessions {
+			response := layoutRequest(t, router, session, http.MethodGet, path, nil, true)
+			want := http.StatusOK
+			if role == "messe" {
+				want = http.StatusForbidden
+			}
+			if response.Code != want {
+				t.Fatalf("%s GET %s: got %d, want %d: %s", role, path, response.Code, want, response.Body.String())
+			}
+		}
+	}
+
+	reservationIDs := map[string]string{}
+	for role, session := range sessions {
+		response := layoutRequest(t, router, session, http.MethodPost, "/api/v1/accessory-reservations",
+			map[string]any{
+				"productId": product.ID, "locationId": location.ID, "quantity": 1, "layoutId": layout.ID,
+			}, true)
+		want := http.StatusForbidden
+		if role == "admin" || role == "editor" || role == "planner" {
+			want = http.StatusCreated
+		}
+		if response.Code != want {
+			t.Fatalf("%s reserve: got %d, want %d: %s", role, response.Code, want, response.Body.String())
+		}
+		if want == http.StatusCreated {
+			var reservation application.AccessoryReservation
+			decodeResponse(t, response, &reservation)
+			reservationIDs[role] = reservation.ID
+		}
+	}
+
+	withoutCSRF := layoutRequest(t, router, sessions["planner"], http.MethodPost,
+		"/api/v1/accessory-reservations", map[string]any{
+			"productId": product.ID, "locationId": location.ID, "quantity": 1, "layoutId": layout.ID,
+		}, false)
+	assertProblem(t, withoutCSRF, http.StatusForbidden, "csrf_required")
+
+	for _, role := range []string{"admin", "editor", "planner"} {
+		path := "/api/v1/accessory-reservations/" + reservationIDs[role] + "/cancel"
+		assertStatus(t, layoutRequest(t, router, sessions[role], http.MethodPost, path, nil, true), http.StatusOK)
+	}
+	for _, role := range []string{"viewer", "messe"} {
+		path := "/api/v1/accessory-reservations/not-allowed/cancel"
+		assertStatus(t, layoutRequest(t, router, sessions[role], http.MethodPost, path, nil, true),
+			http.StatusForbidden)
+	}
+
+	installations := map[string]application.AccessoryInstallation{}
+	for role, session := range sessions {
+		response := layoutRequest(t, router, session, http.MethodPost, "/api/v1/accessory-installations",
+			map[string]any{
+				"productId": product.ID, "sourceLocationId": location.ID, "quantity": 1,
+				"layoutId": layout.ID, "condition": "ready",
+			}, true)
+		want := http.StatusForbidden
+		if role == "admin" || role == "editor" {
+			want = http.StatusCreated
+		}
+		if response.Code != want {
+			t.Fatalf("%s install: got %d, want %d: %s", role, response.Code, want, response.Body.String())
+		}
+		if want == http.StatusCreated {
+			var installation application.AccessoryInstallation
+			decodeResponse(t, response, &installation)
+			installations[role] = installation
+		}
+	}
+
+	conditionPath := "/api/v1/accessory-installations/" + installations["admin"].ID + "/condition"
+	assertStatus(t, layoutRequest(t, router, sessions["admin"], http.MethodPut, conditionPath,
+		map[string]any{"condition": "maintenance_due"}, true), http.StatusOK)
+	removePath := "/api/v1/accessory-installations/" + installations["editor"].ID + "/remove"
+	assertStatus(t, layoutRequest(t, router, sessions["editor"], http.MethodPost, removePath,
+		map[string]any{"disposition": "stored", "storageLocationId": location.ID}, true), http.StatusOK)
+	for _, role := range []string{"planner", "viewer", "messe"} {
+		assertStatus(t, layoutRequest(t, router, sessions[role], http.MethodPut,
+			"/api/v1/accessory-installations/not-allowed/condition",
+			map[string]any{"condition": "ready"}, true), http.StatusForbidden)
+		assertStatus(t, layoutRequest(t, router, sessions[role], http.MethodPost,
+			"/api/v1/accessory-installations/not-allowed/remove",
+			map[string]any{"disposition": "maintenance"}, true), http.StatusForbidden)
+	}
+}
+
+func TestAccessoryAllocationRoutesCoverLifecycleAndSummary(t *testing.T) {
+	router, sessions, product, location, layout := accessoryAllocationRouter(t)
+	editor := sessions["editor"]
+
+	reservationResponse := layoutRequest(t, router, editor, http.MethodPost,
+		"/api/v1/accessory-reservations", map[string]any{
+			"productId": product.ID, "locationId": location.ID, "quantity": 4,
+			"layoutId": layout.ID, "note": "Bahnhof",
+		}, true)
+	assertStatus(t, reservationResponse, http.StatusCreated)
+	var reservation application.AccessoryReservation
+	decodeResponse(t, reservationResponse, &reservation)
+
+	installResponse := layoutRequest(t, router, editor, http.MethodPost,
+		"/api/v1/accessory-installations", map[string]any{
+			"reservationId": reservation.ID, "productId": product.ID, "sourceLocationId": location.ID,
+			"quantity": 4, "layoutId": layout.ID, "condition": "ready", "notes": "Montiert",
+		}, true)
+	assertStatus(t, installResponse, http.StatusCreated)
+	var installation application.AccessoryInstallation
+	decodeResponse(t, installResponse, &installation)
+
+	assertStatus(t, layoutRequest(t, router, editor, http.MethodGet,
+		"/api/v1/accessory-reservations?productId="+product.ID, nil, true), http.StatusOK)
+	assertStatus(t, layoutRequest(t, router, editor, http.MethodGet,
+		"/api/v1/accessory-installations?productId="+product.ID, nil, true), http.StatusOK)
+
+	summaryResponse := layoutRequest(t, router, editor, http.MethodGet,
+		"/api/v1/accessory-products/"+product.ID+"/allocation-summary", nil, true)
+	assertStatus(t, summaryResponse, http.StatusOK)
+	var summary application.AccessoryAllocationSummary
+	decodeResponse(t, summaryResponse, &summary)
+	if summary.Owned != 40 || summary.Stored != 36 || summary.Reserved != 0 || summary.Installed != 4 ||
+		summary.Available != 36 || summary.Missing != 0 {
+		t.Fatalf("unexpected allocation summary: %#v", summary)
+	}
+
+	removeResponse := layoutRequest(t, router, editor, http.MethodPost,
+		"/api/v1/accessory-installations/"+installation.ID+"/remove",
+		map[string]any{"disposition": "maintenance", "notes": "Prüfstand"}, true)
+	assertStatus(t, removeResponse, http.StatusOK)
+
+	invalid := layoutRequest(t, router, editor, http.MethodPost, "/api/v1/accessory-reservations",
+		map[string]any{"productId": product.ID, "locationId": location.ID, "quantity": 1}, true)
+	assertProblem(t, invalid, http.StatusBadRequest, "accessory_validation")
+}
+
+func accessoryAllocationRouter(t *testing.T) (
+	http.Handler,
+	map[string]*application.LoginResult,
+	*application.AccessoryProduct,
+	*application.StorageLocation,
+	*application.Layout,
+) {
+	t.Helper()
+	db := testRouterDB(t)
+	auth := application.NewAuthService(db)
+	for _, user := range []application.CreateUserInput{
+		{Username: "admin", Password: "admin-password", Roles: []string{"Admin"}},
+		{Username: "editor", Password: "editor-password", Roles: []string{"Editor"}},
+		{Username: "viewer", Password: "viewer-password", Roles: []string{"Viewer"}},
+		{Username: "planner", Password: "planner-password", Roles: []string{"Planner"}},
+		{Username: "messe", Password: "messe-password", Roles: []string{"Messe"}},
+	} {
+		if _, err := auth.CreateUser(t.Context(), "", user); err != nil {
+			t.Fatal(err)
+		}
+	}
+	sessions := map[string]*application.LoginResult{
+		"admin":   loginRouteTestUser(t, auth, "admin", "admin-password"),
+		"editor":  loginRouteTestUser(t, auth, "editor", "editor-password"),
+		"viewer":  loginRouteTestUser(t, auth, "viewer", "viewer-password"),
+		"planner": loginRouteTestUser(t, auth, "planner", "planner-password"),
+		"messe":   loginRouteTestUser(t, auth, "messe", "messe-password"),
+	}
+
+	repository := infrastructure.NewAccessoryRepository(db)
+	accessories := application.NewAccessoryService(repository)
+	product, err := accessories.CreateProduct(t.Context(), application.CreateAccessoryProductInput{
+		Manufacturer: "Tillig", ArticleNumber: "83101", Name: "Gerades Gleis",
+		Category: "Gleismaterial", TrackingMode: domain.AccessoryTrackingModeQuantity,
+	}, "seed")
+	if err != nil {
+		t.Fatal(err)
+	}
+	location, err := accessories.CreateLocation(t.Context(), application.CreateStorageLocationInput{Name: "Lager"}, "seed")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := accessories.AdjustStock(t.Context(), product.ID, application.StockAdjustmentInput{
+		LocationID: location.ID, Delta: 40,
+	}, "seed"); err != nil {
+		t.Fatal(err)
+	}
+	layouts := application.NewLayoutService(infrastructure.NewLayoutRepository(db))
+	layout, err := layouts.CreateLayout(t.Context(), application.CreateLayoutInput{
+		Name: "Heimanlage", Kind: domain.LayoutKindPrivate, Gauge: "TT", Scale: "1:120",
+	}, "seed")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	router := NewRouter(Config{
+		AuthService:                auth,
+		AccessoryService:           accessories,
+		AccessoryAllocationService: application.NewAccessoryAllocationService(repository),
+	})
+	return router, sessions, product, location, layout
+}

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -29,6 +29,7 @@ type Config struct {
 	ExhibitionService           *application.ExhibitionService
 	LayoutService               *application.LayoutService
 	AccessoryService            *application.AccessoryService
+	AccessoryAllocationService  *application.AccessoryAllocationService
 	ECoSService                 *application.ECoSService
 	DigitalCenterService        *application.DigitalCenterService
 	SettingsService             *application.SettingsService
@@ -60,6 +61,7 @@ type App struct {
 	exhibitionService           *application.ExhibitionService
 	layoutService               *application.LayoutService
 	accessoryService            *application.AccessoryService
+	accessoryAllocationService  *application.AccessoryAllocationService
 	ecosService                 *application.ECoSService
 	digitalCenterService        *application.DigitalCenterService
 	settingsService             *application.SettingsService
@@ -98,6 +100,7 @@ func NewRouter(config Config) http.Handler {
 		exhibitionService:           config.ExhibitionService,
 		layoutService:               config.LayoutService,
 		accessoryService:            config.AccessoryService,
+		accessoryAllocationService:  config.AccessoryAllocationService,
 		ecosService:                 config.ECoSService,
 		digitalCenterService:        config.DigitalCenterService,
 		settingsService:             config.SettingsService,

--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -5,12 +5,13 @@ import "net/http"
 type routeAccess string
 
 const (
-	routeAccessPublic  routeAccess = "public"
-	routeAccessAdmin   routeAccess = "Admin"
-	routeAccessEditor  routeAccess = "Editor"
-	routeAccessViewer  routeAccess = "Viewer"
-	routeAccessMesse   routeAccess = "Messe"
-	routeAccessPlanner routeAccess = "Planner"
+	routeAccessPublic          routeAccess = "public"
+	routeAccessAdmin           routeAccess = "Admin"
+	routeAccessEditor          routeAccess = "Editor"
+	routeAccessViewer          routeAccess = "Viewer"
+	routeAccessMesse           routeAccess = "Messe"
+	routeAccessPlanner         routeAccess = "Planner"
+	routeAccessEditorOrPlanner routeAccess = "EditorOrPlanner"
 )
 
 type routeHandler func(*App, http.ResponseWriter, *http.Request)
@@ -116,6 +117,14 @@ func apiRouteSpecs() []routeSpec {
 		{http.MethodGet, "/api/v1/accessory-products/{id}/assets", routeAccessViewer, (*App).listAccessoryAssets, nil},
 		{http.MethodPost, "/api/v1/accessory-products/{id}/assets", routeAccessEditor, (*App).createAccessoryAsset, nil},
 		{http.MethodPut, "/api/v1/accessory-assets/{id}", routeAccessEditor, (*App).updateAccessoryAsset, nil},
+		{http.MethodGet, "/api/v1/accessory-products/{id}/allocation-summary", routeAccessViewer, (*App).getAccessoryAllocationSummary, nil},
+		{http.MethodGet, "/api/v1/accessory-reservations", routeAccessViewer, (*App).listAccessoryReservations, nil},
+		{http.MethodPost, "/api/v1/accessory-reservations", routeAccessEditorOrPlanner, (*App).createAccessoryReservation, nil},
+		{http.MethodPost, "/api/v1/accessory-reservations/{id}/cancel", routeAccessEditorOrPlanner, (*App).cancelAccessoryReservation, nil},
+		{http.MethodGet, "/api/v1/accessory-installations", routeAccessViewer, (*App).listAccessoryInstallations, nil},
+		{http.MethodPost, "/api/v1/accessory-installations", routeAccessEditor, (*App).createAccessoryInstallation, nil},
+		{http.MethodPost, "/api/v1/accessory-installations/{id}/remove", routeAccessEditor, (*App).removeAccessoryInstallation, nil},
+		{http.MethodPut, "/api/v1/accessory-installations/{id}/condition", routeAccessEditor, (*App).updateAccessoryInstallationCondition, nil},
 		{http.MethodGet, "/api/v1/storage-locations", routeAccessViewer, (*App).listStorageLocations, nil},
 		{http.MethodPost, "/api/v1/storage-locations", routeAccessEditor, (*App).createStorageLocation, nil},
 		{http.MethodPut, "/api/v1/storage-locations/{id}", routeAccessEditor, (*App).updateStorageLocation, nil},
@@ -169,6 +178,8 @@ func (a *App) registerRoutes(mux *http.ServeMux) {
 		})
 		if route.Authorize != nil {
 			handler = route.Authorize(a, handler)
+		} else if route.Access == routeAccessEditorOrPlanner {
+			handler = a.requireAny([]string{"Editor", "Planner"}, handler)
 		} else if route.Access != routeAccessPublic {
 			handler = a.require(string(route.Access), handler)
 		}

--- a/backend/internal/api/routes_security_test.go
+++ b/backend/internal/api/routes_security_test.go
@@ -27,7 +27,7 @@ func TestAPIRoutesDeclareAccess(t *testing.T) {
 		}
 		switch route.Access {
 		case routeAccessPublic, routeAccessAdmin, routeAccessEditor, routeAccessViewer, routeAccessMesse,
-			routeAccessPlanner:
+			routeAccessPlanner, routeAccessEditorOrPlanner:
 		default:
 			t.Fatalf("route %s %s has invalid access %q", route.Method, route.Path, route.Access)
 		}
@@ -53,11 +53,12 @@ func TestProtectedRoutesRejectUnauthorizedAndInsufficientRoles(t *testing.T) {
 	messe := loginRouteTestUser(t, auth, "messe", "messe-password")
 	planner := loginRouteTestUser(t, auth, "planner", "planner-password")
 	insufficient := map[routeAccess]*application.LoginResult{
-		routeAccessAdmin:   viewer,
-		routeAccessEditor:  planner,
-		routeAccessViewer:  messe,
-		routeAccessMesse:   viewer,
-		routeAccessPlanner: viewer,
+		routeAccessAdmin:           viewer,
+		routeAccessEditor:          planner,
+		routeAccessViewer:          messe,
+		routeAccessMesse:           viewer,
+		routeAccessPlanner:         viewer,
+		routeAccessEditorOrPlanner: viewer,
 	}
 
 	app := &App{authService: auth, logger: slog.Default()}

--- a/openapi/railkeeper.yaml
+++ b/openapi/railkeeper.yaml
@@ -24,6 +24,11 @@ components:
       type: apiKey
       in: cookie
       name: rk_session
+    csrfHeader:
+      type: apiKey
+      in: header
+      name: X-CSRF-Token
+      description: Required together with the session cookie for API mutations.
   schemas:
     Problem:
       type: object
@@ -1161,7 +1166,7 @@ components:
           enum: [ready, maintenance_due, defective, unknown]
         lifecycle:
           type: string
-          enum: [stored, reserved, installed, maintenance, retired]
+          enum: [stored, maintenance, retired]
         storageLocationId:
           type: string
         purchaseDate:
@@ -1286,7 +1291,7 @@ components:
       allOf:
         - $ref: "#/components/schemas/AccessoryAllocationTarget"
         - type: object
-          required: [productId, sourceLocationId, quantity, condition]
+          required: [productId, sourceLocationId, quantity]
           properties:
             reservationId:
               type: string
@@ -1315,6 +1320,16 @@ components:
           type: string
         notes:
           type: string
+      oneOf:
+        - properties:
+            disposition:
+              const: stored
+          required: [storageLocationId]
+        - properties:
+            disposition:
+              enum: [maintenance, defective, retired]
+          not:
+            required: [storageLocationId]
     AccessoryInstallationConditionInput:
       type: object
       required: [condition]
@@ -1391,9 +1406,6 @@ components:
           type: string
         archived:
           type: boolean
-        expectedVersion:
-          type: integer
-          minimum: 1
     UpdateLayoutInput:
       allOf:
         - $ref: "#/components/schemas/LayoutInput"
@@ -1454,9 +1466,6 @@ components:
           minimum: 0
         archived:
           type: boolean
-        expectedVersion:
-          type: integer
-          minimum: 1
     UpdateLayoutUnitInput:
       allOf:
         - $ref: "#/components/schemas/LayoutUnitInput"
@@ -1534,9 +1543,6 @@ components:
           type: string
         description:
           type: string
-        expectedVersion:
-          type: integer
-          minimum: 1
         archived:
           type: boolean
         units:
@@ -2632,6 +2638,7 @@ paths:
       description: Planner, Editor, or Admin role required.
       security:
         - sessionCookie: []
+          csrfHeader: []
       requestBody:
         required: true
         content:
@@ -2651,6 +2658,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Problem"
+        "404":
+          description: Product, location, target, or asset not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Problem"
         "409":
           description: Insufficient or conflicting accessory stock
           content:
@@ -2664,6 +2677,7 @@ paths:
       description: Planner, Editor, or Admin role required.
       security:
         - sessionCookie: []
+          csrfHeader: []
       parameters:
         - name: id
           in: path
@@ -2716,6 +2730,7 @@ paths:
       description: Editor or Admin role required.
       security:
         - sessionCookie: []
+          csrfHeader: []
       requestBody:
         required: true
         content:
@@ -2735,6 +2750,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Problem"
+        "404":
+          description: Product, location, target, asset, or reservation not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Problem"
         "409":
           description: Insufficient or conflicting accessory stock
           content:
@@ -2748,6 +2769,7 @@ paths:
       description: Editor or Admin role required.
       security:
         - sessionCookie: []
+          csrfHeader: []
       parameters:
         - name: id
           in: path
@@ -2792,6 +2814,7 @@ paths:
       description: Editor or Admin role required.
       security:
         - sessionCookie: []
+          csrfHeader: []
       parameters:
         - name: id
           in: path

--- a/openapi/railkeeper.yaml
+++ b/openapi/railkeeper.yaml
@@ -1172,6 +1172,180 @@ components:
           type: string
         notes:
           type: string
+    AccessoryAllocationTarget:
+      type: object
+      properties:
+        vehicleId:
+          type: string
+        layoutId:
+          type: string
+        layoutUnitId:
+          type: string
+      oneOf:
+        - required: [vehicleId]
+          not:
+            anyOf:
+              - required: [layoutId]
+              - required: [layoutUnitId]
+        - required: [layoutId]
+          not:
+            anyOf:
+              - required: [vehicleId]
+              - required: [layoutUnitId]
+        - required: [layoutUnitId]
+          not:
+            anyOf:
+              - required: [vehicleId]
+              - required: [layoutId]
+    AccessoryReservation:
+      allOf:
+        - $ref: "#/components/schemas/AccessoryAllocationTarget"
+        - type: object
+          required: [id, productId, locationId, quantity, status, createdBy, createdAt, updatedAt]
+          properties:
+            id:
+              type: string
+            productId:
+              type: string
+            assetId:
+              type: string
+            locationId:
+              type: string
+            quantity:
+              type: integer
+              minimum: 1
+            status:
+              type: string
+              enum: [active, fulfilled, cancelled]
+            note:
+              type: string
+            createdBy:
+              type: string
+            createdAt:
+              type: string
+              format: date-time
+            updatedAt:
+              type: string
+              format: date-time
+    AccessoryReservationInput:
+      allOf:
+        - $ref: "#/components/schemas/AccessoryAllocationTarget"
+        - type: object
+          required: [productId, locationId, quantity]
+          properties:
+            productId:
+              type: string
+            assetId:
+              type: string
+            locationId:
+              type: string
+            quantity:
+              type: integer
+              minimum: 1
+            note:
+              type: string
+    AccessoryInstallation:
+      allOf:
+        - $ref: "#/components/schemas/AccessoryAllocationTarget"
+        - type: object
+          required:
+            [id, productId, sourceLocationId, quantity, condition, installedBy, installedAt]
+          properties:
+            id:
+              type: string
+            productId:
+              type: string
+            assetId:
+              type: string
+            sourceLocationId:
+              type: string
+            quantity:
+              type: integer
+              minimum: 1
+            condition:
+              type: string
+              enum: [ready, maintenance_due, defective, unknown]
+            installedBy:
+              type: string
+            installedAt:
+              type: string
+              format: date-time
+            removedBy:
+              type: string
+            removedAt:
+              type: string
+              format: date-time
+            removalDisposition:
+              type: string
+              enum: [stored, maintenance, defective, retired]
+            notes:
+              type: string
+            removalNotes:
+              type: string
+    AccessoryInstallationInput:
+      allOf:
+        - $ref: "#/components/schemas/AccessoryAllocationTarget"
+        - type: object
+          required: [productId, sourceLocationId, quantity, condition]
+          properties:
+            reservationId:
+              type: string
+            productId:
+              type: string
+            assetId:
+              type: string
+            sourceLocationId:
+              type: string
+            quantity:
+              type: integer
+              minimum: 1
+            condition:
+              type: string
+              enum: [ready, maintenance_due, defective, unknown]
+            notes:
+              type: string
+    AccessoryInstallationRemovalInput:
+      type: object
+      required: [disposition]
+      properties:
+        disposition:
+          type: string
+          enum: [stored, maintenance, defective, retired]
+        storageLocationId:
+          type: string
+        notes:
+          type: string
+    AccessoryInstallationConditionInput:
+      type: object
+      required: [condition]
+      properties:
+        condition:
+          type: string
+          enum: [ready, maintenance_due, defective, unknown]
+    AccessoryAllocationSummary:
+      type: object
+      required: [productId, owned, stored, reserved, installed, available, missing]
+      properties:
+        productId:
+          type: string
+        owned:
+          type: integer
+          minimum: 0
+        stored:
+          type: integer
+          minimum: 0
+        reserved:
+          type: integer
+          minimum: 0
+        installed:
+          type: integer
+          minimum: 0
+        available:
+          type: integer
+          minimum: 0
+        missing:
+          type: integer
+          minimum: 0
     Layout:
       type: object
       required: [id, name, kind, gauge, scale, version, archived, createdAt, updatedAt]
@@ -2401,6 +2575,256 @@ paths:
                 $ref: "#/components/schemas/Problem"
         "409":
           description: Accessory asset conflicts with existing data
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+  /accessory-products/{id}/allocation-summary:
+    get:
+      tags: [Accessories]
+      summary: Get owned, stored, reserved, installed, available, and missing quantities
+      description: Viewer, Planner, Editor, or Admin role required.
+      security:
+        - sessionCookie: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Accessory allocation summary
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AccessoryAllocationSummary"
+        "404":
+          description: Accessory product not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+  /accessory-reservations:
+    get:
+      tags: [Accessories]
+      summary: List accessory reservations
+      description: Viewer, Planner, Editor, or Admin role required.
+      security:
+        - sessionCookie: []
+      parameters:
+        - name: productId
+          in: query
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Accessory reservation list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/AccessoryReservation"
+    post:
+      tags: [Accessories]
+      summary: Reserve accessory stock or an individual asset
+      description: Planner, Editor, or Admin role required.
+      security:
+        - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AccessoryReservationInput"
+      responses:
+        "201":
+          description: Accessory reservation created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AccessoryReservation"
+        "400":
+          description: Invalid reservation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "409":
+          description: Insufficient or conflicting accessory stock
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+  /accessory-reservations/{id}/cancel:
+    post:
+      tags: [Accessories]
+      summary: Cancel an active accessory reservation
+      description: Planner, Editor, or Admin role required.
+      security:
+        - sessionCookie: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Cancelled accessory reservation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AccessoryReservation"
+        "404":
+          description: Accessory reservation not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "409":
+          description: Accessory reservation is no longer active
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+  /accessory-installations:
+    get:
+      tags: [Accessories]
+      summary: List accessory installation history
+      description: Viewer, Planner, Editor, or Admin role required.
+      security:
+        - sessionCookie: []
+      parameters:
+        - name: productId
+          in: query
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Accessory installation list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/AccessoryInstallation"
+    post:
+      tags: [Accessories]
+      summary: Install accessory stock or an individual asset
+      description: Editor or Admin role required.
+      security:
+        - sessionCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AccessoryInstallationInput"
+      responses:
+        "201":
+          description: Accessory installation created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AccessoryInstallation"
+        "400":
+          description: Invalid installation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "409":
+          description: Insufficient or conflicting accessory stock
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+  /accessory-installations/{id}/remove:
+    post:
+      tags: [Accessories]
+      summary: Remove an active accessory installation
+      description: Editor or Admin role required.
+      security:
+        - sessionCookie: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AccessoryInstallationRemovalInput"
+      responses:
+        "200":
+          description: Closed accessory installation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AccessoryInstallation"
+        "400":
+          description: Invalid removal disposition
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "404":
+          description: Accessory installation not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "409":
+          description: Accessory installation is already closed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+  /accessory-installations/{id}/condition:
+    put:
+      tags: [Accessories]
+      summary: Update the condition of an installed accessory
+      description: Editor or Admin role required.
+      security:
+        - sessionCookie: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AccessoryInstallationConditionInput"
+      responses:
+        "200":
+          description: Updated accessory installation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AccessoryInstallation"
+        "400":
+          description: Invalid condition
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "404":
+          description: Accessory installation not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "409":
+          description: Accessory installation is already closed
           content:
             application/json:
               schema:


### PR DESCRIPTION
## Deutsch

Schließt die HTTP- und Rollen-Scheibe der Zubehör-Reservierungen und Einbauhistorie ab.

### Inhalt

- stellt Reservierungen, Stornierung, Einbau, Ausbau und Zustandsänderung über HTTP bereit
- erlaubt Reservieren und Stornieren für Planner, Editor und Admin
- beschränkt Einbau, Ausbau und Zustandsänderung auf Editor und Admin
- erlaubt lesenden Zugriff für Viewer, Planner, Editor und Admin, nicht für Messe
- ergänzt die fehlende Bestandszusammenfassung mit `owned`, `stored`, `reserved`, `installed`, `available` und `missing`
- bindet den transaktionalen SQLite-Owner in den Programmstart ein
- dokumentiert Routen, Rollen und JSON-Schemas in OpenAPI
- prüft Rollenmatrix, CSRF, vollständigen Lifecycle, Produktfilter und Summenberechnung

### Prüfung

- `go test ./internal/api -count=1`
- `go test ./...`
- `go vet ./...`
- `git diff --check`
- `npm.cmd run build`

Der lokale Windows-Go-Lauf unterstützt weiterhin kein `-race`, weil CGO deaktiviert ist. Es wird kein lokales Race-Ergebnis behauptet.

## English

Completes the HTTP and role slice for accessory reservations and installation history.

### Included

- exposes reservations, cancellation, installation, removal, and condition changes over HTTP
- allows Planner, Editor, and Admin to reserve and cancel
- restricts installation, removal, and condition changes to Editor and Admin
- allows read access for Viewer, Planner, Editor, and Admin, but not Messe
- adds the missing allocation summary with `owned`, `stored`, `reserved`, `installed`, `available`, and `missing`
- wires the transactional SQLite owner into application startup
- documents routes, roles, and JSON schemas in OpenAPI
- tests the role matrix, CSRF, full lifecycle, product filtering, and summary calculation

### Verification

- `go test ./internal/api -count=1`
- `go test ./...`
- `go vet ./...`
- `git diff --check`
- `npm.cmd run build`

The local Windows Go runtime still cannot run `-race` because CGO is disabled. No local race result is claimed.

Closes #39