### PR TITLE
feat(api): add typed layout and accessory client

### DIFF
--- a/backend/internal/api/openapi_contract_test.go
+++ b/backend/internal/api/openapi_contract_test.go
@@ -39,17 +39,45 @@ func TestOpenAPIDocumentsRegisteredAPIRoutes(t *testing.T) {
 
 func TestFrontendAPIAdapterUsesDocumentedRoutes(t *testing.T) {
 	operations := readOpenAPIOperations(t)
-	data, err := os.ReadFile(filepath.Join("..", "..", "..", "frontend", "src", "shared", "api.ts"))
+	files, err := filepath.Glob(filepath.Join("..", "..", "..", "frontend", "src", "shared", "api*.ts"))
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	for _, operation := range frontendAPIOperations(string(data)) {
-		if operation.Path == "" {
+	for _, file := range files {
+		if strings.HasSuffix(file, ".test.ts") {
 			continue
 		}
-		if !openAPIOperationExists(operations, operation) {
-			t.Fatalf("frontend API adapter uses undocumented operation %s %s", operation.Method, operation.Path)
+		data, readErr := os.ReadFile(file)
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		for _, operation := range frontendAPIOperations(string(data)) {
+			if operation.Path != "" && !openAPIOperationExists(operations, operation) {
+				t.Fatalf("%s uses undocumented operation %s %s", filepath.Base(file), operation.Method, operation.Path)
+			}
+		}
+	}
+}
+
+func TestOpenAPIDocumentsLayoutAndAccessorySchemas(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "..", "..", "openapi", "railkeeper.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	contract := string(data)
+	want := []string{
+		"Layout", "LayoutInput", "UpdateLayoutInput", "LayoutUnit", "LayoutUnitInput",
+		"UpdateLayoutUnitInput", "LayoutConfiguration", "LayoutConfigurationInput",
+		"UpdateLayoutConfigurationInput", "PlanVariant", "PlanVariantInput", "PlanRevision",
+		"PlanRevisionInput", "PlanRevisionTransitionInput", "AccessoryProduct", "AccessoryProductInput",
+		"StorageLocation", "StorageLocationInput", "AccessoryStockSummary", "AccessoryStockAdjustmentInput",
+		"AccessoryAsset", "AccessoryAssetInput", "AccessoryAllocationTarget", "AccessoryReservation",
+		"AccessoryReservationInput", "AccessoryInstallation", "AccessoryInstallationInput",
+		"AccessoryInstallationRemovalInput", "AccessoryInstallationConditionInput", "AccessoryAllocationSummary",
+	}
+	for _, schema := range want {
+		if !strings.Contains(contract, "    "+schema+":\n") {
+			t.Errorf("OpenAPI contract is missing schema %s", schema)
 		}
 	}
 }
@@ -66,7 +94,8 @@ const api = {
   update: () => request<UserSession>("/auth/password", { method: "PUT" }),
   dynamic: (id: string) => request<void>(` + "`/sessions/${encodeURIComponent(id)}/revoke`" + `, {
     method: "PUT"
-  })
+  }),
+  helper: () => request<void>("/layouts", json("POST", input))
 };
 `
 
@@ -76,6 +105,7 @@ const api = {
 		{Method: "GET", Path: "/auth/session"},
 		{Method: "PUT", Path: "/auth/password"},
 		{Method: "PUT", Path: "/sessions/{}/revoke"},
+		{Method: "POST", Path: "/layouts"},
 	}
 	if len(operations) != len(expected) {
 		t.Fatalf("expected %#v, got %#v", expected, operations)
@@ -155,6 +185,7 @@ func frontendAPIOperations(source string) []frontendAPIOperation {
 
 func extractRequestOperations(source string) []frontendAPIOperation {
 	methodPattern := regexp.MustCompile(`method:\s*["'](GET|POST|PUT|DELETE|PATCH)["']`)
+	jsonHelperPattern := regexp.MustCompile(`json\(\s*["'](POST|PUT|PATCH)["']`)
 	paths := []frontendAPIOperation{}
 	searchFrom := 0
 	for {
@@ -183,7 +214,10 @@ func extractRequestOperations(source string) []frontendAPIOperation {
 		if strings.HasPrefix(path, "/") {
 			method := "GET"
 			if callEnd := findCallEnd(source, index+argumentStart); callEnd > next {
-				if match := methodPattern.FindStringSubmatch(source[next:callEnd]); len(match) == 2 {
+				call := source[next:callEnd]
+				if match := methodPattern.FindStringSubmatch(call); len(match) == 2 {
+					method = match[1]
+				} else if match := jsonHelperPattern.FindStringSubmatch(call); len(match) == 2 {
 					method = match[1]
 				}
 			}

--- a/frontend/src/shared/api.ts
+++ b/frontend/src/shared/api.ts
@@ -1,3 +1,7 @@
+import { createLayoutsAccessoriesAPI } from "./apiLayoutsAccessories";
+
+export * from "./apiLayoutsAccessories";
+
 export type SetupStatus = {
   setupRequired: boolean;
 };
@@ -1074,6 +1078,7 @@ async function request<T>(path: string, init: RequestInit = {}, options: Request
 }
 
 export const api = {
+  ...createLayoutsAccessoriesAPI(request),
   setupStatus: () => request<SetupStatus>("/setup/status"),
   createAdmin: (input: CreateAdminRequest) =>
     request<{ status: string }>("/setup/admin", {

--- a/frontend/src/shared/apiLayoutsAccessories.test.ts
+++ b/frontend/src/shared/apiLayoutsAccessories.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { api } from "./api";
+
+describe("layout and accessory API client", () => {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: async () => ({})
+  });
+
+  beforeEach(() => {
+    fetchMock.mockClear();
+    vi.stubGlobal("fetch", fetchMock);
+    document.cookie = "rk_csrf=client-test-token; path=/";
+  });
+
+  it("encodes layout paths, methods, bodies, and CSRF headers", async () => {
+    const layoutInput = {
+      name: "Clubanlage",
+      kind: "club" as const,
+      gauge: "TT",
+      scale: "1:120",
+      description: "Vereinsanlage",
+      archived: false
+    };
+    const unitInput = {
+      name: "Modul 1",
+      kind: "module" as const,
+      ownerLabel: "Daniel",
+      widthMm: 1000,
+      heightMm: 500,
+      archived: false
+    };
+    const configurationInput = {
+      name: "Ausstellung",
+      description: "Aufbau A",
+      expectedVersion: 2,
+      archived: false,
+      units: [{
+        unitId: "unit/1",
+        planRevisionId: "revision/1",
+        positionXMm: 10,
+        positionYMm: 20,
+        rotationDegrees: 90,
+        sortOrder: 0
+      }]
+    };
+
+    await api.layouts();
+    await api.createLayout(layoutInput);
+    await api.layout("layout/1");
+    await api.updateLayout("layout/1", { ...layoutInput, expectedVersion: 3 });
+    await api.layoutUnits("layout/1");
+    await api.createLayoutUnit("layout/1", unitInput);
+    await api.updateLayoutUnit("unit/1", { ...unitInput, expectedVersion: 2 });
+    await api.layoutConfigurations("layout/1");
+    await api.createLayoutConfiguration("layout/1", configurationInput);
+    await api.updateLayoutConfiguration("configuration/1", configurationInput);
+    await api.planVariants("unit/1");
+    await api.createPlanVariant("unit/1", { name: "Sommer", description: "Variante" });
+    await api.createPlanRevision("variant/1", { baseRevisionId: "revision/1" });
+    await api.submitPlanRevision("revision/1", 4);
+    await api.publishPlanRevision("revision/1", 5);
+
+    expectRequests([
+      ["GET", "/api/v1/layouts"],
+      ["POST", "/api/v1/layouts", layoutInput],
+      ["GET", "/api/v1/layouts/layout%2F1"],
+      ["PUT", "/api/v1/layouts/layout%2F1", { ...layoutInput, expectedVersion: 3 }],
+      ["GET", "/api/v1/layouts/layout%2F1/units"],
+      ["POST", "/api/v1/layouts/layout%2F1/units", unitInput],
+      ["PUT", "/api/v1/layout-units/unit%2F1", { ...unitInput, expectedVersion: 2 }],
+      ["GET", "/api/v1/layouts/layout%2F1/configurations"],
+      ["POST", "/api/v1/layouts/layout%2F1/configurations", configurationInput],
+      ["PUT", "/api/v1/layout-configurations/configuration%2F1", configurationInput],
+      ["GET", "/api/v1/layout-units/unit%2F1/plan-variants"],
+      ["POST", "/api/v1/layout-units/unit%2F1/plan-variants", { name: "Sommer", description: "Variante" }],
+      ["POST", "/api/v1/plan-variants/variant%2F1/revisions", { baseRevisionId: "revision/1" }],
+      ["POST", "/api/v1/plan-revisions/revision%2F1/submit", { expectedVersion: 4 }],
+      ["POST", "/api/v1/plan-revisions/revision%2F1/publish", { expectedVersion: 5 }]
+    ]);
+  });
+
+  it("encodes accessory paths, filters, bodies, and CSRF headers", async () => {
+    const productInput = {
+      manufacturer: "Tillig",
+      articleNumber: "83101",
+      name: "Gerades Gleis",
+      category: "Gleismaterial",
+      trackingMode: "quantity" as const,
+      description: "Modellgleis"
+    };
+    const locationInput = { name: "Schrank A", parentId: "room/1", description: "Fach 2", archived: false };
+    const assetInput = {
+      inventoryNumber: "RK-Z-0001",
+      serialNumber: "123",
+      condition: "ready" as const,
+      lifecycle: "stored" as const,
+      storageLocationId: "location/1",
+      purchaseDate: "2026-08-07",
+      purchasePrice: "19.90",
+      warrantyUntil: "2028-08-07",
+      notes: "Test"
+    };
+    const reservationInput = {
+      productId: "product/1",
+      locationId: "location/1",
+      quantity: 2,
+      layoutId: "layout/1" as const,
+      note: "Bahnhof"
+    };
+    const installationInput = {
+      reservationId: "reservation/1",
+      productId: "product/1",
+      sourceLocationId: "location/1",
+      quantity: 2,
+      layoutId: "layout/1" as const,
+      condition: "ready" as const,
+      notes: "Montiert"
+    };
+
+    await api.accessoryProducts("Tillig & TT");
+    await api.createAccessoryProduct(productInput);
+    await api.accessoryProduct("product/1");
+    await api.updateAccessoryProduct("product/1", productInput);
+    await api.storageLocations();
+    await api.createStorageLocation(locationInput);
+    await api.updateStorageLocation("location/1", locationInput);
+    await api.accessoryStock("product/1");
+    await api.adjustAccessoryStock("product/1", { locationId: "location/1", delta: 5 });
+    await api.accessoryAssets("product/1");
+    await api.createAccessoryAsset("product/1", assetInput);
+    await api.updateAccessoryAsset("asset/1", assetInput);
+    await api.accessoryAllocationSummary("product/1");
+    await api.accessoryReservations("product/1");
+    await api.createAccessoryReservation(reservationInput);
+    await api.cancelAccessoryReservation("reservation/1");
+    await api.accessoryInstallations("product/1");
+    await api.createAccessoryInstallation(installationInput);
+    await api.removeAccessoryInstallation("installation/1", {
+      disposition: "stored",
+      storageLocationId: "location/1",
+      notes: "Ausgebaut"
+    });
+    await api.updateAccessoryInstallationCondition("installation/1", { condition: "maintenance_due" });
+
+    expectRequests([
+      ["GET", "/api/v1/accessory-products?query=Tillig%20%26%20TT"],
+      ["POST", "/api/v1/accessory-products", productInput],
+      ["GET", "/api/v1/accessory-products/product%2F1"],
+      ["PUT", "/api/v1/accessory-products/product%2F1", productInput],
+      ["GET", "/api/v1/storage-locations"],
+      ["POST", "/api/v1/storage-locations", locationInput],
+      ["PUT", "/api/v1/storage-locations/location%2F1", locationInput],
+      ["GET", "/api/v1/accessory-products/product%2F1/stock"],
+      ["POST", "/api/v1/accessory-products/product%2F1/stock-adjustments", { locationId: "location/1", delta: 5 }],
+      ["GET", "/api/v1/accessory-products/product%2F1/assets"],
+      ["POST", "/api/v1/accessory-products/product%2F1/assets", assetInput],
+      ["PUT", "/api/v1/accessory-assets/asset%2F1", assetInput],
+      ["GET", "/api/v1/accessory-products/product%2F1/allocation-summary"],
+      ["GET", "/api/v1/accessory-reservations?productId=product%2F1"],
+      ["POST", "/api/v1/accessory-reservations", reservationInput],
+      ["POST", "/api/v1/accessory-reservations/reservation%2F1/cancel"],
+      ["GET", "/api/v1/accessory-installations?productId=product%2F1"],
+      ["POST", "/api/v1/accessory-installations", installationInput],
+      ["POST", "/api/v1/accessory-installations/installation%2F1/remove", {
+        disposition: "stored", storageLocationId: "location/1", notes: "Ausgebaut"
+      }],
+      ["PUT", "/api/v1/accessory-installations/installation%2F1/condition", {
+        condition: "maintenance_due"
+      }]
+    ]);
+  });
+
+  function expectRequests(expected: Array<[string, string, object?]>) {
+    expect(fetchMock).toHaveBeenCalledTimes(expected.length);
+    expected.forEach(([method, path, body], index) => {
+      const [url, init] = fetchMock.mock.calls[index];
+      expect(url).toBe(path);
+      expect(init.method ?? "GET").toBe(method);
+      expect(init.body).toBe(body === undefined ? undefined : JSON.stringify(body));
+      if (method === "GET") {
+        expect(init.headers["X-CSRF-Token"]).toBeUndefined();
+      } else {
+        expect(init.headers["X-CSRF-Token"]).toBe("client-test-token");
+      }
+    });
+  }
+});

--- a/frontend/src/shared/apiLayoutsAccessories.test.ts
+++ b/frontend/src/shared/apiLayoutsAccessories.test.ts
@@ -29,8 +29,6 @@ describe("layout and accessory API client", () => {
       name: "Modul 1",
       kind: "module" as const,
       ownerLabel: "Daniel",
-      widthMm: 1000,
-      heightMm: 500,
       archived: false
     };
     const configurationInput = {
@@ -43,8 +41,7 @@ describe("layout and accessory API client", () => {
         planRevisionId: "revision/1",
         positionXMm: 10,
         positionYMm: 20,
-        rotationDegrees: 90,
-        sortOrder: 0
+        rotationDegrees: 90
       }]
     };
 

--- a/frontend/src/shared/apiLayoutsAccessories.ts
+++ b/frontend/src/shared/apiLayoutsAccessories.ts
@@ -44,8 +44,8 @@ export type LayoutUnitInput = {
   name: string;
   kind: LayoutUnitKind;
   ownerLabel?: string;
-  widthMm: number;
-  heightMm: number;
+  widthMm?: number;
+  heightMm?: number;
   archived?: boolean;
 };
 
@@ -58,6 +58,14 @@ export type ConfigurationUnit = {
   positionYMm: number;
   rotationDegrees: number;
   sortOrder: number;
+};
+
+export type ConfigurationUnitInput = {
+  unitId: string;
+  planRevisionId?: string;
+  positionXMm?: number;
+  positionYMm?: number;
+  rotationDegrees?: number;
 };
 
 export type LayoutConfiguration = {
@@ -76,7 +84,7 @@ export type LayoutConfigurationInput = {
   name: string;
   description?: string;
   archived?: boolean;
-  units: ConfigurationUnit[];
+  units: ConfigurationUnitInput[];
 };
 
 export type LayoutConfigurationUpdateInput = LayoutConfigurationInput & { expectedVersion: number };
@@ -249,11 +257,13 @@ export type AccessoryInstallationInput = AllocationTarget & {
   notes?: string;
 };
 
-export type AccessoryInstallationRemovalInput = {
-  disposition: AccessoryRemovalDisposition;
-  storageLocationId?: string;
-  notes?: string;
-};
+export type AccessoryInstallationRemovalInput =
+  | { disposition: "stored"; storageLocationId: string; notes?: string }
+  | {
+      disposition: Exclude<AccessoryRemovalDisposition, "stored">;
+      storageLocationId?: never;
+      notes?: string;
+    };
 
 export type AccessoryInstallationConditionInput = { condition: AccessoryCondition };
 

--- a/frontend/src/shared/apiLayoutsAccessories.ts
+++ b/frontend/src/shared/apiLayoutsAccessories.ts
@@ -1,0 +1,351 @@
+export type LayoutKind = "private" | "club";
+export type LayoutUnitKind = "baseboard" | "module" | "segment" | "area";
+export type PlanRevisionStatus = "draft" | "review" | "published" | "archived";
+
+export type Layout = {
+  id: string;
+  name: string;
+  kind: LayoutKind;
+  gauge: string;
+  scale: string;
+  description?: string;
+  version: number;
+  archived: boolean;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type LayoutInput = {
+  name: string;
+  kind: LayoutKind;
+  gauge: string;
+  scale: string;
+  description?: string;
+  archived?: boolean;
+};
+
+export type LayoutUpdateInput = LayoutInput & { expectedVersion: number };
+
+export type LayoutUnit = {
+  id: string;
+  layoutId: string;
+  name: string;
+  kind: LayoutUnitKind;
+  ownerLabel?: string;
+  widthMm: number;
+  heightMm: number;
+  version: number;
+  archived: boolean;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type LayoutUnitInput = {
+  name: string;
+  kind: LayoutUnitKind;
+  ownerLabel?: string;
+  widthMm: number;
+  heightMm: number;
+  archived?: boolean;
+};
+
+export type LayoutUnitUpdateInput = LayoutUnitInput & { expectedVersion: number };
+
+export type ConfigurationUnit = {
+  unitId: string;
+  planRevisionId?: string;
+  positionXMm: number;
+  positionYMm: number;
+  rotationDegrees: number;
+  sortOrder: number;
+};
+
+export type LayoutConfiguration = {
+  id: string;
+  layoutId: string;
+  name: string;
+  description?: string;
+  version: number;
+  archived: boolean;
+  units: ConfigurationUnit[];
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type LayoutConfigurationInput = {
+  name: string;
+  description?: string;
+  archived?: boolean;
+  units: ConfigurationUnit[];
+};
+
+export type LayoutConfigurationUpdateInput = LayoutConfigurationInput & { expectedVersion: number };
+
+export type PlanRevision = {
+  id: string;
+  variantId: string;
+  revisionNumber: number;
+  status: PlanRevisionStatus;
+  baseRevisionId?: string;
+  version: number;
+  createdBy: string;
+  publishedBy?: string;
+  publishedAt?: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type PlanVariant = {
+  id: string;
+  layoutUnitId: string;
+  name: string;
+  description?: string;
+  archived: boolean;
+  revisions: PlanRevision[];
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type PlanVariantInput = { name: string; description?: string };
+export type PlanRevisionInput = { baseRevisionId?: string };
+
+export type AccessoryTrackingMode = "quantity" | "individual";
+export type AccessoryCondition = "ready" | "maintenance_due" | "defective" | "unknown";
+export type AccessoryLifecycle = "stored" | "reserved" | "installed" | "maintenance" | "retired";
+export type AccessoryReservationStatus = "active" | "fulfilled" | "cancelled";
+export type AccessoryRemovalDisposition = "stored" | "maintenance" | "defective" | "retired";
+
+export type AccessoryProduct = {
+  id: string;
+  manufacturer: string;
+  articleNumber?: string;
+  name: string;
+  category: string;
+  trackingMode: AccessoryTrackingMode;
+  description?: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type AccessoryProductInput = {
+  manufacturer: string;
+  articleNumber?: string;
+  name: string;
+  category: string;
+  trackingMode: AccessoryTrackingMode;
+  description?: string;
+};
+
+export type StorageLocation = {
+  id: string;
+  parentId?: string;
+  name: string;
+  description?: string;
+  archived: boolean;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type StorageLocationInput = {
+  parentId?: string;
+  name: string;
+  description?: string;
+  archived?: boolean;
+};
+
+export type AccessoryStockLevel = {
+  locationId: string;
+  locationName: string;
+  quantity: number;
+  updatedAt: string;
+};
+
+export type AccessoryStockSummary = {
+  productId: string;
+  trackingMode: AccessoryTrackingMode;
+  totalQuantity: number;
+  locations: AccessoryStockLevel[];
+};
+
+export type AccessoryStockAdjustmentInput = { locationId: string; delta: number };
+
+export type AccessoryAsset = {
+  id: string;
+  productId: string;
+  inventoryNumber?: string;
+  serialNumber?: string;
+  condition: AccessoryCondition;
+  lifecycle: AccessoryLifecycle;
+  storageLocationId?: string;
+  purchaseDate?: string;
+  purchasePrice?: string;
+  warrantyUntil?: string;
+  notes?: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type AccessoryAssetInput = {
+  inventoryNumber?: string;
+  serialNumber?: string;
+  condition?: AccessoryCondition;
+  lifecycle?: Exclude<AccessoryLifecycle, "reserved" | "installed">;
+  storageLocationId?: string;
+  purchaseDate?: string;
+  purchasePrice?: string;
+  warrantyUntil?: string;
+  notes?: string;
+};
+
+export type AllocationTarget =
+  | { vehicleId: string; layoutId?: never; layoutUnitId?: never }
+  | { vehicleId?: never; layoutId: string; layoutUnitId?: never }
+  | { vehicleId?: never; layoutId?: never; layoutUnitId: string };
+
+export type AccessoryReservation = AllocationTarget & {
+  id: string;
+  productId: string;
+  assetId?: string;
+  locationId: string;
+  quantity: number;
+  status: AccessoryReservationStatus;
+  note?: string;
+  createdBy: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type AccessoryReservationInput = AllocationTarget & {
+  productId: string;
+  assetId?: string;
+  locationId: string;
+  quantity: number;
+  note?: string;
+};
+
+export type AccessoryInstallation = AllocationTarget & {
+  id: string;
+  productId: string;
+  assetId?: string;
+  sourceLocationId: string;
+  quantity: number;
+  condition: AccessoryCondition;
+  installedBy: string;
+  installedAt: string;
+  removedBy?: string;
+  removedAt?: string;
+  removalDisposition?: AccessoryRemovalDisposition;
+  notes?: string;
+  removalNotes?: string;
+};
+
+export type AccessoryInstallationInput = AllocationTarget & {
+  reservationId?: string;
+  productId: string;
+  assetId?: string;
+  sourceLocationId: string;
+  quantity: number;
+  condition?: AccessoryCondition;
+  notes?: string;
+};
+
+export type AccessoryInstallationRemovalInput = {
+  disposition: AccessoryRemovalDisposition;
+  storageLocationId?: string;
+  notes?: string;
+};
+
+export type AccessoryInstallationConditionInput = { condition: AccessoryCondition };
+
+export type AccessoryAllocationSummary = {
+  productId: string;
+  owned: number;
+  stored: number;
+  reserved: number;
+  installed: number;
+  available: number;
+  missing: number;
+};
+
+type RequestOptions = { retries?: number; timeoutMs?: number };
+type APIRequest = <T>(path: string, init?: RequestInit, options?: RequestOptions) => Promise<T>;
+
+export function createLayoutsAccessoriesAPI(request: APIRequest) {
+  const productQuery = (productId?: string) => productId ? `?productId=${encodeURIComponent(productId)}` : "";
+  return {
+    layouts: () => request<Layout[]>("/layouts"),
+    createLayout: (input: LayoutInput) => request<Layout>("/layouts", json("POST", input)),
+    layout: (id: string) => request<Layout>(`/layouts/${encodeURIComponent(id)}`),
+    updateLayout: (id: string, input: LayoutUpdateInput) =>
+      request<Layout>(`/layouts/${encodeURIComponent(id)}`, json("PUT", input)),
+    layoutUnits: (layoutId: string) => request<LayoutUnit[]>(`/layouts/${encodeURIComponent(layoutId)}/units`),
+    createLayoutUnit: (layoutId: string, input: LayoutUnitInput) =>
+      request<LayoutUnit>(`/layouts/${encodeURIComponent(layoutId)}/units`, json("POST", input)),
+    updateLayoutUnit: (id: string, input: LayoutUnitUpdateInput) =>
+      request<LayoutUnit>(`/layout-units/${encodeURIComponent(id)}`, json("PUT", input)),
+    layoutConfigurations: (layoutId: string) =>
+      request<LayoutConfiguration[]>(`/layouts/${encodeURIComponent(layoutId)}/configurations`),
+    createLayoutConfiguration: (layoutId: string, input: LayoutConfigurationInput) =>
+      request<LayoutConfiguration>(`/layouts/${encodeURIComponent(layoutId)}/configurations`, json("POST", input)),
+    updateLayoutConfiguration: (id: string, input: LayoutConfigurationUpdateInput) =>
+      request<LayoutConfiguration>(`/layout-configurations/${encodeURIComponent(id)}`, json("PUT", input)),
+    planVariants: (unitId: string) =>
+      request<PlanVariant[]>(`/layout-units/${encodeURIComponent(unitId)}/plan-variants`),
+    createPlanVariant: (unitId: string, input: PlanVariantInput) =>
+      request<PlanVariant>(`/layout-units/${encodeURIComponent(unitId)}/plan-variants`, json("POST", input)),
+    createPlanRevision: (variantId: string, input: PlanRevisionInput) =>
+      request<PlanRevision>(`/plan-variants/${encodeURIComponent(variantId)}/revisions`, json("POST", input)),
+    submitPlanRevision: (id: string, expectedVersion: number) =>
+      request<PlanRevision>(`/plan-revisions/${encodeURIComponent(id)}/submit`, json("POST", { expectedVersion })),
+    publishPlanRevision: (id: string, expectedVersion: number) =>
+      request<PlanRevision>(`/plan-revisions/${encodeURIComponent(id)}/publish`, json("POST", { expectedVersion })),
+    accessoryProducts: (query = "") =>
+      request<AccessoryProduct[]>(`/accessory-products${query ? `?query=${encodeURIComponent(query)}` : ""}`),
+    createAccessoryProduct: (input: AccessoryProductInput) =>
+      request<AccessoryProduct>("/accessory-products", json("POST", input)),
+    accessoryProduct: (id: string) => request<AccessoryProduct>(`/accessory-products/${encodeURIComponent(id)}`),
+    updateAccessoryProduct: (id: string, input: AccessoryProductInput) =>
+      request<AccessoryProduct>(`/accessory-products/${encodeURIComponent(id)}`, json("PUT", input)),
+    storageLocations: () => request<StorageLocation[]>("/storage-locations"),
+    createStorageLocation: (input: StorageLocationInput) =>
+      request<StorageLocation>("/storage-locations", json("POST", input)),
+    updateStorageLocation: (id: string, input: StorageLocationInput) =>
+      request<StorageLocation>(`/storage-locations/${encodeURIComponent(id)}`, json("PUT", input)),
+    accessoryStock: (productId: string) =>
+      request<AccessoryStockSummary>(`/accessory-products/${encodeURIComponent(productId)}/stock`),
+    adjustAccessoryStock: (productId: string, input: AccessoryStockAdjustmentInput) =>
+      request<AccessoryStockSummary>(
+        `/accessory-products/${encodeURIComponent(productId)}/stock-adjustments`, json("POST", input)
+      ),
+    accessoryAssets: (productId: string) =>
+      request<AccessoryAsset[]>(`/accessory-products/${encodeURIComponent(productId)}/assets`),
+    createAccessoryAsset: (productId: string, input: AccessoryAssetInput) =>
+      request<AccessoryAsset>(`/accessory-products/${encodeURIComponent(productId)}/assets`, json("POST", input)),
+    updateAccessoryAsset: (id: string, input: AccessoryAssetInput) =>
+      request<AccessoryAsset>(`/accessory-assets/${encodeURIComponent(id)}`, json("PUT", input)),
+    accessoryAllocationSummary: (productId: string) =>
+      request<AccessoryAllocationSummary>(
+        `/accessory-products/${encodeURIComponent(productId)}/allocation-summary`
+      ),
+    accessoryReservations: (productId?: string) =>
+      request<AccessoryReservation[]>(`/accessory-reservations${productQuery(productId)}`),
+    createAccessoryReservation: (input: AccessoryReservationInput) =>
+      request<AccessoryReservation>("/accessory-reservations", json("POST", input)),
+    cancelAccessoryReservation: (id: string) =>
+      request<AccessoryReservation>(`/accessory-reservations/${encodeURIComponent(id)}/cancel`, { method: "POST" }),
+    accessoryInstallations: (productId?: string) =>
+      request<AccessoryInstallation[]>(`/accessory-installations${productQuery(productId)}`),
+    createAccessoryInstallation: (input: AccessoryInstallationInput) =>
+      request<AccessoryInstallation>("/accessory-installations", json("POST", input)),
+    removeAccessoryInstallation: (id: string, input: AccessoryInstallationRemovalInput) =>
+      request<AccessoryInstallation>(`/accessory-installations/${encodeURIComponent(id)}/remove`, json("POST", input)),
+    updateAccessoryInstallationCondition: (id: string, input: AccessoryInstallationConditionInput) =>
+      request<AccessoryInstallation>(
+        `/accessory-installations/${encodeURIComponent(id)}/condition`, json("PUT", input)
+      )
+  };
+}
+
+function json(method: "POST" | "PUT", body: object): RequestInit {
+  return { method, body: JSON.stringify(body) };
+}


### PR DESCRIPTION
## Deutsch

Schließt den strikten Frontend-Client-Vertrag für alle Anlagen- und Zubehörfunktionen aus Etappe 1 ab.

### Inhalt

- bildet Anlagen, Einheiten, Aufbaukonfigurationen, Varianten und Revisionen strikt typisiert ab
- bildet Zubehörprodukte, Lagerorte, Bestand, Einzelobjekte, Reservierungen und Einbauhistorie strikt typisiert ab
- modelliert Installationsziele als TypeScript-Union mit genau einem Ziel
- schließt manuell erzeugte Zustände `reserved` und `installed` bei allgemeinen Asset-Eingaben aus
- verwendet ausschließlich den vorhandenen `request`-Transport und hält die zentrale API-Datei klein
- erweitert den Go-Vertragstest auf fokussierte API-Module und alle neuen Schemas
- prüft sämtliche Pfade, URL-Kodierung, Methoden, Bodies und CSRF-Header
- korrigiert bereits in PR #54 gemergte OpenAPI-Abweichungen für optionale Defaults, Enums, Versionen und Ausbaukombinationen

### Prüfung

- `go test ./internal/api -run "OpenAPI|FrontendAPI" -count=1`
- `go test ./...`
- `go vet ./...`
- `npm.cmd run test:run`, 21 Dateien, 65 Tests
- `npm.cmd run build`
- `git diff --check`

## English

Completes the strict frontend client contract for every Stage 1 layout and accessory function.

### Included

- strictly types layouts, units, setup configurations, variants, and revisions
- strictly types accessory products, storage locations, stock, individual assets, reservations, and installation history
- models installation targets as a TypeScript union with exactly one target
- excludes manually assigned `reserved` and `installed` states from generic asset inputs
- exclusively uses the existing `request` transport and keeps the central API file small
- extends the Go contract test to focused API modules and every new schema
- verifies every path, URL encoding, method, body, and CSRF header
- builds on the OpenAPI corrections merged through PR #54 for optional defaults, enums, versions, and removal combinations

### Verification

- `go test ./internal/api -run "OpenAPI|FrontendAPI" -count=1`
- `go test ./...`
- `go vet ./...`
- `npm.cmd run test:run`, 21 files, 65 tests
- `npm.cmd run build`
- `git diff --check`

Closes #41