### PR TITLE
chore: add sponsor button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+buy_me_a_coffee: drothe20128


### PR DESCRIPTION
## Summary
- add GitHub funding configuration for the existing Buy Me a Coffee account
- expose the repository Sponsor button without changing the README support links

## Verification
- go test ./...
- npm.cmd run test:run (302 tests)
- FUNDING.yml contains only the supported buy_me_a_coffee account entry