### PR TITLE
chore: prepare v0.1.17 release

### DIFF
--- a/CHANGELOG.de.md
+++ b/CHANGELOG.de.md
@@ -4,6 +4,38 @@
 
 Diese Datei dokumentiert alle wesentlichen Änderungen an RailKeeper.
 
+## [0.1.17] - 2026-08-13
+
+### Hinzugefügt
+
+- Artikeldaten- und Barcodesuche sind jetzt direkt beim Anlegen und Bearbeiten von Zubehör
+  verfügbar, mit Quellenvorschau und ausdrücklicher felweiser Auswahl vor der Übernahme.
+- Ausgewählte Produktbilder aus Suchtreffern lassen sich nach dem Speichern als private
+  Zubehördokumente importieren.
+- Die GitHub-Sponsoring-Links enthalten jetzt Buy Me a Coffee und PayPal.
+
+### Geändert
+
+- Der bisherige Bereich `Artikelübersicht` heißt jetzt `Zubehör`; die bestehende Route
+  `/accessories` bleibt unverändert.
+- Gemeinsame Artikelsuch- und Barcodedialoge verwenden in Fahrzeug- und Zubehörabläufen jetzt
+  anwendungseigene Modal-, Tastatur-, Fokusfallen- und Fokuswiederherstellungslogik.
+- `modernc.org/sqlite` wurde auf 1.56.0, `lucide-react` auf 1.29.0 und Vite auf 8.2.1 aktualisiert.
+
+### Behoben
+
+- Unbekannte oder inaktive Hersteller- und Spurweitenvorschläge lassen sich nicht mehr auswählen,
+  wenn der entsprechende Stammdatenwert nicht verfügbar ist.
+- Wiederholte Bildimporte sind idempotent, erhalten vorhandene Hauptbilder und liefern bereits
+  gespeicherte Dokumente ohne erneuten Download zurück.
+- Escape und Tab bleiben im aktiven untergeordneten Suchdialog, statt den dahinterliegenden
+  Zubehördialog zu erreichen.
+
+### Sicherheit
+
+- Externe Zubehörbilder sind auf öffentliche HTTP(S)-Ziele beschränkt und werden vor der
+  Speicherung anhand von URL, DNS, Weiterleitungen, MIME-Typ und Anhangsgröße geprüft.
+
 ## [0.1.16] - 2026-08-09
 
 ### Hinzugefügt
@@ -49,4 +81,5 @@ Diese Datei dokumentiert alle wesentlichen Änderungen an RailKeeper.
 - Die Vorprüfung der Backup-Wiederherstellung bleibt konservativ, Authentifizierungsdaten bleiben
   aus Exporten ausgeschlossen.
 
+[0.1.17]: https://github.com/ichwars/RailKeeper/compare/v0.1.16...v0.1.17
 [0.1.16]: https://github.com/ichwars/RailKeeper/compare/v0.1.15...v0.1.16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@
 
 All notable changes to RailKeeper are documented in this file.
 
+## [0.1.17] - 2026-08-13
+
+### Added
+
+- Article-data and barcode search are now available directly while creating or editing accessories,
+  with source previews and explicit field-by-field selection before values are applied.
+- Selected product images from article-search results can be imported as private accessory
+  documents after saving the article.
+- GitHub sponsorship links now include Buy Me a Coffee and PayPal.
+
+### Changed
+
+- The former `Article Overview` area is now named `Accessories` while its existing `/accessories`
+  route remains stable.
+- Shared article-search and barcode dialogs now use app-owned modal, keyboard, focus-trap, and focus
+  restoration behavior in both vehicle and accessory workflows.
+- Updated `modernc.org/sqlite` to 1.56.0, `lucide-react` to 1.29.0, and Vite to 8.2.1.
+
+### Fixed
+
+- Unknown or inactive manufacturer and gauge suggestions can no longer be selected when the
+  corresponding master-data value is unavailable.
+- Remote image-import retries are idempotent, preserve existing primary images, and return an
+  already committed document without downloading it again.
+- Escape and Tab remain scoped to the active nested search dialog instead of reaching the accessory
+  editor behind it.
+
+### Security
+
+- Remote accessory images are restricted to public HTTP(S) targets with URL, DNS, redirect, MIME,
+  and attachment-size validation before they are stored.
+
 ## [0.1.16] - 2026-08-09
 
 ### Added
@@ -43,4 +75,5 @@ All notable changes to RailKeeper are documented in this file.
 - Tightened API validation and protected master-data import invariants.
 - Kept backup restore preflight conservative and authentication data excluded from exports.
 
+[0.1.17]: https://github.com/ichwars/RailKeeper/compare/v0.1.16...v0.1.17
 [0.1.16]: https://github.com/ichwars/RailKeeper/compare/v0.1.15...v0.1.16

--- a/README.de.md
+++ b/README.de.md
@@ -71,7 +71,8 @@ RailKeeper ist um Arbeitsansichten statt Marketingseiten aufgebaut:
 
 - **Übersicht** für Bestand, Wert, Wartung und Datenqualität
 - **Fahrzeugbestand** für Fahrzeugsuche, Filter, Leseansichten, Berichte, Bearbeitung, Uploads, CVs und Funktionstasten
-- **Artikelübersicht** für Artikelsuche, sortierbare Bestandsdaten, Lagerbestände, Reservierungen, Einbauten, Dokumente und Historie
+- **Zubehör** für Artikeldaten- und Barcodesuche, sortierbare Bestandsdaten, Lagerbestände,
+  Reservierungen, Einbauten, Dokumente und Historie
 - **Ausstellung** für Messe- und Ausstellungsbetrieb
 - **Import/Export** für CSV-, TSV-, XML- und JSON-Importe, kontrollierte Aktualisierungen und ECoS-Auslesung
 - **Einstellungen** für Stammdaten, Darstellung, Backups, Aktualisierungen und Authentifizierung
@@ -122,7 +123,7 @@ SQLite-Datenbank, Uploads und lokale Dateien bleiben im Docker-Volume `railkeepe
 Um statt `latest` ein bestimmtes Release festzulegen, trage Folgendes in `.env` ein:
 
 ```env
-RAILKEEPER_IMAGE=ghcr.io/ichwars/railkeeper:v0.1.16
+RAILKEEPER_IMAGE=ghcr.io/ichwars/railkeeper:v0.1.17
 ```
 
 Wenn du bewusst den ausgecheckten Quellstand bauen möchtest, verwende:

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ RailKeeper is built around operational views instead of marketing pages:
 
 - **Overview** for inventory, value, maintenance and data quality
 - **Inventory** for vehicle search, filtering, read views, reports, editing, uploads, CVs and function keys
-- **Article Overview** for article search, sortable inventory data, stock, reservations, installations, documents and history
+- **Accessories** for article-data and barcode search, sortable inventory data, stock, reservations,
+  installations, documents and history
 - **Exhibition List** for fair/show operations
 - **Import/Export** for CSV, TSV, XML and JSON imports, controlled updates and ECoS readout
 - **Settings** for master data, appearance, backups, updates and authentication
@@ -112,7 +113,7 @@ The SQLite database, uploads and local files stay in the `railkeeper_data` Docke
 To pin a specific release instead of `latest`, set this in `.env`:
 
 ```env
-RAILKEEPER_IMAGE=ghcr.io/ichwars/railkeeper:v0.1.16
+RAILKEEPER_IMAGE=ghcr.io/ichwars/railkeeper:v0.1.17
 ```
 
 If you intentionally want to build the checked-out source tree, use:

--- a/backend/cmd/railkeeper/main.go
+++ b/backend/cmd/railkeeper/main.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	version               = "0.1.16"
+	version               = "0.1.17"
 	defaultUpdateCheckURL = "https://api.github.com/repos/ichwars/RailKeeper/releases/latest"
 )
 

--- a/docs/releases/v0.1.17.md
+++ b/docs/releases/v0.1.17.md
@@ -1,0 +1,30 @@
+# RailKeeper v0.1.17
+
+## Deutsch
+
+RailKeeper 0.1.17 bringt die aus dem Fahrzeugbestand bekannte Artikeldaten- und Barcodesuche in den
+Bereich „Zubehör“. Beim Anlegen und Bearbeiten bleiben Treffer Vorschläge: Quelle, Feldwerte und
+Bilder werden vor der ausdrücklichen Übernahme angezeigt. Bereits erfasste Werte und vorhandene
+Hauptbilder bleiben geschützt.
+
+Externe Produktbilder werden nur von öffentlichen HTTP(S)-Zielen geladen, vor der Speicherung
+geprüft und bei Wiederholungen idempotent verarbeitet. Zusätzlich aktualisiert dieses Release
+SQLite, Lucide und Vite und ergänzt die Sponsoring-Links des Projekts.
+
+Weitere Details stehen im
+[deutschen Änderungsprotokoll](https://github.com/ichwars/RailKeeper/blob/v0.1.17/CHANGELOG.de.md).
+
+## English
+
+RailKeeper 0.1.17 brings the vehicle inventory's article-data and barcode search workflow to the
+Accessories area. Search matches remain suggestions while creating or editing an accessory: their
+source, field values, and images are shown before explicit selection. Existing values and primary
+images remain protected.
+
+Remote product images are limited to public HTTP(S) targets, validated before storage, and handled
+idempotently on retries. This release also updates SQLite, Lucide, and Vite and adds the project's
+sponsorship links.
+
+See the
+[English changelog](https://github.com/ichwars/RailKeeper/blob/v0.1.17/CHANGELOG.md)
+for details.


### PR DESCRIPTION
## Summary

- bump the RailKeeper runtime version to 0.1.17
- document accessory article-data and barcode search in English and German
- record safe, idempotent accessory image imports and merged dependency updates
- update pinned Docker examples and add bilingual release notes

## Why

PR #67 completed issue #61, and dependency PRs #65 and #66 were updated, fully checked, and merged.
This change prepares the stable v0.1.17 release from that combined `main` state.

## Verification

- `cd backend; go test ./...`
- `cd backend; go vet ./...`
- `cd frontend; npm.cmd run test -- --run --reporter=dot` (53 files, 318 tests)
- `cd frontend; npm.cmd run build`
- `git diff --check`
