### PR TITLE
feat: enrich accessory article search

### DIFF
--- a/CHANGELOG.de.md
+++ b/CHANGELOG.de.md
@@ -4,6 +4,27 @@
 
 Diese Datei dokumentiert alle wesentlichen Änderungen an RailKeeper.
 
+## [0.1.17.1] - 2026-08-13
+
+### Hinzugefügt
+
+- Die Zubehör-Artikelsuche erfasst beschriftete Gleis-Fachangaben wie Gleissystem, Abmessungen,
+  Richtung, Bettung, Anschlüsse und Digitaltauglichkeit als einzeln auswählbare, typisierte
+  Vorschläge.
+- Die Auswahl einer Spurweite trägt den konfigurierten Maßstab automatisch ein, bis das
+  Maßstabsfeld manuell bearbeitet wird.
+- Neue oder bisher unverschlagwortete Artikel erhalten synchronisierte Schlagwortvorschläge aus
+  Bezeichnung, Hersteller, Artikelart und Unterart, bis das Schlagwortfeld manuell bearbeitet wird.
+
+### Behoben
+
+- Der Zubehör-Artikelsuchdialog wird jetzt über dem Editor angezeigt, statt hinter dessen
+  Modalebene verborgen zu bleiben.
+- Spurweiten-Mehrfachauswahlen reagieren auf eingegebene Optionsbezeichnungen und begrenzen Escape
+  auf die geöffnete Auswahlliste, statt den gesamten Artikeleditor zu schließen.
+- Fehlerhafte oder unpassende Gleis-Fachangaben externer Seiten lassen sich nicht auswählen oder
+  importieren.
+
 ## [0.1.17] - 2026-08-13
 
 ### Hinzugefügt
@@ -81,5 +102,6 @@ Diese Datei dokumentiert alle wesentlichen Änderungen an RailKeeper.
 - Die Vorprüfung der Backup-Wiederherstellung bleibt konservativ, Authentifizierungsdaten bleiben
   aus Exporten ausgeschlossen.
 
+[0.1.17.1]: https://github.com/ichwars/RailKeeper/compare/v0.1.17...v0.1.17.1
 [0.1.17]: https://github.com/ichwars/RailKeeper/compare/v0.1.16...v0.1.17
 [0.1.16]: https://github.com/ichwars/RailKeeper/compare/v0.1.15...v0.1.16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@
 
 All notable changes to RailKeeper are documented in this file.
 
+## [0.1.17.1] - 2026-08-13
+
+### Added
+
+- Accessory article search now extracts labelled track specifications such as track system,
+  dimensions, direction, roadbed, connections, and digital suitability as individually selectable
+  typed suggestions.
+- Selecting a gauge automatically fills its configured scale until the scale is edited manually.
+- New or previously untagged accessories receive synchronized keyword suggestions from their name,
+  manufacturer, article type, and subtype until the keyword field is edited manually.
+
+### Fixed
+
+- The accessory article-search dialog now renders above the editor instead of remaining hidden
+  behind its modal layer.
+- Gauge multi-selects react to typed option labels and keep Escape scoped to the open option list
+  instead of closing the complete article editor.
+- Malformed or incompatible track specifications from external pages cannot be selected or imported.
+
 ## [0.1.17] - 2026-08-13
 
 ### Added
@@ -75,5 +94,6 @@ All notable changes to RailKeeper are documented in this file.
 - Tightened API validation and protected master-data import invariants.
 - Kept backup restore preflight conservative and authentication data excluded from exports.
 
+[0.1.17.1]: https://github.com/ichwars/RailKeeper/compare/v0.1.17...v0.1.17.1
 [0.1.17]: https://github.com/ichwars/RailKeeper/compare/v0.1.16...v0.1.17
 [0.1.16]: https://github.com/ichwars/RailKeeper/compare/v0.1.15...v0.1.16

--- a/README.de.md
+++ b/README.de.md
@@ -41,7 +41,8 @@ Importprüfung, ECoS-Auslesung und die Suche nach neuen Releases.
 - Fahrzeugdatensätze mit Modelldaten, technischen Feldern, Eigentumsangaben, Bildern, Anhängen, QR-Codes und übersichtlichen Leseansichten
 - Artikelbestand mit generierten Inventarnummern, sortierbarer Auswahlspalte, Mengen- oder Einzelverfolgung, Lagerortbeständen, Reservierungen, Einbauten, Dokumenten und Nutzungshistorie
 - Fundament für Anlagen, Module, Aufbauten und Planrevisionen mit Versionskonfliktschutz; der Eintrag in der Hauptnavigation bleibt vorübergehend deaktiviert, solange der Arbeitsbereich weiter verfeinert wird
-- Websuche nach Artikeldaten mit konfigurierbaren Quellen, Barcode-/EAN-Eingabe, ZXing-Kamerascanner und ausdrücklicher feldweiser Prüfung
+- Websuche nach Artikeldaten mit konfigurierbaren Quellen, Barcode-/EAN-Eingabe,
+  ZXing-Kamerascanner, typisierten Gleis-Fachangaben und ausdrücklicher feldweiser Prüfung
 - PDF-Berichtsdialog für Bestandsübersicht und Detaillisten mit auswählbaren Fahrzeugen, QR-Codes und Bildern
 - Responsiver Bestandsablauf mit mobil optimierten Dialogen, Filtern und Kameraersatz für die Barcode-Eingabe
 - Digitalzentralen-Adapter: ECoS-Lese-/Schreibsynchronisation sowie Verbindungstests für Z21 per UDP und CS3 per HTTP
@@ -123,7 +124,7 @@ SQLite-Datenbank, Uploads und lokale Dateien bleiben im Docker-Volume `railkeepe
 Um statt `latest` ein bestimmtes Release festzulegen, trage Folgendes in `.env` ein:
 
 ```env
-RAILKEEPER_IMAGE=ghcr.io/ichwars/railkeeper:v0.1.17
+RAILKEEPER_IMAGE=ghcr.io/ichwars/railkeeper:v0.1.17.1
 ```
 
 Wenn du bewusst den ausgecheckten Quellstand bauen möchtest, verwende:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ The project is designed for private collections, clubs and small workshops that 
 - Vehicle records with model data, technical fields, ownership details, images, attachments, QR codes and clean read-only detail views
 - Article inventory with generated inventory numbers, sortable selection-first overview, quantity or individual tracking, storage-location stock, reservations, installations, documents and usage history
 - Layout, module, setup and plan-revision foundation with version-conflict protection; its main-navigation entry remains temporarily disabled while the workspace is refined
-- Article data web search with configurable sources, barcode/EAN entry, ZXing-based camera scanning and explicit field-by-field review
+- Article data web search with configurable sources, barcode/EAN entry, ZXing-based camera scanning,
+  typed track details, and explicit field-by-field review
 - PDF report dialog for inventory overview and detail lists with selectable vehicles, QR codes and images
 - Responsive inventory workflow with mobile-optimized dialogs, filter controls and camera fallback for barcode entry
 - Digital command-station adapters: ECoS live read/write sync plus Z21 UDP and CS3 HTTP connection tests
@@ -113,7 +114,7 @@ The SQLite database, uploads and local files stay in the `railkeeper_data` Docke
 To pin a specific release instead of `latest`, set this in `.env`:
 
 ```env
-RAILKEEPER_IMAGE=ghcr.io/ichwars/railkeeper:v0.1.17
+RAILKEEPER_IMAGE=ghcr.io/ichwars/railkeeper:v0.1.17.1
 ```
 
 If you intentionally want to build the checked-out source tree, use:

--- a/backend/cmd/railkeeper/main.go
+++ b/backend/cmd/railkeeper/main.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	version               = "0.1.17"
+	version               = "0.1.17.1"
 	defaultUpdateCheckURL = "https://api.github.com/repos/ichwars/RailKeeper/releases/latest"
 )
 

--- a/backend/internal/application/article_search_ranking.go
+++ b/backend/internal/application/article_search_ranking.go
@@ -141,6 +141,11 @@ func buildArticleFields(input ArticleSearchInput, title, resultURL, snippet stri
 	} else if hasExplicitInteriorLighting(combinedLower) {
 		fields["lightingEnabled"] = ArticleSearchField{Label: "Beleuchtung", Value: "Ja", Confidence: 34}
 	}
+	for key, field := range buildTrackArticleFields(input, combined) {
+		if existing, ok := fields[key]; !ok || field.Confidence > existing.Confidence {
+			fields[key] = field
+		}
+	}
 	return fields
 }
 

--- a/backend/internal/application/article_search_test.go
+++ b/backend/internal/application/article_search_test.go
@@ -479,6 +479,77 @@ func TestBuildArticleFieldsExtractsModellbahnFokusDetails(t *testing.T) {
 	}
 }
 
+func TestBuildArticleFieldsExtractsTrackSubjectFields(t *testing.T) {
+	input := ArticleSearchInput{
+		Manufacturer:  "Tillig",
+		ArticleNumber: "83329",
+		Gauge:         "TT",
+		Fields:        map[string]string{"articleType": "track"},
+	}
+	fields := buildArticleFields(input,
+		"Tillig 83329 Einfache Weiche EW1 links",
+		"https://www.tillig.com/83329",
+		`Gleissystem: TT Modellgleis
+Länge: 129,5 mm
+Radius: 353 mm
+Winkel: 15°
+Richtung: links
+Herzstückwinkel: 12°
+Schwellenart: Holz
+Profilhöhe: 2,07 mm
+Bettung: nein
+Anzahl Anschlüsse: 3
+Digitaltauglich: ja`,
+	)
+
+	expected := map[string]string{
+		"trackSystem":      "TT Modellgleis",
+		"lengthMm":         "129.5",
+		"radiusMm":         "353",
+		"angleDegrees":     "15",
+		"direction":        "left",
+		"frogAngleDegrees": "12",
+		"sleeperType":      "Holz",
+		"railHeightMm":     "2.07",
+		"roadbed":          "false",
+		"connectionCount":  "3",
+		"digitalReady":     "true",
+	}
+	for key, value := range expected {
+		if fields[key].Value != value {
+			t.Errorf("expected %s=%q, got %#v", key, value, fields[key])
+		}
+	}
+}
+
+func TestBuildArticleFieldsRestrictsTrackSubjectFieldsToTrackArticles(t *testing.T) {
+	fields := buildArticleFields(
+		ArticleSearchInput{Fields: map[string]string{"articleType": "signal"}},
+		"Tillig Signal", "https://example.test/signal",
+		"Gleissystem: TT Modellgleis\nRadius: 353 mm\nRichtung: links\nDigitaltauglich: ja",
+	)
+
+	for _, key := range []string{"trackSystem", "radiusMm", "direction", "digitalReady"} {
+		if _, ok := fields[key]; ok {
+			t.Errorf("non-track result must not contain %s: %#v", key, fields[key])
+		}
+	}
+}
+
+func TestBuildArticleFieldsRejectsAmbiguousTrackBooleans(t *testing.T) {
+	fields := buildArticleFields(
+		ArticleSearchInput{Fields: map[string]string{"articleType": "track"}},
+		"Modellgleis", "https://example.test/track",
+		"Bettung: optional erhältlich\nDigitaltauglich: mit zusätzlichem Decoder möglich",
+	)
+
+	for _, key := range []string{"roadbed", "digitalReady"} {
+		if _, ok := fields[key]; ok {
+			t.Errorf("ambiguous value must not produce %s: %#v", key, fields[key])
+		}
+	}
+}
+
 func TestBuildArticleFieldsKeepsProductDataClean(t *testing.T) {
 	input := ArticleSearchInput{Manufacturer: "Piko", ArticleNumber: "47284", Name: "V 180", Gauge: "TT"}
 	fields := buildArticleFields(input,

--- a/backend/internal/application/article_search_track_fields.go
+++ b/backend/internal/application/article_search_track_fields.go
@@ -1,0 +1,182 @@
+package application
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var trackNumberPattern = regexp.MustCompile(`[-+]?\d+(?:[,.]\d+)?`)
+
+var trackDetailLabels = []string{
+	"Gleissystem", "Gleissortiment", "Track system",
+	"Länge", "Laenge", "Length", "Radius", "Winkel", "Weichenwinkel", "Angle",
+	"Richtung", "Direction", "Herzstückwinkel", "Herzstueckwinkel", "Frog angle",
+	"Schwellenart", "Schwellen", "Sleeper type", "Profilhöhe", "Profilhoehe", "Rail height",
+	"Bettung", "Gleisbettung", "Roadbed", "Anzahl Anschlüsse", "Anzahl Anschluesse", "Connections",
+	"Digitaltauglich", "Digital geeignet", "Digital ready",
+}
+
+func buildTrackArticleFields(input ArticleSearchInput, text string) map[string]ArticleSearchField {
+	if !strings.EqualFold(strings.TrimSpace(input.Fields["articleType"]), "track") {
+		return nil
+	}
+	fields := map[string]ArticleSearchField{}
+	addTextTrackField(fields, "trackSystem", "Gleissystem", text,
+		[]string{"Gleissystem", "Gleissortiment", "Track system"})
+	addDecimalTrackField(fields, "lengthMm", "Länge (mm)", text,
+		[]string{"Länge", "Laenge", "Length"})
+	addDecimalTrackField(fields, "radiusMm", "Radius (mm)", text, []string{"Radius"})
+	addDecimalTrackField(fields, "angleDegrees", "Winkel (°)", text,
+		[]string{"Winkel", "Weichenwinkel", "Angle"})
+	addDirectionTrackField(fields, text)
+	addDecimalTrackField(fields, "frogAngleDegrees", "Herzstückwinkel (°)", text,
+		[]string{"Herzstückwinkel", "Herzstueckwinkel", "Frog angle"})
+	addTextTrackField(fields, "sleeperType", "Schwellenart", text,
+		[]string{"Schwellenart", "Schwellen", "Sleeper type"})
+	addDecimalTrackField(fields, "railHeightMm", "Profilhöhe (mm)", text,
+		[]string{"Profilhöhe", "Profilhoehe", "Rail height"})
+	addBooleanTrackField(fields, "roadbed", "Bettung", text,
+		[]string{"Bettung", "Gleisbettung", "Roadbed"})
+	addIntegerTrackField(fields, "connectionCount", "Anzahl Anschlüsse", text,
+		[]string{"Anzahl Anschlüsse", "Anzahl Anschluesse", "Connections"})
+	addBooleanTrackField(fields, "digitalReady", "Digitaltauglich", text,
+		[]string{"Digitaltauglich", "Digital geeignet", "Digital ready"})
+	return fields
+}
+
+func addTextTrackField(
+	fields map[string]ArticleSearchField,
+	key, label, text string,
+	labels []string,
+) {
+	value := normalizeWhitespace(trackLabeledValue(text, labels))
+	value = strings.Trim(value, " -:;,.\t")
+	if value == "" || len(value) > 90 {
+		return
+	}
+	fields[key] = ArticleSearchField{Label: label, Value: value, Confidence: 78}
+}
+
+func addDecimalTrackField(
+	fields map[string]ArticleSearchField,
+	key, label, text string,
+	labels []string,
+) {
+	raw := trackLabeledValue(text, labels)
+	match := trackNumberPattern.FindString(raw)
+	if match == "" {
+		return
+	}
+	value, err := strconv.ParseFloat(strings.ReplaceAll(match, ",", "."), 64)
+	if err != nil || value < 0 {
+		return
+	}
+	fields[key] = ArticleSearchField{
+		Label: label, Value: strconv.FormatFloat(value, 'f', -1, 64), Confidence: 82,
+	}
+}
+
+func addIntegerTrackField(
+	fields map[string]ArticleSearchField,
+	key, label, text string,
+	labels []string,
+) {
+	raw := trackLabeledValue(text, labels)
+	match := regexp.MustCompile(`\d+`).FindString(raw)
+	if match == "" {
+		return
+	}
+	value, err := strconv.Atoi(match)
+	if err != nil || value < 0 {
+		return
+	}
+	fields[key] = ArticleSearchField{Label: label, Value: strconv.Itoa(value), Confidence: 82}
+}
+
+func addDirectionTrackField(fields map[string]ArticleSearchField, text string) {
+	value := strings.ToLower(trackLabeledValue(text, []string{"Richtung", "Direction"}))
+	normalized := ""
+	switch {
+	case strings.HasPrefix(value, "links"), strings.HasPrefix(value, "left"):
+		normalized = "left"
+	case strings.HasPrefix(value, "rechts"), strings.HasPrefix(value, "right"):
+		normalized = "right"
+	case strings.HasPrefix(value, "symmetrisch"), strings.HasPrefix(value, "symmetric"):
+		normalized = "symmetric"
+	}
+	if normalized != "" {
+		fields["direction"] = ArticleSearchField{Label: "Richtung", Value: normalized, Confidence: 82}
+	}
+}
+
+func addBooleanTrackField(
+	fields map[string]ArticleSearchField,
+	key, label, text string,
+	labels []string,
+) {
+	value := strings.ToLower(trackLabeledValue(text, labels))
+	normalized := ""
+	switch {
+	case strings.HasPrefix(value, "ja"), strings.HasPrefix(value, "yes"), strings.HasPrefix(value, "true"):
+		normalized = "true"
+	case strings.HasPrefix(value, "nein"), strings.HasPrefix(value, "no"), strings.HasPrefix(value, "false"):
+		normalized = "false"
+	}
+	if normalized != "" {
+		fields[key] = ArticleSearchField{Label: label, Value: normalized, Confidence: 82}
+	}
+}
+
+func trackLabeledValue(text string, labels []string) string {
+	text = repairMojibake(text)
+	lower := strings.ToLower(text)
+	for _, label := range labels {
+		lowerLabel := strings.ToLower(label)
+		for offset := 0; offset < len(lower); {
+			relative := strings.Index(lower[offset:], lowerLabel)
+			if relative < 0 {
+				break
+			}
+			index := offset + relative
+			if index > 0 && isTrackLabelCharacter(lower[index-1]) {
+				offset = index + len(lowerLabel)
+				continue
+			}
+			start := index + len(label)
+			for start < len(text) && strings.ContainsRune(" \t\u00a0:-", rune(text[start])) {
+				start++
+			}
+			end := len(text)
+			for _, nextLabel := range trackDetailLabels {
+				nextLower := strings.ToLower(nextLabel)
+				searchOffset := start
+				for searchOffset < len(lower) {
+					nextRelative := strings.Index(lower[searchOffset:], nextLower)
+					if nextRelative < 0 {
+						break
+					}
+					next := searchOffset + nextRelative
+					if next > start && !isTrackLabelCharacter(lower[next-1]) {
+						if next < end {
+							end = next
+						}
+						break
+					}
+					searchOffset = next + len(nextLower)
+				}
+			}
+			value := normalizeWhitespace(text[start:end])
+			value = strings.Trim(value, " -:;,.\t")
+			if value != "" && len(value) <= 90 {
+				return value
+			}
+			offset = index + len(lowerLabel)
+		}
+	}
+	return ""
+}
+
+func isTrackLabelCharacter(value byte) bool {
+	return value >= 'a' && value <= 'z'
+}

--- a/docs/releases/v0.1.17.1.md
+++ b/docs/releases/v0.1.17.1.md
@@ -1,0 +1,34 @@
+# RailKeeper v0.1.17.1
+
+## Deutsch
+
+RailKeeper 0.1.17.1 erweitert die Zubehör-Artikelsuche um typisierte Gleis-Fachangaben. Erkannte
+Werte wie Gleissystem, Länge, Radius, Winkel, Richtung, Bettung und Digitaltauglichkeit bleiben
+einzeln auswählbare Vorschläge und werden vor der Übernahme gegen die vorhandenen Felddefinitionen
+geprüft.
+
+Spurweiten tragen ihren konfigurierten Maßstab automatisch ein. Bezeichnung, Hersteller,
+Artikelart und Unterart erzeugen passende Schlagwortvorschläge. Beide Automatiken enden für die
+aktuelle Bearbeitung, sobald das jeweilige Feld manuell geändert wird. Zusätzlich erscheinen
+Artikelsuchtreffer wieder zuverlässig über dem Editor und die Spurweitenauswahl unterstützt
+Tastatureingaben, ohne dass Escape den gesamten Dialog schließt.
+
+Weitere Details stehen im
+[deutschen Änderungsprotokoll](https://github.com/ichwars/RailKeeper/blob/v0.1.17.1/CHANGELOG.de.md).
+
+## English
+
+RailKeeper 0.1.17.1 extends accessory article search with typed track specifications. Detected
+values such as track system, length, radius, angle, direction, roadbed, and digital suitability
+remain individually selectable suggestions and are validated against the existing field definitions
+before import.
+
+Gauges now fill their configured scale automatically. The name, manufacturer, article type, and
+subtype provide synchronized keyword suggestions. Both automatic behaviors stop for the current
+editing session once their respective field is changed manually. Article-search results also render
+reliably above the editor again, and gauge selection supports typed input without Escape closing the
+complete dialog.
+
+See the
+[English changelog](https://github.com/ichwars/RailKeeper/blob/v0.1.17.1/CHANGELOG.md)
+for details.

--- a/docs/superpowers/plans/2026-08-13-accessory-search-enrichment.md
+++ b/docs/superpowers/plans/2026-08-13-accessory-search-enrichment.md
@@ -1,0 +1,310 @@
+# Accessory Search Enrichment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add safe structured track-data suggestions to accessory web search and automatically manage scale and keyword defaults without overwriting manual edits.
+
+**Architecture:** Extend the existing generic article-search `fields` map with canonical track keys, parsed by a focused backend helper and converted by the accessory frontend into existing typed attributes. Keep scale and keyword automation in the article-editor session, where current form values, gauge metadata, and localized type/subtype labels are available.
+
+**Tech Stack:** Go 1.24 backend, React 19, TypeScript, Vitest, Testing Library, Vite 8, SQLite-backed master data.
+
+## Global Constraints
+
+- Every web-search value remains a suggestion and requires explicit selection before import.
+- Existing URL, timeout, redirect, MIME, and size protections remain unchanged.
+- Manual scale and keyword values always win over automatic defaults.
+- Non-track article types retain their current article-search behavior.
+- No database migration or new API response shape is introduced.
+- Keep all work local on `dev/fix-accessory-search-dialog`; do not push or merge.
+
+---
+
+### Task 1: Extract canonical track fields in article search
+
+**Files:**
+- Create: `backend/internal/application/article_search_track_fields.go`
+- Modify: `backend/internal/application/article_search_ranking.go`
+- Test: `backend/internal/application/article_search_test.go`
+
+**Interfaces:**
+- Consumes: `ArticleSearchInput.Fields["articleType"]` and cleaned page/search text.
+- Produces: `buildTrackArticleFields(input ArticleSearchInput, text string) map[string]ArticleSearchField`.
+
+- [ ] **Step 1: Write failing extraction tests**
+
+Add table-driven tests that call `buildArticleFields` with `Fields: map[string]string{"articleType": "track"}` and representative labelled specifications. Assert canonical values for text, decimal numbers, booleans, connection count, and direction:
+
+```go
+input := ArticleSearchInput{Fields: map[string]string{"articleType": "track"}}
+fields := buildArticleFields(input, "Tillig EW1", "https://www.tillig.com/83329", `
+Gleissystem: TT Modellgleis
+Länge: 129,5 mm
+Radius: 353 mm
+Winkel: 15°
+Richtung: links
+Herzstückwinkel: 12°
+Schwellenart: Holz
+Profilhöhe: 2,07 mm
+Bettung: nein
+Anzahl Anschlüsse: 3
+Digitaltauglich: ja`)
+expectArticleField(t, fields, "trackSystem", "TT Modellgleis")
+expectArticleField(t, fields, "lengthMm", "129.5")
+expectArticleField(t, fields, "direction", "left")
+expectArticleField(t, fields, "roadbed", "false")
+expectArticleField(t, fields, "digitalReady", "true")
+```
+
+Also assert that the same text does not add track fields when `articleType` is not `track`, and that ambiguous boolean prose produces no boolean field.
+
+- [ ] **Step 2: Run the backend test and verify RED**
+
+Run: `go test ./internal/application -run 'Test.*Track.*Article.*Fields' -count=1`
+
+Expected: FAIL because canonical track fields are absent.
+
+- [ ] **Step 3: Implement the focused parser**
+
+Create `article_search_track_fields.go` with explicit label maps and conservative normalizers:
+
+```go
+func buildTrackArticleFields(input ArticleSearchInput, text string) map[string]ArticleSearchField {
+    if !strings.EqualFold(strings.TrimSpace(input.Fields["articleType"]), "track") {
+        return nil
+    }
+    fields := map[string]ArticleSearchField{}
+    addTextTrackField(fields, "trackSystem", "Gleissystem", text,
+        []string{"Gleissystem", "Gleissortiment", "Track system"})
+    addDecimalTrackField(fields, "lengthMm", "Länge (mm)", text,
+        []string{"Länge", "Laenge", "Length"})
+    addDecimalTrackField(fields, "radiusMm", "Radius (mm)", text, []string{"Radius"})
+    addDecimalTrackField(fields, "angleDegrees", "Winkel (°)", text,
+        []string{"Winkel", "Angle"})
+    addDirectionTrackField(fields, text)
+    addDecimalTrackField(fields, "frogAngleDegrees", "Herzstückwinkel (°)", text,
+        []string{"Herzstückwinkel", "Herzstueckwinkel", "Frog angle"})
+    addTextTrackField(fields, "sleeperType", "Schwellenart", text,
+        []string{"Schwellenart", "Schwellen", "Sleeper type"})
+    addDecimalTrackField(fields, "railHeightMm", "Profilhöhe (mm)", text,
+        []string{"Profilhöhe", "Profilhoehe", "Rail height"})
+    addBooleanTrackField(fields, "roadbed", "Bettung", text,
+        []string{"Bettung", "Gleisbettung", "Roadbed"})
+    addIntegerTrackField(fields, "connectionCount", "Anzahl Anschlüsse", text,
+        []string{"Anzahl Anschlüsse", "Anzahl Anschluesse", "Connections"})
+    addBooleanTrackField(fields, "digitalReady", "Digitaltauglich", text,
+        []string{"Digitaltauglich", "Digital geeignet", "Digital ready"})
+    return fields
+}
+```
+
+Normalize decimal commas to dots, accept only finite nonnegative values, map `links/rechts/symmetrisch` and English equivalents to `left/right/symmetric`, and accept booleans only for explicit `ja/nein`, `yes/no`, or `true/false` labelled values.
+
+Merge these fields at the end of `buildArticleFields`, retaining the higher-confidence value if a generic field already exists.
+
+- [ ] **Step 4: Run focused and full backend verification**
+
+Run:
+
+```powershell
+go test ./internal/application -run 'Test.*Track.*Article.*Fields' -count=1
+go test ./...
+go vet ./...
+```
+
+Expected: all commands PASS.
+
+---
+
+### Task 2: Convert track search suggestions into typed accessory subject values
+
+**Files:**
+- Modify: `frontend/src/features/accessories/accessoryArticleSearch.ts`
+- Modify: `frontend/src/features/accessories/useAccessoryArticleSearchController.ts`
+- Test: `frontend/src/features/accessories/accessoryArticleSearch.test.ts`
+- Test: `frontend/src/features/accessories/useAccessoryArticleSearchController.test.tsx`
+
+**Interfaces:**
+- Consumes: canonical track search fields from Task 1 and the existing `articleTypeFieldRegistry.track` definitions.
+- Produces: `accessorySearchInput`, `accessorySearchFieldGroups`, `currentAccessorySearchValue`, `isSelectableAccessorySearchValue`, and `applyAccessorySearchResult` with typed track support.
+
+- [ ] **Step 1: Write failing frontend mapping tests**
+
+Create a track form containing existing attributes and assert that:
+
+```ts
+expect(accessorySearchInput(form).fields).toMatchObject({
+  articleType: "track",
+  subtype: "turnout",
+  trackSystem: "TT Modellgleis",
+  lengthMm: "129.5",
+  roadbed: "false"
+});
+expect(currentAccessorySearchValue(form, "lengthMm")).toBe("129.5");
+expect(isSelectableAccessorySearchValue("direction", "left", manufacturers, gauges, "track")).toBe(true);
+expect(isSelectableAccessorySearchValue("direction", "up", manufacturers, gauges, "track")).toBe(false);
+```
+
+Apply a selected result and assert that text/boolean/single-select attributes are replaced by key while numbers populate `attributeNumberDrafts` with the normalized value and preserve the registry unit.
+
+- [ ] **Step 2: Run focused tests and verify RED**
+
+Run: `npm.cmd test -- --run src/features/accessories/accessoryArticleSearch.test.ts src/features/accessories/useAccessoryArticleSearchController.test.tsx`
+
+Expected: FAIL because track fields are neither exposed nor applied.
+
+- [ ] **Step 3: Implement typed mapping**
+
+Add helpers based on `fieldDefinitionsForType(form.articleType)`:
+
+```ts
+function subjectSearchValue(form: ArticleEditorForm, key: string): string {
+  const draft = form.attributeNumberDrafts[key];
+  if (draft !== undefined) return draft.trim();
+  const attribute = form.attributes.find((item) => item.key === key);
+  if (!attribute) return "";
+  if (attribute.kind === "text") return attribute.textValue;
+  if (attribute.kind === "number") return String(attribute.numberValue);
+  if (attribute.kind === "boolean") return String(attribute.booleanValue);
+  return attribute.optionValues.join(", ");
+}
+```
+
+Include `articleType`, `subtype`, and nonempty subject values in the search request. Add a localized `Fachangaben: Gleis` group using existing subject-field translations. Validate each suggestion against its definition before selection. Convert selected values into existing `AccessoryAttributeValue` variants without changing the API response type.
+
+Update `canSelectField` calls in the controller to pass the current article type.
+
+- [ ] **Step 4: Run focused frontend tests**
+
+Run: `npm.cmd test -- --run src/features/accessories/accessoryArticleSearch.test.ts src/features/accessories/useAccessoryArticleSearchController.test.tsx`
+
+Expected: PASS.
+
+---
+
+### Task 3: Auto-manage scale and keyword defaults per editor session
+
+**Files:**
+- Create: `frontend/src/features/accessories/articleEditorAutomation.ts`
+- Create: `frontend/src/features/accessories/articleEditorAutomation.test.ts`
+- Modify: `frontend/src/features/accessories/ArticleEditorDialog.tsx`
+- Modify: `frontend/src/features/accessories/ArticleCoreTab.tsx`
+- Test: `frontend/src/features/accessories/ArticleEditorDialog.test.tsx`
+
+**Interfaces:**
+- Produces: `scaleForGauges(gauges: string[], entries: MasterDataEntry[]): string` and `suggestedArticleKeywords(form: ArticleEditorForm, articleTypeLabel: string, subtypeLabel: string): string`.
+- Consumes: gauge `metadata.scale`, localized type/subtype labels, and the existing `onChange` form patch seam.
+
+- [ ] **Step 1: Write failing pure helper tests**
+
+Assert that TT resolves to `1:120`, missing metadata returns an empty string, and keyword values are trimmed and deduplicated case-insensitively:
+
+```ts
+expect(scaleForGauges(["TT"], gaugeEntries)).toBe("1:120");
+expect(suggestedArticleKeywords(form, "Gleis", "Weiche"))
+  .toBe("Einfache Weiche EW1 links, Tillig, Gleis, Weiche");
+```
+
+- [ ] **Step 2: Write failing editor-session behavior tests**
+
+Use an `ArticleEditorDialog` harness whose `onChange` updates form state. Verify:
+
+1. selecting TT fills `1:120`;
+2. selecting another gauge updates an untouched auto scale;
+3. manually typing `1:100` prevents later gauge changes from overwriting it;
+4. name/manufacturer/type/subtype changes update generated keywords;
+5. manually editing keywords prevents later source changes from overwriting them;
+6. a persisted nonempty keyword field starts in manual mode.
+
+- [ ] **Step 3: Run tests and verify RED**
+
+Run: `npm.cmd test -- --run src/features/accessories/articleEditorAutomation.test.ts src/features/accessories/ArticleEditorDialog.test.tsx`
+
+Expected: FAIL because automatic defaults do not exist.
+
+- [ ] **Step 4: Implement helpers and session ownership**
+
+Implement pure derivation helpers. In `ArticleEditorDialog`, initialize refs once per keyed session:
+
+```ts
+const scaleAutoManagedRef = useRef(!props.form.scale.trim());
+const keywordAutoManagedRef = useRef(!props.form.keywords.trim());
+const lastAutoScaleRef = useRef("");
+```
+
+Wrap user-originated core changes so direct edits to `scale` or `keywords` disable their respective automatic mode. Use effects keyed to gauges and keyword source fields to call `props.onChange` only when the derived value differs. The editor is already keyed by `sessionKey`, so refs reset for each create/edit session. Keep `ArticleCoreTab` controlled and route scale/keyword edits through the wrapper.
+
+- [ ] **Step 5: Run focused frontend tests**
+
+Run: `npm.cmd test -- --run src/features/accessories/articleEditorAutomation.test.ts src/features/accessories/ArticleEditorDialog.test.tsx`
+
+Expected: PASS.
+
+---
+
+### Task 4: Preserve and verify popup stacking and gauge typeahead fixes
+
+**Files:**
+- Modify: `frontend/src/styles/vehicle-dialogs.css`
+- Modify: `frontend/src/shared/ui/AppMultiSelect.tsx`
+- Test: `frontend/src/features/accessories/accessoriesResponsive.test.ts`
+- Test: `frontend/src/shared/ui/AppMultiSelect.test.tsx`
+
+**Interfaces:**
+- Preserves the already implemented local behavior: search layers above editor layer and label typeahead for multi-selects.
+
+- [ ] **Step 1: Re-run the existing focused regression tests**
+
+Run: `npm.cmd test -- --run src/features/accessories/accessoriesResponsive.test.ts src/shared/ui/AppMultiSelect.test.tsx`
+
+Expected: 13 tests PASS.
+
+- [ ] **Step 2: Review integration with new scale behavior**
+
+Confirm the gauge typeahead test selects `TT`, the editor receives `gauges: ["TT"]`, and Task 3 derives `scale: "1:120"` without treating the selection as a manual scale edit.
+
+---
+
+### Task 5: Full verification and local server update
+
+**Files:**
+- Verify only; do not commit generated `frontend/dist`, `.cache`, or local `data`.
+
+**Interfaces:**
+- Produces a locally testable `v0.1.17` server with the unpushed fixes.
+
+- [ ] **Step 1: Run all checks**
+
+Run:
+
+```powershell
+cd backend
+go test ./...
+go vet ./...
+cd ..\frontend
+npm.cmd test -- --run
+npm.cmd run build
+cd ..
+git diff --check
+git status --short
+```
+
+Expected: all tests/builds pass; only intended source, test, spec, and plan files are changed or committed.
+
+- [ ] **Step 2: Restart the local server from this worktree**
+
+Identify the exact PID listening on `18083`, stop only that process, and start `go run ./cmd/railkeeper` with:
+
+```powershell
+$env:RAILKEEPER_ADDR=':18083'
+$env:RAILKEEPER_DATA_DIR='C:\Users\droth\Documents\GitHub\RailKeeper\data'
+$env:RAILKEEPER_MIGRATIONS_DIR='C:\Users\droth\Documents\GitHub\RailKeeper\.worktrees\accessory-search-interactions\backend\migrations'
+$env:RAILKEEPER_SEEDS_DIR='C:\Users\droth\Documents\GitHub\RailKeeper\.worktrees\accessory-search-interactions\backend\seeds'
+$env:RAILKEEPER_STATIC_DIR='C:\Users\droth\Documents\GitHub\RailKeeper\.worktrees\accessory-search-interactions\frontend\dist'
+$env:GOCACHE='C:\Users\droth\Documents\GitHub\RailKeeper\.worktrees\accessory-search-interactions\.cache\go-build'
+```
+
+Expected: `/health` returns `{"status":"ok"}`, `/api/v1/version` returns `0.1.17`, `/accessories` returns HTTP 200, and its HTML references the newly built asset.
+
+- [ ] **Step 3: Report local-only state**
+
+Report exact test counts, build result, changed files, server state, and that no implementation commit, push, PR, merge, or release was performed.

--- a/docs/superpowers/specs/2026-08-13-accessory-search-enrichment-design.md
+++ b/docs/superpowers/specs/2026-08-13-accessory-search-enrichment-design.md
@@ -1,0 +1,98 @@
+# Accessory Search Enrichment Design
+
+## Goal
+
+Extend the accessory editor with structured subject-data suggestions from article web search,
+automatic scale selection from gauge master data, and useful keyword defaults. The behavior must
+preserve manual user input and remain local to the accessory search fix branch.
+
+## Scope
+
+### Structured track data from web search
+
+For articles of type `track`, the article search request includes the article type, subtype, and
+the current track subject values as search context. Search enrichment may return the following
+canonical fields:
+
+- `trackSystem`
+- `lengthMm`
+- `radiusMm`
+- `angleDegrees`
+- `direction`
+- `frogAngleDegrees`
+- `sleeperType`
+- `railHeightMm`
+- `roadbed`
+- `connectionCount`
+- `digitalReady`
+
+The article search dialog presents these values in a separate `Fachangaben: Gleis` field group.
+Every value remains a suggestion and must be selected before it is applied. The frontend validates
+the returned value against the existing track field definition before converting it to an
+`AccessoryAttributeValue` or numeric draft. Invalid numbers, booleans, or option values cannot be
+selected or imported. Existing subject values are shown as conflicts and are not selected by
+default.
+
+Search extraction should use structured page data and clearly labelled product specifications.
+It must not infer unsupported values from unrelated prose. Existing URL, timeout, redirect, MIME,
+and size protections remain unchanged.
+
+## Automatic scale behavior
+
+Gauge master data already contains a `scale` metadata value. Selecting the first gauge fills the
+article scale from that active gauge entry.
+
+The scale remains auto-managed while it is empty or still equals the last automatically derived
+value. A later gauge change updates an auto-managed scale. As soon as the user edits the scale
+field manually, subsequent gauge changes leave it unchanged. When several gauges are selected,
+the first selected gauge determines the automatic scale.
+
+## Automatic keyword behavior
+
+For a new article with an initially empty keyword field, RailKeeper builds a comma-separated,
+case-insensitively deduplicated list from:
+
+- the complete article designation,
+- the manufacturer label,
+- the localized article-type label,
+- the localized subtype label.
+
+The generated list stays synchronized while those source fields change. The first manual edit of
+the keyword field disables automatic synchronization for the current editor session. Existing
+articles with stored keywords start in manual mode. An existing article with no keywords starts in
+automatic mode, so missing keywords can be populated without overwriting stored content.
+
+## Component boundaries
+
+- Pure accessory editor helpers derive scale and keyword defaults and convert search fields to
+  typed subject attributes.
+- `ArticleCoreTab` reports user changes without owning synchronization state.
+- `ArticleEditorDialog` owns per-editor-session auto-management state and composes patches before
+  forwarding them to the existing controller.
+- The accessory article-search adapter supplies request context, field groups, selection
+  validation, current-value comparison, and result application.
+- Backend article-search enrichment extracts only canonical track fields and returns them through
+  the existing `fields` map, so the public response shape stays compatible.
+
+## Error handling and compatibility
+
+- Missing gauge scale metadata leaves the scale unchanged.
+- Unknown or inactive gauges remain non-importable, matching existing master-data behavior.
+- Unsupported, malformed, or ambiguous subject values remain visible only when safe to display,
+  but cannot be applied.
+- Manual scale and keyword values always win over automatic defaults.
+- Non-track accessory types keep their current article-search behavior.
+- No database migration or API response schema change is required.
+
+## Verification
+
+Tests cover:
+
+- extraction and normalization of representative Tillig track specifications,
+- search request context and the additional track field group,
+- safe conversion of text, number, boolean, and direction suggestions,
+- rejection of malformed or unsupported subject values,
+- scale derivation, gauge changes, and manual scale preservation,
+- keyword synchronization, deduplication, and manual override,
+- the existing article-search popup and keyboard interaction regressions,
+- the complete frontend suite, backend suite, frontend production build, and `git diff --check`.

--- a/frontend/src/features/accessories/ArticleEditorDialog.test.tsx
+++ b/frontend/src/features/accessories/ArticleEditorDialog.test.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { render, screen, within } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
@@ -51,7 +51,8 @@ const manufacturerEntries: MasterDataEntry[] = [{
 }];
 const gaugeEntries: MasterDataEntry[] = [{
   id: "gauge:tt", type: "gauge", key: "tt", label: "TT", active: true,
-  sortOrder: 10, metadata: {}, createdAt: "2026-08-08T08:00:00Z", updatedAt: "2026-08-08T08:00:00Z"
+  sortOrder: 10, metadata: { scale: "1:120" }, createdAt: "2026-08-08T08:00:00Z",
+  updatedAt: "2026-08-08T08:00:00Z"
 }];
 const stockUnitEntries: MasterDataEntry[] = [{
   id: "stock-unit-piece", type: "stock_unit", key: "piece", label: "Piece", active: true,
@@ -119,7 +120,81 @@ function props(overrides: Partial<ArticleEditorDialogProps> = {}): ArticleEditor
   };
 }
 
+function AutomationHarness({
+  initialForm,
+  gauges = [
+    ...gaugeEntries,
+    { ...gaugeEntries[0]!, id: "gauge:h0", key: "h0", label: "H0", metadata: { scale: "1:87" } }
+  ]
+}: {
+  initialForm: ReturnType<typeof emptyArticleEditorForm>;
+  gauges?: MasterDataEntry[];
+}) {
+  const [form, setForm] = useState(initialForm);
+  const change = (patch: Partial<typeof form>) => setForm((current) => ({ ...current, ...patch }));
+  return <>
+    <button type="button" onClick={() => change({ gauges: ["TT"] })}>Testspur TT</button>
+    <button type="button" onClick={() => change({ gauges: ["H0"] })}>Testspur H0</button>
+    <button type="button" onClick={() => change({ name: "Neue Bezeichnung" })}>Testname ändern</button>
+    <ArticleEditorDialog {...props({ form, gaugeEntries: gauges, onChange: change })} />
+  </>;
+}
+
 describe("ArticleEditorDialog", () => {
+  it("updates an automatically derived scale until the scale is edited manually", async () => {
+    const user = userEvent.setup();
+    render(<AutomationHarness initialForm={emptyArticleEditorForm()} />);
+
+    await user.click(screen.getByRole("button", { name: "Testspur TT" }));
+    await waitFor(() => expect(screen.getByRole("textbox", { name: "Maßstab" })).toHaveValue("1:120"));
+    await user.click(screen.getByRole("button", { name: "Testspur H0" }));
+    await waitFor(() => expect(screen.getByRole("textbox", { name: "Maßstab" })).toHaveValue("1:87"));
+
+    const scale = screen.getByRole("textbox", { name: "Maßstab" });
+    await user.clear(scale);
+    await user.type(scale, "1:100");
+    await user.click(screen.getByRole("button", { name: "Testspur TT" }));
+    expect(scale).toHaveValue("1:100");
+  });
+
+  it("synchronizes generated keywords until their first manual edit", async () => {
+    const user = userEvent.setup();
+    render(<AutomationHarness initialForm={{
+      ...emptyArticleEditorForm(),
+      name: "Einfache Weiche EW1 links",
+      manufacturer: "Tillig",
+      articleType: "track",
+      subtype: "straight"
+    }} />);
+
+    await user.click(screen.getByText("Weitere Angaben"));
+    const keywords = screen.getByRole("textbox", { name: "Schlagwörter" });
+    await waitFor(() => expect(keywords)
+      .toHaveValue("Einfache Weiche EW1 links, Tillig, Gleis, Gerade"));
+
+    await user.clear(keywords);
+    await user.type(keywords, "eigene, werte");
+    await user.click(screen.getByRole("button", { name: "Testname ändern" }));
+    expect(keywords).toHaveValue("eigene, werte");
+  });
+
+  it("treats persisted nonempty keywords as manual content", async () => {
+    const user = userEvent.setup();
+    render(<AutomationHarness initialForm={{
+      ...emptyArticleEditorForm(),
+      name: "Alte Bezeichnung",
+      manufacturer: "Tillig",
+      articleType: "track",
+      subtype: "straight",
+      keywords: "Bestandswert"
+    }} />);
+
+    await user.click(screen.getByText("Weitere Angaben"));
+    const keywords = screen.getByRole("textbox", { name: "Schlagwörter" });
+    await user.click(screen.getByRole("button", { name: "Testname ändern" }));
+    expect(keywords).toHaveValue("Bestandswert");
+  });
+
   it("offers the vehicle-style barcode and article-data searches in the article tab", async () => {
     const user = userEvent.setup();
     const run = vi.fn();

--- a/frontend/src/features/accessories/ArticleEditorDialog.tsx
+++ b/frontend/src/features/accessories/ArticleEditorDialog.tsx
@@ -17,6 +17,7 @@ import { ArticlePurchaseDocumentsTab } from "./ArticlePurchaseDocumentsTab";
 import { ArticleStockTab } from "./ArticleStockTab";
 import { ArticleSubjectTab } from "./ArticleSubjectTab";
 import { ArticleUsageHistoryTab } from "./ArticleUsageHistoryTab";
+import { scaleForGauges, suggestedArticleKeywords } from "./articleEditorAutomation";
 import type {
   ArticleEditorFieldErrors,
   ArticleEditorForm,
@@ -32,6 +33,7 @@ import {
   compatibleNumberDraftsForType,
   type CustomArticleSubjectFieldDefinition
 } from "./articleTypeFields";
+import { articleSubtypeLabel } from "./articleSubtypes";
 import { articleTypeLabel } from "./articleTypes";
 
 export type ArticleEditorDialogProps = {
@@ -111,6 +113,10 @@ export function ArticleEditorDialog(props: ArticleEditorDialogProps) {
   const viewInitialFocusRef = useRef<HTMLButtonElement | null>(null);
   const articleTypeTriggerRef = useRef<HTMLButtonElement | null>(null);
   const tabListRef = useRef<HTMLElement | null>(null);
+  const automationInitializedRef = useRef(false);
+  const scaleAutoManagedRef = useRef(false);
+  const keywordsAutoManagedRef = useRef(false);
+  const lastAutoScaleRef = useRef("");
   const [pendingArticleType, setPendingArticleType] = useState<AccessoryArticleType | null>(null);
   const confirmationPending = props.closeConfirmationOpen || props.duplicateCandidates.length > 0 ||
     pendingArticleType !== null;
@@ -120,6 +126,9 @@ export function ArticleEditorDialog(props: ArticleEditorDialogProps) {
     ? t("accessories.editor.create")
     : props.mode === "edit" ? t("accessories.editor.edit") : t("accessories.editor.view");
   const configuredArticleTypeLabel = articleTypeLabel(props.form.articleType, props.articleTypeEntries, t);
+  const configuredSubtypeLabel = props.form.subtype
+    ? articleSubtypeLabel(props.form.articleType, props.form.subtype, props.subtypeEntries, t)
+    : "";
   const primaryImageDocument = props.resources.documents.find((document) =>
     document.category === "image" && document.isPrimary);
   const displayedArticle = props.article ? {
@@ -130,6 +139,7 @@ export function ArticleEditorDialog(props: ArticleEditorDialogProps) {
   } : null;
   const createTypeConfigurationUnavailable = props.mode === "create" &&
     (props.articleTypeEntriesLoading || Boolean(props.articleTypeEntriesError));
+  const automationEnabled = props.mode !== "view" && props.permissions.canEdit;
   const tabs: Array<{ key: ArticleEditorTab; label: string; subject?: boolean }> = [
     { key: "article", label: t("accessories.editor.tabs.article") },
     { key: "stock", label: t("accessories.editor.tabs.stock") },
@@ -145,6 +155,8 @@ export function ArticleEditorDialog(props: ArticleEditorDialogProps) {
   ];
 
   const changeCore = (patch: Partial<ArticleEditorForm>) => {
+    if (patch.scale !== undefined) scaleAutoManagedRef.current = false;
+    if (patch.keywords !== undefined) keywordsAutoManagedRef.current = false;
     const nextType = patch.articleType;
     if (!nextType || nextType === props.form.articleType) {
       props.onChange(patch);
@@ -181,6 +193,44 @@ export function ArticleEditorDialog(props: ArticleEditorDialogProps) {
     });
     setPendingArticleType(null);
   };
+
+  useEffect(() => {
+    if (props.loading || !automationEnabled || automationInitializedRef.current) return;
+    scaleAutoManagedRef.current = !props.form.scale.trim();
+    keywordsAutoManagedRef.current = !props.form.keywords.trim();
+    automationInitializedRef.current = true;
+  }, [automationEnabled, props.loading]);
+
+  useEffect(() => {
+    if (props.loading || !automationEnabled || !automationInitializedRef.current ||
+        !scaleAutoManagedRef.current) return;
+    const scale = scaleForGauges(props.form.gauges, props.gaugeEntries || []);
+    if (!scale || scale === props.form.scale) return;
+    lastAutoScaleRef.current = scale;
+    props.onChange({ scale });
+  }, [automationEnabled, props.form.gauges, props.form.scale, props.gaugeEntries, props.loading]);
+
+  useEffect(() => {
+    if (props.loading || !automationEnabled || !automationInitializedRef.current ||
+        !keywordsAutoManagedRef.current) return;
+    const keywords = suggestedArticleKeywords(
+      props.form,
+      configuredArticleTypeLabel,
+      configuredSubtypeLabel
+    );
+    if (keywords === props.form.keywords) return;
+    props.onChange({ keywords });
+  }, [
+    props.form.name,
+    props.form.manufacturer,
+    props.form.articleType,
+    props.form.subtype,
+    props.form.keywords,
+    configuredArticleTypeLabel,
+    configuredSubtypeLabel,
+    automationEnabled,
+    props.loading
+  ]);
 
   useEffect(() => {
     if (props.loading) return;
@@ -355,7 +405,7 @@ export function ArticleEditorDialog(props: ArticleEditorDialogProps) {
       </footer>
     </section>
     {props.articleSearch?.state.open ? <ArticleSearchDialog
-      fieldGroups={accessorySearchFieldGroups(t)}
+      fieldGroups={accessorySearchFieldGroups(t, props.form.articleType)}
       currentValue={(key) => currentAccessorySearchValue(props.form, key)}
       loading={props.articleSearch.state.loading}
       response={props.articleSearch.state.response}

--- a/frontend/src/features/accessories/accessoriesResponsive.test.ts
+++ b/frontend/src/features/accessories/accessoriesResponsive.test.ts
@@ -4,6 +4,12 @@ import { describe, expect, it } from "vitest";
 
 const responsiveCss = readFileSync(resolve(process.cwd(), "src/styles/overrides-responsive.css"), "utf8");
 const accessoriesCss = readFileSync(resolve(process.cwd(), "src/styles/accessories.css"), "utf8");
+const vehicleDialogsCss = readFileSync(resolve(process.cwd(), "src/styles/vehicle-dialogs.css"), "utf8");
+
+function zIndex(css: string, selector: string) {
+  const match = css.match(new RegExp(`${selector}\\s*\\{[^}]*z-index:\\s*(\\d+)`, "s"));
+  return match ? Number(match[1]) : -1;
+}
 
 describe("article editor responsive tabs", () => {
   it("restores horizontally reachable tabs in the later mobile override stylesheet", () => {
@@ -51,5 +57,12 @@ describe("article editor responsive tabs", () => {
     );
     expect(accessoriesCss).not.toMatch(/\.article-stock-form\s*\{[^}]*height:\s*100%/s);
     expect(accessoriesCss).not.toContain(".article-stock-form > .primary-button");
+  });
+
+  it("stacks article and barcode search dialogs above the article editor", () => {
+    const editorLayer = zIndex(accessoriesCss, "\\.article-editor-layer");
+
+    expect(zIndex(vehicleDialogsCss, "\\.article-search-layer")).toBeGreaterThan(editorLayer);
+    expect(zIndex(vehicleDialogsCss, "\\.barcode-search-layer")).toBeGreaterThan(editorLayer);
   });
 });

--- a/frontend/src/features/accessories/accessoryArticleSearch.test.ts
+++ b/frontend/src/features/accessories/accessoryArticleSearch.test.ts
@@ -5,9 +5,11 @@ import { articleSelectionKey } from "../../shared/articleSearch/articleSearchMod
 import { emptyArticleEditorForm } from "./articleEditorModel";
 import {
   accessorySearchInput,
+  accessorySearchFieldGroups,
   applyAccessorySearchResult,
   currentAccessorySearchValue,
   hasAccessorySearchCriteria,
+  isSelectableAccessorySearchValue,
   isUsableAccessorySearchValue
 } from "./accessoryArticleSearch";
 
@@ -58,23 +60,35 @@ const result: ArticleSearchResult = {
 };
 
 describe("accessory article search", () => {
-  it("maps article criteria without inferring article type", () => {
+  it("maps article criteria and current typed subject values as search context", () => {
     const input = accessorySearchInput({
       ...emptyArticleEditorForm(),
       manufacturer: "Tillig",
       articleNumber: "83101",
       gauges: ["TT"],
-      ean: "4012500831012"
+      ean: "4012500831012",
+      articleType: "track",
+      subtype: "turnout",
+      attributes: [
+        { key: "trackSystem", kind: "text", textValue: "TT Modellgleis" },
+        { key: "roadbed", kind: "boolean", booleanValue: false }
+      ],
+      attributeNumberDrafts: { lengthMm: "129,5" }
     });
 
     expect(input).toEqual(expect.objectContaining({
       manufacturer: "Tillig",
       articleNumber: "83101",
       gauge: "TT",
-      fields: expect.objectContaining({ ean: "4012500831012" })
+      fields: expect.objectContaining({
+        ean: "4012500831012",
+        articleType: "track",
+        subtype: "turnout",
+        trackSystem: "TT Modellgleis",
+        roadbed: "false",
+        lengthMm: "129.5"
+      })
     }));
-    expect(input.fields).not.toHaveProperty("articleType");
-    expect(input.fields).not.toHaveProperty("subtype");
   });
 
   it("accepts EAN alone or manufacturer, gauge, and article identity", () => {
@@ -141,8 +155,80 @@ describe("accessory article search", () => {
   });
 
   it("formats current accessory values for conflict comparison", () => {
-    const form = { ...emptyArticleEditorForm(), gauges: ["TT", "H0"], productUrl: result.url };
+    const form = {
+      ...emptyArticleEditorForm(),
+      articleType: "track" as const,
+      gauges: ["TT", "H0"],
+      productUrl: result.url,
+      attributes: [
+        { key: "trackSystem", kind: "text" as const, textValue: "TT Modellgleis" },
+        { key: "roadbed", kind: "boolean" as const, booleanValue: false }
+      ],
+      attributeNumberDrafts: { lengthMm: "129,5" }
+    };
     expect(currentAccessorySearchValue(form, "gauge")).toBe("TT, H0");
     expect(currentAccessorySearchValue(form, "articleSourceUrl")).toBe(result.url);
+    expect(currentAccessorySearchValue(form, "trackSystem")).toBe("TT Modellgleis");
+    expect(currentAccessorySearchValue(form, "roadbed")).toBe("false");
+    expect(currentAccessorySearchValue(form, "lengthMm")).toBe("129.5");
+  });
+
+  it("shows and validates the track subject field group", () => {
+    const t = (key: string, values?: Record<string, string | number>) =>
+      key === "accessories.editor.tabs.subject" ? `Fachangaben: ${values?.type}` : key;
+    const groups = accessorySearchFieldGroups(t, "track");
+
+    expect(groups.at(-1)).toMatchObject({
+      key: "subject",
+      label: "Fachangaben: accessories.articleType.track"
+    });
+    expect(groups.at(-1)?.fields.map((field) => field.key)).toEqual(expect.arrayContaining([
+      "trackSystem", "lengthMm", "radiusMm", "direction", "roadbed", "digitalReady"
+    ]));
+    expect(isSelectableAccessorySearchValue("direction", "left", [manufacturer], [gauge], "track"))
+      .toBe(true);
+    expect(isSelectableAccessorySearchValue("direction", "up", [manufacturer], [gauge], "track"))
+      .toBe(false);
+    expect(isSelectableAccessorySearchValue("lengthMm", "129,5", [manufacturer], [gauge], "track"))
+      .toBe(true);
+    expect(isSelectableAccessorySearchValue("lengthMm", "-2", [manufacturer], [gauge], "track"))
+      .toBe(false);
+  });
+
+  it("applies selected track subject fields as typed values", () => {
+    const trackResult: ArticleSearchResult = {
+      ...result,
+      fields: {
+        trackSystem: { label: "Gleissystem", value: "TT Modellgleis", confidence: 1 },
+        lengthMm: { label: "Länge", value: "129,5", confidence: 1 },
+        direction: { label: "Richtung", value: "left", confidence: 1 },
+        roadbed: { label: "Bettung", value: "false", confidence: 1 },
+        digitalReady: { label: "Digitaltauglich", value: "true", confidence: 1 }
+      }
+    };
+    const selectedFields = Object.fromEntries(Object.keys(trackResult.fields).map((key) => [
+      articleSelectionKey(trackResult, key, 0), true
+    ]));
+    const patch = applyAccessorySearchResult({
+      form: {
+        ...emptyArticleEditorForm(),
+        articleType: "track",
+        attributes: [{ key: "trackSystem", kind: "text", textValue: "Alt" }]
+      },
+      result: trackResult,
+      resultIndex: 0,
+      selectedFields,
+      manufacturers: [manufacturer],
+      gauges: [gauge]
+    });
+
+    expect(patch.attributeNumberDrafts).toEqual({ lengthMm: "129.5" });
+    expect(patch.attributes).toEqual(expect.arrayContaining([
+      { key: "trackSystem", kind: "text", textValue: "TT Modellgleis" },
+      { key: "direction", kind: "single_select", optionValues: ["left"] },
+      { key: "roadbed", kind: "boolean", booleanValue: false },
+      { key: "digitalReady", kind: "boolean", booleanValue: true }
+    ]));
+    expect(patch.attributes?.filter((attribute) => attribute.key === "trackSystem")).toHaveLength(1);
   });
 });

--- a/frontend/src/features/accessories/accessoryArticleSearch.ts
+++ b/frontend/src/features/accessories/accessoryArticleSearch.ts
@@ -1,4 +1,6 @@
 import type {
+  AccessoryArticleType,
+  AccessoryAttributeValue,
   ArticleSearchInput,
   ArticleSearchResult,
   MasterDataEntry
@@ -11,6 +13,11 @@ import {
 } from "../../shared/articleSearch/articleSearchModel";
 import { articleSearchSources } from "../../shared/articleSearch/articleSearchPreferences";
 import type { ArticleEditorForm } from "./articleEditorModel";
+import {
+  articleTypeFieldRegistry,
+  subjectValidationIssues,
+  type ArticleSubjectFieldDefinition
+} from "./articleTypeFields";
 
 const directFieldMap = {
   manufacturer: "manufacturer",
@@ -45,21 +52,52 @@ export function isSelectableAccessorySearchValue(
   key: string,
   value: string,
   manufacturers: MasterDataEntry[],
-  gauges: MasterDataEntry[]
+  gauges: MasterDataEntry[],
+  articleType: AccessoryArticleType = "other"
 ) {
-  if (!isUsableAccessorySearchValue(key, value)) return false;
+  if (!isUsableAccessorySearchValue(key, value, articleType)) return false;
   if (key === "manufacturer") return Boolean(knownActiveLabel(manufacturers, value));
   if (key === "gauge") return Boolean(knownActiveLabel(gauges, value));
   return true;
 }
 
+function subjectDefinition(articleType: AccessoryArticleType, key: string) {
+  return articleTypeFieldRegistry[articleType].find((definition) => definition.key === key);
+}
+
+function subjectSearchValue(form: ArticleEditorForm, key: string) {
+  const definition = subjectDefinition(form.articleType, key);
+  if (!definition) return "";
+  if (definition.kind === "number") {
+    const draft = form.attributeNumberDrafts[key]?.trim();
+    if (draft) return draft.replace(",", ".");
+  }
+  const attribute = form.attributes.find((candidate) =>
+    candidate.key === key && candidate.kind === definition.kind);
+  if (!attribute) return "";
+  switch (attribute.kind) {
+  case "text": return attribute.textValue.trim();
+  case "number": return String(attribute.numberValue);
+  case "boolean": return String(attribute.booleanValue);
+  case "date": return attribute.dateValue.trim();
+  case "single_select":
+  case "multi_select": return attribute.optionValues.join(", ");
+  }
+}
+
 export function accessorySearchInput(form: ArticleEditorForm): ArticleSearchInput {
+  const subjectFields = Object.fromEntries(articleTypeFieldRegistry[form.articleType]
+    .map((definition) => [definition.key, subjectSearchValue(form, definition.key)])
+    .filter(([, value]) => value));
   const fields = Object.fromEntries(Object.entries({
     ean: form.ean,
     scale: form.scale,
     description: form.description,
-    articleSourceUrl: form.productUrl
-  }).map(([key, value]) => [key, value.trim()]).filter(([, value]) => value));
+    articleSourceUrl: form.productUrl,
+    articleType: form.articleType,
+    subtype: form.subtype,
+    ...subjectFields
+  }).map(([key, value]) => [key, compact(value)]).filter(([, value]) => value));
   return {
     manufacturer: compact(form.manufacturer) || undefined,
     articleNumber: compact(form.articleNumber) || undefined,
@@ -79,8 +117,11 @@ export function hasAccessorySearchCriteria(input: ArticleSearchInput) {
   return Boolean(identity && manufacturer && gauge);
 }
 
-export function accessorySearchFieldGroups(t: Translate): ArticleSearchFieldGroup[] {
-  return [
+export function accessorySearchFieldGroups(
+  t: Translate,
+  articleType: AccessoryArticleType = "other"
+): ArticleSearchFieldGroup[] {
+  const groups: ArticleSearchFieldGroup[] = [
     {
       key: "article",
       label: t("vehicles.articleSearch.group.model"),
@@ -102,25 +143,87 @@ export function accessorySearchFieldGroups(t: Translate): ArticleSearchFieldGrou
       ]
     }
   ];
+  if (articleType === "track") {
+    groups.push({
+      key: "subject",
+      label: t("accessories.editor.tabs.subject", { type: t("accessories.articleType.track") }),
+      fields: articleTypeFieldRegistry[articleType].map((definition) => ({
+        key: definition.key,
+        label: t(definition.labelKey)
+      }))
+    });
+  }
+  return groups;
 }
 
 export function currentAccessorySearchValue(form: ArticleEditorForm, key: string) {
   if (key === "gauge") return form.gauges.join(", ");
   if (key === "articleSourceUrl") return form.productUrl.trim();
   const target = directFieldMap[key as keyof typeof directFieldMap];
-  return target ? compact(form[target]) : "";
+  return target ? compact(form[target]) : subjectSearchValue(form, key);
 }
 
-export function isUsableAccessorySearchValue(key: string, value: string) {
-  if (!searchFieldKeys.has(key as AccessorySearchFieldKey) || isBadCommonArticleValue(key, value)) {
-    return false;
+function isUsableSubjectValue(
+  definition: ArticleSubjectFieldDefinition,
+  value: string,
+  articleType: AccessoryArticleType
+) {
+  const normalized = value.trim();
+  if (!normalized) return false;
+  if (definition.kind === "number") {
+    return !subjectValidationIssues(articleType, [], {
+      [definition.key]: normalized.replace(",", ".")
+    })[definition.key];
   }
+  if (definition.kind === "boolean") return normalized === "true" || normalized === "false";
+  if (definition.kind === "single_select") return definition.options?.includes(normalized) ?? false;
+  if (definition.kind === "multi_select") {
+    const values = normalized.split(",").map((entry) => entry.trim()).filter(Boolean);
+    return values.length > 0 && values.every((entry) => definition.options?.includes(entry));
+  }
+  return true;
+}
+
+export function isUsableAccessorySearchValue(
+  key: string,
+  value: string,
+  articleType: AccessoryArticleType = "other"
+) {
+  const definition = subjectDefinition(articleType, key);
+  if (definition) return isUsableSubjectValue(definition, value, articleType);
+  if (!searchFieldKeys.has(key as AccessorySearchFieldKey) || isBadCommonArticleValue(key, value)) return false;
   if (key !== "articleSourceUrl") return true;
   try {
     const url = new URL(value);
     return url.protocol === "http:" || url.protocol === "https:";
   } catch {
     return false;
+  }
+}
+
+function replaceAttribute(
+  attributes: readonly AccessoryAttributeValue[],
+  nextAttribute: AccessoryAttributeValue
+) {
+  return [...attributes.filter((attribute) => attribute.key !== nextAttribute.key), nextAttribute];
+}
+
+function subjectAttribute(
+  definition: ArticleSubjectFieldDefinition,
+  value: string
+): AccessoryAttributeValue | undefined {
+  const normalized = value.trim();
+  switch (definition.kind) {
+  case "text": return { key: definition.key, kind: "text", textValue: normalized };
+  case "boolean": return { key: definition.key, kind: "boolean", booleanValue: normalized === "true" };
+  case "date": return { key: definition.key, kind: "date", dateValue: normalized };
+  case "single_select": return { key: definition.key, kind: "single_select", optionValues: [normalized] };
+  case "multi_select": return {
+    key: definition.key,
+    kind: "multi_select",
+    optionValues: normalized.split(",").map((entry) => entry.trim()).filter(Boolean)
+  };
+  case "number": return undefined;
   }
 }
 
@@ -140,9 +243,24 @@ export function applyAccessorySearchResult({
   gauges: MasterDataEntry[];
 }): Partial<ArticleEditorForm> {
   const patch: Partial<ArticleEditorForm> = {};
+  let nextAttributes = form.attributes;
+  let nextNumberDrafts = form.attributeNumberDrafts;
   for (const [key, field] of Object.entries(result.fields)) {
     if (!selectedFields[articleSelectionKey(result, key, resultIndex)] ||
-        !isUsableAccessorySearchValue(key, field.value)) {
+        !isUsableAccessorySearchValue(key, field.value, form.articleType)) {
+      continue;
+    }
+    const definition = subjectDefinition(form.articleType, key);
+    if (definition?.kind === "number") {
+      nextNumberDrafts = {
+        ...nextNumberDrafts,
+        [key]: field.value.trim().replace(",", ".")
+      };
+      continue;
+    }
+    if (definition) {
+      const attribute = subjectAttribute(definition, field.value);
+      if (attribute) nextAttributes = replaceAttribute(nextAttributes, attribute);
       continue;
     }
     if (key === "manufacturer") {
@@ -158,5 +276,7 @@ export function applyAccessorySearchResult({
     const target = directFieldMap[key as keyof typeof directFieldMap];
     if (target) Object.assign(patch, { [target]: field.value.trim() });
   }
+  if (nextAttributes !== form.attributes) patch.attributes = nextAttributes;
+  if (nextNumberDrafts !== form.attributeNumberDrafts) patch.attributeNumberDrafts = nextNumberDrafts;
   return patch;
 }

--- a/frontend/src/features/accessories/articleEditorAutomation.test.ts
+++ b/frontend/src/features/accessories/articleEditorAutomation.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import type { MasterDataEntry } from "../../shared/api";
+import { emptyArticleEditorForm } from "./articleEditorModel";
+import { scaleForGauges, suggestedArticleKeywords } from "./articleEditorAutomation";
+
+const timestamp = "2026-08-13T10:00:00Z";
+const gaugeEntries: MasterDataEntry[] = [{
+  id: "gauge:tt",
+  type: "gauge",
+  key: "tt",
+  label: "TT",
+  active: true,
+  sortOrder: 10,
+  metadata: { scale: "1:120" },
+  createdAt: timestamp,
+  updatedAt: timestamp
+}, {
+  id: "gauge:h0",
+  type: "gauge",
+  key: "h0",
+  label: "H0",
+  active: true,
+  sortOrder: 20,
+  metadata: {},
+  createdAt: timestamp,
+  updatedAt: timestamp
+}];
+
+describe("article editor automation", () => {
+  it("resolves scale metadata from the first active selected gauge", () => {
+    expect(scaleForGauges(["TT"], gaugeEntries)).toBe("1:120");
+    expect(scaleForGauges(["tt"], gaugeEntries)).toBe("1:120");
+    expect(scaleForGauges(["H0"], gaugeEntries)).toBe("");
+    expect(scaleForGauges(["unbekannt"], gaugeEntries)).toBe("");
+  });
+
+  it("builds trimmed, case-insensitively deduplicated keyword suggestions", () => {
+    const form = {
+      ...emptyArticleEditorForm(),
+      name: "  Einfache Weiche EW1 links ",
+      manufacturer: " Tillig ",
+      articleType: "track" as const,
+      subtype: "turnout"
+    };
+
+    expect(suggestedArticleKeywords(form, "Gleis", "Weiche"))
+      .toBe("Einfache Weiche EW1 links, Tillig, Gleis, Weiche");
+    expect(suggestedArticleKeywords({ ...form, manufacturer: "gleis" }, "Gleis", "Weiche"))
+      .toBe("Einfache Weiche EW1 links, gleis, Weiche");
+  });
+
+  it("does not generate keywords before an article has identity data", () => {
+    expect(suggestedArticleKeywords(emptyArticleEditorForm(), "Sonstiges", "")).toBe("");
+  });
+});

--- a/frontend/src/features/accessories/articleEditorAutomation.ts
+++ b/frontend/src/features/accessories/articleEditorAutomation.ts
@@ -1,0 +1,35 @@
+import type { MasterDataEntry } from "../../shared/api";
+import type { ArticleEditorForm } from "./articleEditorModel";
+
+function normalized(value: string) {
+  return value.trim().toLocaleLowerCase("de-DE");
+}
+
+export function scaleForGauges(gauges: readonly string[], entries: readonly MasterDataEntry[]) {
+  const firstGauge = gauges[0];
+  if (!firstGauge) return "";
+  const selected = normalized(firstGauge);
+  const entry = entries.find((candidate) => candidate.active && (
+    normalized(candidate.label) === selected || normalized(candidate.key) === selected
+  ));
+  const scale = entry?.metadata.scale;
+  return typeof scale === "string" ? scale.trim() : "";
+}
+
+export function suggestedArticleKeywords(
+  form: ArticleEditorForm,
+  articleTypeLabel: string,
+  subtypeLabel: string
+) {
+  if (!form.name.trim() && !form.manufacturer.trim()) return "";
+  const seen = new Set<string>();
+  return [form.name, form.manufacturer, articleTypeLabel, subtypeLabel]
+    .map((value) => value.trim())
+    .filter((value) => {
+      const key = normalized(value);
+      if (!key || seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    })
+    .join(", ");
+}

--- a/frontend/src/features/accessories/useAccessoryArticleSearchController.test.tsx
+++ b/frontend/src/features/accessories/useAccessoryArticleSearchController.test.tsx
@@ -142,6 +142,49 @@ describe("useAccessoryArticleSearchController", () => {
     }));
   });
 
+  it("preselects and applies compatible track subject suggestions", async () => {
+    const trackResult: ArticleSearchResult = {
+      ...searchResult,
+      fields: {
+        lengthMm: { label: "Länge", value: "129.5", confidence: 1 },
+        direction: { label: "Richtung", value: "left", confidence: 1 }
+      }
+    };
+    const articleSearch = vi.spyOn(api, "articleSearch")
+      .mockResolvedValue({ query: "Tillig 83101 TT", results: [trackResult] });
+    const form = {
+      ...emptyArticleEditorForm(),
+      manufacturer: "Tillig",
+      articleNumber: "83101",
+      gauges: ["TT"],
+      articleType: "track" as const
+    };
+    const updateForm = vi.fn();
+    const { result } = renderHook(() => useAccessoryArticleSearchController({
+      form,
+      readOnly: false,
+      pendingImageCount: 0,
+      manufacturers: entries("manufacturer", "tillig", "Tillig"),
+      gauges: entries("gauge", "tt", "TT"),
+      updateForm,
+      addImages: vi.fn()
+    }));
+
+    act(() => result.current.commands.run());
+    await waitFor(() => expect(result.current.state.loading).toBe(false));
+
+    expect(articleSearch).toHaveBeenCalledWith(expect.objectContaining({
+      fields: expect.objectContaining({ articleType: "track" })
+    }));
+    expect(result.current.state.selectedFields[articleSelectionKey(trackResult, "lengthMm", 0)])
+      .toBe(true);
+    act(() => result.current.commands.applyResult(trackResult));
+    expect(updateForm).toHaveBeenCalledWith(expect.objectContaining({
+      attributeNumberDrafts: { lengthMm: "129.5" },
+      attributes: [{ key: "direction", kind: "single_select", optionValues: ["left"] }]
+    }));
+  });
+
   it("does not open searches in read-only mode", () => {
     const articleSearch = vi.spyOn(api, "articleSearch");
     const { result } = renderController(true);

--- a/frontend/src/features/accessories/useAccessoryArticleSearchController.ts
+++ b/frontend/src/features/accessories/useAccessoryArticleSearchController.ts
@@ -68,7 +68,7 @@ export function useAccessoryArticleSearchController({
   const [selectedImages, setSelectedImages] = useState<Record<string, boolean>>({});
 
   const canSelectField = (key: string, value: string) =>
-    isSelectableAccessorySearchValue(key, value, manufacturers, gauges);
+    isSelectableAccessorySearchValue(key, value, manufacturers, gauges, form.articleType);
 
   const run = (searchForm = form, searchInput?: ArticleSearchInput) => {
     if (readOnly) return;

--- a/frontend/src/shared/ui/AppMultiSelect.test.tsx
+++ b/frontend/src/shared/ui/AppMultiSelect.test.tsx
@@ -73,9 +73,10 @@ describe("AppMultiSelect", () => {
   it("uses one roving option focus and supports listbox keyboard navigation", async () => {
     const user = userEvent.setup();
     const onValueChange = vi.fn();
+    const onParentKeyDown = vi.fn();
 
     render(
-      <>
+      <div onKeyDown={onParentKeyDown}>
         <AppMultiSelect
           label="Spurweiten"
           options={options}
@@ -84,7 +85,7 @@ describe("AppMultiSelect", () => {
           placeholder="Spurweiten auswählen"
         />
         <button type="button">Danach</button>
-      </>
+      </div>
     );
 
     const trigger = screen.getByRole("button", { name: "Spurweiten Spurweiten auswählen" });
@@ -105,15 +106,43 @@ describe("AppMultiSelect", () => {
     expect(h0).toHaveFocus();
     await user.keyboard("{End}");
     expect(tt).toHaveFocus();
+    onParentKeyDown.mockClear();
     await user.keyboard("{Escape}");
     expect(trigger).toHaveFocus();
     expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    expect(onParentKeyDown).not.toHaveBeenCalled();
 
     await user.keyboard("{Enter}");
     expect(screen.getByRole("option", { name: "H0" })).toHaveFocus();
     await user.tab();
     expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Danach" })).toHaveFocus();
+  });
+
+  it("opens and moves focus to an option when its label is typed", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+
+    render(
+      <AppMultiSelect
+        label="Spurweite"
+        options={options}
+        value={[]}
+        onValueChange={onValueChange}
+        placeholder="Spurweite auswählen"
+      />
+    );
+
+    const trigger = screen.getByRole("button", { name: "Spurweite Spurweite auswählen" });
+    trigger.focus();
+    await user.keyboard("tt");
+
+    expect(screen.getByRole("listbox", { name: "Spurweite" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "TT" })).toHaveFocus();
+    expect(onValueChange).not.toHaveBeenCalled();
+
+    await user.keyboard(" ");
+    expect(onValueChange).toHaveBeenCalledWith(["tt"]);
   });
 
   it("submits selected values and redirects required validation to the visible control", () => {

--- a/frontend/src/shared/ui/AppMultiSelect.tsx
+++ b/frontend/src/shared/ui/AppMultiSelect.tsx
@@ -5,6 +5,7 @@ import {
   Fragment,
   KeyboardEvent,
   ReactNode,
+  isValidElement,
   useEffect,
   useId,
   useRef,
@@ -33,6 +34,13 @@ export type AppMultiSelectProps = {
   placeholder: string;
   "aria-describedby"?: string;
 };
+
+function optionLabelText(label: ReactNode): string {
+  if (typeof label === "string" || typeof label === "number") return String(label);
+  if (Array.isArray(label)) return label.map(optionLabelText).join(" ");
+  if (isValidElement<{ children?: ReactNode }>(label)) return optionLabelText(label.props.children);
+  return "";
+}
 
 export const AppMultiSelect = forwardRef<HTMLButtonElement, AppMultiSelectProps>(function AppMultiSelect(
   {
@@ -64,6 +72,8 @@ export const AppMultiSelect = forwardRef<HTMLButtonElement, AppMultiSelectProps>
   const rootRef = useRef<HTMLDivElement | null>(null);
   const triggerRef = useRef<HTMLButtonElement | null>(null);
   const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const typeaheadRef = useRef("");
+  const typeaheadTimerRef = useRef<number | null>(null);
   const firstEnabled = options.findIndex((option) => !option.disabled);
   const lastEnabled = options
     .map((option, index) => ({ option, index }))
@@ -90,6 +100,10 @@ export const AppMultiSelect = forwardRef<HTMLButtonElement, AppMultiSelectProps>
     document.addEventListener("pointerdown", closeOutside);
     return () => document.removeEventListener("pointerdown", closeOutside);
   }, [open]);
+
+  useEffect(() => () => {
+    if (typeaheadTimerRef.current !== null) window.clearTimeout(typeaheadTimerRef.current);
+  }, []);
 
   const setTriggerRef = (node: HTMLButtonElement | null) => {
     triggerRef.current = node;
@@ -128,6 +142,30 @@ export const AppMultiSelect = forwardRef<HTMLButtonElement, AppMultiSelectProps>
     }
   };
 
+  const applyTypeahead = (key: string) => {
+    if (disabled || readOnly || options.length === 0) return;
+    if (typeaheadTimerRef.current !== null) window.clearTimeout(typeaheadTimerRef.current);
+    typeaheadRef.current = `${typeaheadRef.current}${key}`.slice(-30);
+    typeaheadTimerRef.current = window.setTimeout(() => {
+      typeaheadRef.current = "";
+      typeaheadTimerRef.current = null;
+    }, 700);
+    const repeatedCharacterSearch = typeaheadRef.current.length > 1 &&
+      new Set(typeaheadRef.current.toLocaleLowerCase("de-DE")).size === 1;
+    const query = (repeatedCharacterSearch ? key : typeaheadRef.current).trim().toLocaleLowerCase("de-DE");
+    const candidates = options.map((option, index) => ({
+      index,
+      option,
+      label: optionLabelText(option.label).trim().toLocaleLowerCase("de-DE")
+    }));
+    const ordered = [...candidates.slice(activeIndex + 1), ...candidates.slice(0, activeIndex + 1)];
+    const match = ordered.find((candidate) => !candidate.option.disabled && candidate.label.startsWith(query)) ||
+      ordered.find((candidate) => !candidate.option.disabled && candidate.label.includes(query));
+    if (!match) return;
+    setActiveIndex(match.index);
+    setOpen(true);
+  };
+
   const handleTriggerKeyboard = (event: KeyboardEvent<HTMLButtonElement>) => {
     if (event.key === "ArrowDown" || event.key === "ArrowUp") {
       event.preventDefault();
@@ -139,7 +177,12 @@ export const AppMultiSelect = forwardRef<HTMLButtonElement, AppMultiSelectProps>
     }
     if (event.key === "Escape") {
       event.preventDefault();
+      if (open) event.stopPropagation();
       setOpen(false);
+    }
+    if (event.key.length === 1 && event.key !== " " && !event.altKey && !event.ctrlKey && !event.metaKey) {
+      event.preventDefault();
+      applyTypeahead(event.key);
     }
   };
 
@@ -159,9 +202,14 @@ export const AppMultiSelect = forwardRef<HTMLButtonElement, AppMultiSelectProps>
     }
     if (event.key === "Escape") {
       event.preventDefault();
+      event.stopPropagation();
       closeAndFocusTrigger();
     }
     if (event.key === "Tab") window.setTimeout(() => setOpen(false), 0);
+    if (event.key.length === 1 && event.key !== " " && !event.altKey && !event.ctrlKey && !event.metaKey) {
+      event.preventDefault();
+      applyTypeahead(event.key);
+    }
   };
 
   const handleFocusLeave = (event: FocusEvent<HTMLDivElement>) => {

--- a/frontend/src/styles/vehicle-dialogs.css
+++ b/frontend/src/styles/vehicle-dialogs.css
@@ -51,7 +51,7 @@
 }
 
 .barcode-search-layer {
-  z-index: 42;
+  z-index: 160;
 }
 
 .barcode-search-dialog {
@@ -271,7 +271,7 @@
 }
 
 .article-search-layer {
-  z-index: 42;
+  z-index: 160;
 }
 
 .article-search-dialog {


### PR DESCRIPTION
## Summary

- extract labelled track specifications as typed, individually selectable accessory-search suggestions
- auto-fill scale from gauge and synchronize keyword suggestions while preserving manual edits
- fix nested search-dialog layering and gauge multi-select keyboard behavior
- prepare the bilingual v0.1.17.1 changelog, release notes, README examples, and runtime version

## Validation

- `go test ./...`
- `go vet ./...`
- `npm.cmd test -- --run` (54 files, 329 tests)
- `npm.cmd run build`
- runtime smoke test: `/health` OK, `/accessories` HTTP 200, `/api/v1/version` reports `0.1.17.1`