### PR TITLE
chore: add PayPal funding link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
 buy_me_a_coffee: ichwars
+custom: "https://paypal.me/DRothe343"


### PR DESCRIPTION
## Summary
- add PayPal.Me as a second repository funding option
- keep the existing Buy Me a Coffee funding link

## Verification
- `https://paypal.me/DRothe343` returns HTTP 200 and resolves to PayPal
- FUNDING.yml uses GitHub's supported custom funding URL syntax
- git diff --check