### PR TITLE
chore: update sponsor handle

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-buy_me_a_coffee: drothe20128
+buy_me_a_coffee: ichwars

--- a/README.de.md
+++ b/README.de.md
@@ -284,4 +284,4 @@ RailKeeper wird unter der MIT Self-Hosting License veröffentlicht. Siehe [LICEN
 
 Wenn RailKeeper dir Zeit spart, ist Kaffee ein vollkommen akzeptabler Treibstoff für Fehlerbehebungen:
 
-<a href="https://www.buymeacoffee.com/drothe20128" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me a Coffee" style="height: 60px !important;width: 217px !important;" ></a>
+<a href="https://www.buymeacoffee.com/ichwars" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me a Coffee" style="height: 60px !important;width: 217px !important;" ></a>

--- a/README.md
+++ b/README.md
@@ -266,4 +266,4 @@ RailKeeper is released under the MIT Self-Hosting License. See [LICENSE.md](LICE
 
 If RailKeeper saves you time, coffee is a perfectly acceptable bug fuel:
 
-<a href="https://www.buymeacoffee.com/drothe20128" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me a Coffee" style="height: 60px !important;width: 217px !important;" ></a>
+<a href="https://www.buymeacoffee.com/ichwars" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me a Coffee" style="height: 60px !important;width: 217px !important;" ></a>


### PR DESCRIPTION
## Summary
- update GitHub Sponsor funding handle from `drothe20128` to `ichwars`
- update the English and German README support links

## Verification
- `https://buymeacoffee.com/ichwars` returns HTTP 200
- no old Buy Me a Coffee handle remains in FUNDING.yml or either README
- git diff --check