### PR TITLE
Improve accessory table controls and prepare v0.1.17.3

### DIFF
--- a/CHANGELOG.de.md
+++ b/CHANGELOG.de.md
@@ -6,10 +6,15 @@ Diese Datei dokumentiert alle wesentlichen Änderungen an RailKeeper.
 
 ## Unveröffentlicht
 
+## [0.1.17.3] - 2026-08-14
+
 ### Hinzugefügt
 
 - Dateien für Repository-Zuständigkeit, Beiträge, Verhaltensregeln, Support, Projektkennzeichen und
   Drittanbieterhinweise wurden ergänzt.
+- Die Zubehör-Tabelle bietet eine persistente Spaltenauswahl für Bild, Inventarnummer, Hersteller,
+  Artikelnummer, Name, Art, Spur, Bestand und Lagerung. Inventarnummer und Name können nicht
+  gleichzeitig ausgeblendet werden.
 
 ### Geändert
 
@@ -24,6 +29,9 @@ Diese Datei dokumentiert alle wesentlichen Änderungen an RailKeeper.
 - Aktuelle Geschwindigkeit, Richtung, aktive Funktionszustände, Lokbilder, Schaltartikel,
   Fahrwege, S88, Booster und weitere ECoS-Objektmanager wurden aus Abfragen und UI-Verträgen
   entfernt.
+- Archivieren, Wiederherstellen und endgültiges Löschen stehen in Tabellen-, Kachel- und
+  Kompaktansicht als direkte, beschriftete Symbolaktionen zur Verfügung. Das bisherige
+  Drei-Punkte-Menü entfällt.
 
 ## [0.1.17.2] - 2026-08-14
 
@@ -154,6 +162,7 @@ Diese Datei dokumentiert alle wesentlichen Änderungen an RailKeeper.
 - Die Vorprüfung der Backup-Wiederherstellung bleibt konservativ, Authentifizierungsdaten bleiben
   aus Exporten ausgeschlossen.
 
+[0.1.17.3]: https://github.com/ichwars/RailKeeper/compare/v0.1.17.2...v0.1.17.3
 [0.1.17.2]: https://github.com/ichwars/RailKeeper/compare/v0.1.17.1...v0.1.17.2
 [0.1.17.1]: https://github.com/ichwars/RailKeeper/compare/v0.1.17...v0.1.17.1
 [0.1.17]: https://github.com/ichwars/RailKeeper/compare/v0.1.16...v0.1.17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,15 @@ All notable changes to RailKeeper are documented in this file.
 
 ## Unreleased
 
+## [0.1.17.3] - 2026-08-14
+
 ### Added
 
 - Added repository ownership, contribution, conduct, support, trademark, and third-party notice
   files.
+- The accessory table now provides persistent column selection for image, inventory number,
+  manufacturer, article number, name, type, gauge, stock, and storage. Inventory number and name
+  cannot both be hidden.
 
 ### Changed
 
@@ -23,6 +28,8 @@ All notable changes to RailKeeper are documented in this file.
   confirmation.
 - Current speed, direction, active function states, locomotive images, switch objects, routes,
   S88, boosters, and other ECoS object managers were removed from queries and UI contracts.
+- Archive, restore, and permanent deletion are now direct, labelled icon actions in table, card,
+  and compact views. The previous three-dot menu has been removed.
 
 ## [0.1.17.2] - 2026-08-14
 
@@ -143,6 +150,7 @@ All notable changes to RailKeeper are documented in this file.
 - Tightened API validation and protected master-data import invariants.
 - Kept backup restore preflight conservative and authentication data excluded from exports.
 
+[0.1.17.3]: https://github.com/ichwars/RailKeeper/compare/v0.1.17.2...v0.1.17.3
 [0.1.17.2]: https://github.com/ichwars/RailKeeper/compare/v0.1.17.1...v0.1.17.2
 [0.1.17.1]: https://github.com/ichwars/RailKeeper/compare/v0.1.17...v0.1.17.1
 [0.1.17]: https://github.com/ichwars/RailKeeper/compare/v0.1.16...v0.1.17

--- a/README.de.md
+++ b/README.de.md
@@ -127,7 +127,7 @@ SQLite-Datenbank, Uploads und lokale Dateien bleiben im Docker-Volume `railkeepe
 Um statt `latest` ein bestimmtes Release festzulegen, trage Folgendes in `.env` ein:
 
 ```env
-RAILKEEPER_IMAGE=ghcr.io/ichwars/railkeeper:v0.1.17.2
+RAILKEEPER_IMAGE=ghcr.io/ichwars/railkeeper:v0.1.17.3
 ```
 
 Wenn du bewusst den ausgecheckten Quellstand bauen möchtest, verwende:

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ The SQLite database, uploads and local files stay in the `railkeeper_data` Docke
 To pin a specific release instead of `latest`, set this in `.env`:
 
 ```env
-RAILKEEPER_IMAGE=ghcr.io/ichwars/railkeeper:v0.1.17.2
+RAILKEEPER_IMAGE=ghcr.io/ichwars/railkeeper:v0.1.17.3
 ```
 
 If you intentionally want to build the checked-out source tree, use:

--- a/backend/cmd/railkeeper/main.go
+++ b/backend/cmd/railkeeper/main.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	version               = "0.1.17.2"
+	version               = "0.1.17.3"
 	defaultUpdateCheckURL = "https://api.github.com/repos/ichwars/RailKeeper/releases/latest"
 )
 

--- a/docs/releases/v0.1.17.3.md
+++ b/docs/releases/v0.1.17.3.md
@@ -1,0 +1,40 @@
+# RailKeeper v0.1.17.3
+
+## Deutsch
+
+RailKeeper 0.1.17.3 stellt neue Fassungen unter `AGPL-3.0-only`, ergänzt klare Hinweise zu
+Projektzuständigkeit, Beiträgen, Support, Marken und Drittanbieterrechten und führt die freiwillige
+Projektunterstützung über GitHub Sponsors und Ko-fi zusammen.
+
+Die ECoS-Anbindung konzentriert sich auf Lokstammdaten, CV-Werte und statische
+Funktionsdefinitionen. Schreibzugriffe bleiben nach Prüfung und Bestätigung auf Name, Adresse und
+Protokoll begrenzt. Geschwindigkeit, Richtung, aktive Funktionszustände, Lokbilder, Schaltartikel,
+Fahrwege, S88, Booster und weitere ECoS-Objektmanager sind nicht mehr Bestandteil der Integration.
+
+In der Zubehör-Tabelle lassen sich neun Datenspalten dauerhaft ein- und ausblenden. Inventarnummer
+und Name bleiben als Identitätsschutz mindestens teilweise sichtbar. Archivieren, Wiederherstellen
+und das ausschließlich Administratoren erlaubte Löschen vollständig unbenutzter Artikel stehen in
+allen Übersichten als direkte Symbolaktionen bereit. Das Drei-Punkte-Menü wurde entfernt.
+
+Weitere Details stehen im
+[deutschen Änderungsprotokoll](https://github.com/ichwars/RailKeeper/blob/v0.1.17.3/CHANGELOG.de.md).
+
+## English
+
+RailKeeper 0.1.17.3 places new versions under `AGPL-3.0-only`, adds clear ownership,
+contribution, support, trademark, and third-party notices, and consolidates voluntary project
+support through GitHub Sponsors and Ko-fi.
+
+The ECoS integration now focuses on locomotive master data, CV values, and static function
+definitions. Confirmed write operations remain limited to name, address, and protocol. Speed,
+direction, active function states, locomotive images, switch objects, routes, S88, boosters, and
+other ECoS object managers are no longer part of the integration.
+
+The accessory table can now persistently show or hide nine data columns while keeping at least
+the inventory number or name visible for identification. Archive, restore, and admin-only
+permanent deletion of completely unused articles are available as direct icon actions throughout
+the overview. The three-dot menu has been removed.
+
+See the
+[English changelog](https://github.com/ichwars/RailKeeper/blob/v0.1.17.3/CHANGELOG.md)
+for details.

--- a/frontend/src/features/accessories/AccessoriesView.test.tsx
+++ b/frontend/src/features/accessories/AccessoriesView.test.tsx
@@ -16,6 +16,7 @@ import {
   type StorageLocation
 } from "../../shared/api";
 import { setLanguage } from "../../shared/i18n";
+import { articleTableColumnSettingKey } from "./articleTableColumns";
 import { articleViewSettingKey } from "./articleViewMode";
 import { AccessoriesView } from "./AccessoriesView";
 
@@ -102,6 +103,7 @@ describe("AccessoriesView", () => {
 
   beforeEach(() => {
     window.localStorage.removeItem(articleViewSettingKey);
+    window.localStorage.removeItem(articleTableColumnSettingKey);
     setLanguage("de");
     vi.spyOn(api, "accessoryArticles").mockResolvedValue(overview);
     vi.spyOn(api, "storageLocations").mockResolvedValue([]);
@@ -117,12 +119,11 @@ describe("AccessoriesView", () => {
   });
 
   it("keeps permanent deletion hidden from editors", async () => {
-    const user = userEvent.setup();
     render(<AccessoriesView roles={["Editor"]} />);
     await screen.findByText("Gerades Modellgleis");
 
-    await user.click(screen.getByRole("button", { name: /Weitere Aktionen/ }));
-    expect(screen.queryByRole("menuitem", { name: "Artikel löschen" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Artikel löschen:/ })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Artikel archivieren:/ })).toBeInTheDocument();
   });
 
   it("confirms admin deletion with article identity and reloads", async () => {
@@ -130,8 +131,7 @@ describe("AccessoriesView", () => {
     render(<AccessoriesView roles={["Admin"]} />);
     await screen.findByText("Gerades Modellgleis");
 
-    await user.click(screen.getByRole("button", { name: /Weitere Aktionen/ }));
-    await user.click(screen.getByRole("menuitem", { name: "Artikel löschen" }));
+    await user.click(screen.getByRole("button", { name: /Artikel löschen:/ }));
     const dialog = screen.getByRole("dialog", { name: "Artikel endgültig löschen" });
     expect(within(dialog).getByText(/RK-ART-000001/)).toBeInTheDocument();
     expect(within(dialog).getByText(/Gerades Modellgleis/)).toBeInTheDocument();
@@ -151,8 +151,7 @@ describe("AccessoriesView", () => {
     render(<AccessoriesView roles={["Admin"]} />);
     await screen.findByText("Gerades Modellgleis");
 
-    await user.click(screen.getByRole("button", { name: /Weitere Aktionen/ }));
-    await user.click(screen.getByRole("menuitem", { name: "Artikel löschen" }));
+    await user.click(screen.getByRole("button", { name: /Artikel löschen:/ }));
     await user.click(screen.getByRole("button", { name: "Endgültig löschen" }));
 
     expect(await screen.findByRole("alert")).toHaveTextContent("stock or usage history");
@@ -166,8 +165,7 @@ describe("AccessoriesView", () => {
     render(<AccessoriesView roles={["Admin"]} />);
     await screen.findByText("Gerades Modellgleis");
 
-    await user.click(screen.getByRole("button", { name: /More actions/ }));
-    await user.click(screen.getByRole("menuitem", { name: "Delete article" }));
+    await user.click(screen.getByRole("button", { name: /Delete article:/ }));
 
     const dialog = screen.getByRole("dialog", { name: "Permanently delete article" });
     expect(within(dialog).getByRole("button", { name: "Delete permanently" })).toBeInTheDocument();
@@ -227,6 +225,30 @@ describe("AccessoriesView", () => {
     render(<AccessoriesView roles={["Editor"]} />);
     expect(await screen.findByRole("list", { name: "Artikel-Kachelansicht" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Kachelansicht" })).toHaveClass("active");
+  });
+
+  it("shows the column picker only for the desktop table view", async () => {
+    const user = userEvent.setup();
+    render(<AccessoriesView roles={["Editor"]} />);
+    await screen.findByRole("table");
+
+    expect(screen.getByRole("button", { name: "Tabellenspalten auswählen" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Kachelansicht" }));
+    expect(screen.queryByRole("button", { name: "Tabellenspalten auswählen" }))
+      .not.toBeInTheDocument();
+  });
+
+  it("persists hidden table columns from the toolbar picker", async () => {
+    const user = userEvent.setup();
+    render(<AccessoriesView roles={["Admin"]} />);
+    await screen.findByRole("table");
+
+    await user.click(screen.getByRole("button", { name: "Tabellenspalten auswählen" }));
+    await user.click(screen.getByRole("checkbox", { name: "Hersteller" }));
+
+    expect(screen.queryByRole("columnheader", { name: "Hersteller" })).not.toBeInTheDocument();
+    expect(JSON.parse(window.localStorage.getItem(articleTableColumnSettingKey) || "[]"))
+      .not.toContain("manufacturer");
   });
 
   it("localizes the view controls", async () => {
@@ -426,7 +448,8 @@ describe("AccessoriesView", () => {
     expect(screen.getByRole("button", { name: /Artikel ansehen/ })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Artikel bearbeiten/ })).toBeInTheDocument();
     expect(screen.getByText("Gerades Modellgleis").closest("button")).not.toBeNull();
-    expect(screen.getByRole("button", { name: /Weitere Aktionen/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Artikel archivieren:/ })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Weitere Aktionen/ })).not.toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Neuer Artikel" }));
     expect(screen.getByRole("dialog", { name: "Artikel anlegen" })).toBeInTheDocument();
   });

--- a/frontend/src/features/accessories/AccessoriesView.tsx
+++ b/frontend/src/features/accessories/AccessoriesView.tsx
@@ -9,6 +9,12 @@ import { ArticleMetrics } from "./ArticleMetrics";
 import { ArticleOverviewHeader } from "./ArticleOverviewHeader";
 import { ArticleTable } from "./ArticleTable";
 import { ArticleToolbar } from "./ArticleToolbar";
+import {
+  persistArticleTableColumns,
+  storedArticleTableColumns,
+  toggleArticleTableColumn,
+  type ArticleTableColumn
+} from "./articleTableColumns";
 import { AccessoryConfirmDialog } from "./AccessoryConfirmDialog";
 import { persistArticleViewMode, storedArticleViewMode, type ArticleViewMode } from "./articleViewMode";
 import { useArticleOverview } from "./useArticleOverview";
@@ -68,6 +74,7 @@ export function AccessoriesView({
   const [pendingDeleteArticle, setPendingDeleteArticle] =
     useState<AccessoryArticleListItem | null>(null);
   const [viewMode, setViewMode] = useState<ArticleViewMode>(storedArticleViewMode);
+  const [visibleColumns, setVisibleColumns] = useState(storedArticleTableColumns);
   const compactOverview = useCompactArticleOverview();
   const { t } = useI18n();
 
@@ -104,6 +111,11 @@ export function AccessoriesView({
     setViewMode(mode);
     persistArticleViewMode(mode);
   };
+  const toggleColumn = (column: ArticleTableColumn) => setVisibleColumns((current) => {
+    const next = toggleArticleTableColumn(current, column);
+    persistArticleTableColumns(next);
+    return next;
+  });
   const toggleSelection = (id: string) => setSelectedArticleIDs((current) => {
     const next = new Set(current);
     if (next.has(id)) next.delete(id);
@@ -148,6 +160,8 @@ export function AccessoriesView({
             viewMode={viewMode}
             hasActiveFilters={overview.hasActiveFilters}
             onViewModeChange={changeViewMode}
+            visibleColumns={visibleColumns}
+            onToggleColumn={toggleColumn}
             onFilterChange={overview.setFilter}
             onReset={overview.resetFilters}
           />
@@ -212,6 +226,7 @@ export function AccessoriesView({
                     direction={overview.direction}
                     canEdit={canEdit}
                     canDelete={canDelete}
+                    visibleColumns={visibleColumns}
                     selectedIDs={selectedArticleIDs}
                     onToggleSelection={toggleSelection}
                     onToggleAll={toggleAll}

--- a/frontend/src/features/accessories/ArticleActions.test.tsx
+++ b/frontend/src/features/accessories/ArticleActions.test.tsx
@@ -8,7 +8,7 @@ import { ArticleActions } from "./ArticleActions";
 const article = accessoryArticleFixture();
 
 describe("ArticleActions", () => {
-  it("routes view, edit, and archive for writers", async () => {
+  it("routes direct view, edit, and archive actions for writers", async () => {
     const user = userEvent.setup();
     const onView = vi.fn();
     const onEdit = vi.fn();
@@ -18,95 +18,56 @@ describe("ArticleActions", () => {
 
     await user.click(screen.getByRole("button", { name: "Artikel ansehen: Gerades Modellgleis" }));
     await user.click(screen.getByRole("button", { name: "Artikel bearbeiten: Gerades Modellgleis" }));
-    await user.click(screen.getByRole("button", { name: "Weitere Aktionen: Gerades Modellgleis" }));
-    await user.click(screen.getByRole("menuitem", { name: "Artikel archivieren" }));
+    await user.click(screen.getByRole("button", { name: "Artikel archivieren: Gerades Modellgleis" }));
 
     expect(onView).toHaveBeenCalledWith(article);
     expect(onEdit).toHaveBeenCalledWith(article);
     expect(onArchive).toHaveBeenCalledWith(article);
+    expect(screen.queryByRole("button", { name: /Weitere Aktionen/ })).not.toBeInTheDocument();
   });
 
-  it("routes restore for archived articles", async () => {
+  it("routes a direct restore action for archived articles", async () => {
     const user = userEvent.setup();
     const archived = accessoryArticleFixture({ archived: true });
     const onRestore = vi.fn();
     render(<ArticleActions article={archived} canEdit onView={vi.fn()} onEdit={vi.fn()}
       onArchive={vi.fn()} onRestore={onRestore} />);
 
-    await user.click(screen.getByRole("button", { name: /Weitere Aktionen/ }));
-    await user.click(screen.getByRole("menuitem", { name: "Artikel wiederherstellen" }));
+    await user.click(screen.getByRole("button", {
+      name: "Artikel wiederherstellen: Gerades Modellgleis"
+    }));
     expect(onRestore).toHaveBeenCalledWith(archived);
+    expect(screen.queryByRole("button", { name: /Artikel archivieren:/ })).not.toBeInTheDocument();
   });
 
-  it("shows delete only when explicitly allowed and routes the selected article", async () => {
+  it("shows direct delete only when explicitly allowed and routes the selected article", async () => {
     const user = userEvent.setup();
     const onDelete = vi.fn();
     render(<ArticleActions article={article} canEdit canDelete onView={vi.fn()} onEdit={vi.fn()}
       onArchive={vi.fn()} onRestore={vi.fn()} onDelete={onDelete} />);
 
-    await user.click(screen.getByRole("button", { name: /Weitere Aktionen/ }));
-    await user.click(screen.getByRole("menuitem", { name: "Artikel löschen" }));
+    const deleteButton = screen.getByRole("button", { name: "Artikel löschen: Gerades Modellgleis" });
+    expect(deleteButton).toHaveClass("danger");
+    await user.click(deleteButton);
 
     expect(onDelete).toHaveBeenCalledWith(article);
   });
 
-  it("does not expose delete to editors", async () => {
-    const user = userEvent.setup();
+  it("does not expose delete to editors", () => {
     render(<ArticleActions article={article} canEdit canDelete={false} onView={vi.fn()}
       onEdit={vi.fn()} onArchive={vi.fn()} onRestore={vi.fn()} onDelete={vi.fn()} />);
 
-    await user.click(screen.getByRole("button", { name: /Weitere Aktionen/ }));
-    expect(screen.queryByRole("menuitem", { name: "Artikel löschen" })).not.toBeInTheDocument();
-  });
-
-  it("moves focus through the menu and restores it on Escape", async () => {
-    const user = userEvent.setup();
-    render(<ArticleActions article={article} canEdit canDelete onView={vi.fn()} onEdit={vi.fn()}
-      onArchive={vi.fn()} onRestore={vi.fn()} onDelete={vi.fn()} />);
-    const trigger = screen.getByRole("button", { name: "Weitere Aktionen: Gerades Modellgleis" });
-
-    await user.click(trigger);
-    const [archiveItem, deleteItem] = screen.getAllByRole("menuitem");
-    expect(archiveItem).toHaveFocus();
-    await user.keyboard("{ArrowDown}");
-    expect(deleteItem).toHaveFocus();
-    await user.keyboard("{ArrowDown}");
-    expect(archiveItem).toHaveFocus();
-    await user.keyboard("{End}");
-    expect(deleteItem).toHaveFocus();
-    await user.keyboard("{Home}");
-    expect(archiveItem).toHaveFocus();
-    await user.keyboard("{Escape}");
-    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
-    expect(trigger).toHaveFocus();
-  });
-
-  it("closes on Tab and outside click without restoring the trigger", async () => {
-    const user = userEvent.setup();
-    render(<div>
-      <ArticleActions article={article} canEdit onView={vi.fn()} onEdit={vi.fn()}
-        onArchive={vi.fn()} onRestore={vi.fn()} />
-      <button type="button">Nach Aktionen</button>
-    </div>);
-    const trigger = screen.getByRole("button", { name: /Weitere Aktionen/ });
-
-    await user.click(trigger);
-    await user.tab();
-    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
-    expect(trigger).not.toHaveFocus();
-
-    await user.click(trigger);
-    await user.click(screen.getByRole("button", { name: "Nach Aktionen" }));
-    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Nach Aktionen" })).toHaveFocus();
+    expect(screen.queryByRole("button", { name: /Artikel löschen:/ })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Artikel archivieren:/ })).toBeInTheDocument();
   });
 
   it("keeps mutation actions hidden for read-only users", () => {
     render(<ArticleActions article={article} canEdit={false} onView={vi.fn()} onEdit={vi.fn()}
-      onArchive={vi.fn()} onRestore={vi.fn()} />);
+      onArchive={vi.fn()} onRestore={vi.fn()} onDelete={vi.fn()} />);
 
     expect(screen.getByRole("button", { name: /Artikel ansehen/ })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /Artikel bearbeiten/ })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /Weitere Aktionen/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Artikel archivieren:/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Artikel löschen:/ })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/features/accessories/ArticleActions.tsx
+++ b/frontend/src/features/accessories/ArticleActions.tsx
@@ -1,11 +1,4 @@
-import {
-  type KeyboardEvent as ReactKeyboardEvent,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState
-} from "react";
-import { Eye, MoreHorizontal, Pencil } from "lucide-react";
+import { Archive, ArchiveRestore, Eye, Pencil, Trash2 } from "lucide-react";
 
 import type { AccessoryArticleListItem } from "../../shared/api";
 import { useI18n } from "../../shared/i18n";
@@ -31,59 +24,16 @@ export function ArticleActions({
   onRestore,
   onDelete
 }: ArticleActionsProps) {
-  const [open, setOpen] = useState(false);
-  const rootRef = useRef<HTMLDivElement | null>(null);
-  const menuRef = useRef<HTMLDivElement | null>(null);
-  const triggerRef = useRef<HTMLButtonElement | null>(null);
   const { t } = useI18n();
-
-  useLayoutEffect(() => {
-    if (open) menuRef.current?.querySelector<HTMLButtonElement>("[role='menuitem']")?.focus();
-  }, [open]);
-
-  useEffect(() => {
-    if (!open) return;
-    const closeOutside = (event: PointerEvent) => {
-      if (event.target instanceof Node && rootRef.current?.contains(event.target)) return;
-      setOpen(false);
-    };
-    const closeOnEscape = (event: KeyboardEvent) => {
-      if (event.key !== "Escape") return;
-      event.preventDefault();
-      setOpen(false);
-      triggerRef.current?.focus();
-    };
-    document.addEventListener("pointerdown", closeOutside);
-    document.addEventListener("keydown", closeOnEscape);
-    return () => {
-      document.removeEventListener("pointerdown", closeOutside);
-      document.removeEventListener("keydown", closeOnEscape);
-    };
-  }, [open]);
-
-  const handleMenuKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
-    if (event.key === "Tab") {
-      setOpen(false);
-      return;
-    }
-    if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key)) return;
-    event.preventDefault();
-    const items = Array.from(
-      menuRef.current?.querySelectorAll<HTMLButtonElement>("[role='menuitem']") || []
-    );
-    if (items.length === 0) return;
-    const focusedIndex = items.findIndex((item) => item === document.activeElement);
-    const current = focusedIndex >= 0 ? focusedIndex : 0;
-    let next = current;
-    if (event.key === "Home") next = 0;
-    else if (event.key === "End") next = items.length - 1;
-    else if (event.key === "ArrowDown") next = (current + 1) % items.length;
-    else next = (current - 1 + items.length) % items.length;
-    items[next]?.focus();
-  };
+  const archiveLabel = article.archived
+    ? "accessories.actions.restore"
+    : "accessories.actions.archive";
+  const archiveNamedLabel = article.archived
+    ? "accessories.actions.restoreNamed"
+    : "accessories.actions.archiveNamed";
 
   return (
-    <div ref={rootRef} className="table-actions article-row-actions">
+    <div className="table-actions article-row-actions">
       {onView ? (
         <button
           type="button"
@@ -106,57 +56,29 @@ export function ArticleActions({
           <Pencil size={16} aria-hidden="true" />
         </button>
       ) : null}
-      {canEdit || canDelete ? (
-        <div className="article-overflow">
-          <button
-            ref={triggerRef}
-            type="button"
-            className="icon-button article-action-button"
-            onClick={() => setOpen((current) => !current)}
-            aria-label={t("accessories.actions.moreNamed", { name: article.name })}
-            title={t("accessories.actions.more")}
-            aria-haspopup="menu"
-            aria-expanded={open}
-          >
-            <MoreHorizontal size={17} aria-hidden="true" />
-          </button>
-          {open ? (
-            <div
-              ref={menuRef}
-              className="article-action-menu"
-              role="menu"
-              onKeyDown={handleMenuKeyDown}
-            >
-              {canEdit ? (
-                <button
-                  type="button"
-                  role="menuitem"
-                  tabIndex={0}
-                  onClick={() => {
-                    setOpen(false);
-                    void (article.archived ? onRestore(article) : onArchive(article));
-                  }}
-                >
-                  {t(article.archived ? "accessories.actions.restore" : "accessories.actions.archive")}
-                </button>
-              ) : null}
-              {canDelete && onDelete ? (
-                <button
-                  type="button"
-                  role="menuitem"
-                  tabIndex={-1}
-                  className="danger-menu-item"
-                  onClick={() => {
-                    setOpen(false);
-                    onDelete(article);
-                  }}
-                >
-                  {t("accessories.actions.delete")}
-                </button>
-              ) : null}
-            </div>
-          ) : null}
-        </div>
+      {canEdit ? (
+        <button
+          type="button"
+          className="icon-button article-action-button"
+          onClick={() => void (article.archived ? onRestore(article) : onArchive(article))}
+          aria-label={t(archiveNamedLabel, { name: article.name })}
+          title={t(archiveLabel)}
+        >
+          {article.archived
+            ? <ArchiveRestore size={16} aria-hidden="true" />
+            : <Archive size={16} aria-hidden="true" />}
+        </button>
+      ) : null}
+      {canDelete && onDelete ? (
+        <button
+          type="button"
+          className="icon-button article-action-button danger"
+          onClick={() => onDelete(article)}
+          aria-label={t("accessories.actions.deleteNamed", { name: article.name })}
+          title={t("accessories.actions.delete")}
+        >
+          <Trash2 size={16} aria-hidden="true" />
+        </button>
       ) : null}
     </div>
   );

--- a/frontend/src/features/accessories/ArticleCardGrid.test.tsx
+++ b/frontend/src/features/accessories/ArticleCardGrid.test.tsx
@@ -61,6 +61,20 @@ describe("ArticleCardGrid", () => {
 
     expect(screen.getAllByRole("button", { name: /Artikel ansehen/ }).length).toBeGreaterThan(0);
     expect(screen.queryByRole("button", { name: /Artikel bearbeiten/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Artikel archivieren:/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Artikel löschen:/ })).not.toBeInTheDocument();
+  });
+
+  it("renders archive and admin delete as direct card actions", () => {
+    const article = accessoryArticleFixture();
+    render(<ArticleCardGrid items={[article]} articleTypeEntries={accessoryArticleTypes}
+      subtypeEntries={accessorySubtypes} canEdit canDelete onView={vi.fn()} onEdit={vi.fn()}
+      onArchive={vi.fn()} onRestore={vi.fn()} onDelete={vi.fn()} />);
+
+    expect(screen.getByRole("button", { name: "Artikel archivieren: Gerades Modellgleis" }))
+      .toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Artikel löschen: Gerades Modellgleis" }))
+      .toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /Weitere Aktionen/ })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/features/accessories/ArticleColumnPicker.test.tsx
+++ b/frontend/src/features/accessories/ArticleColumnPicker.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { setLanguage } from "../../shared/i18n";
+import { ArticleColumnPicker } from "./ArticleColumnPicker";
+import { defaultArticleTableColumns, type ArticleTableColumn } from "./articleTableColumns";
+
+describe("ArticleColumnPicker", () => {
+  beforeEach(() => setLanguage("de"));
+
+  it("opens a localized checkbox popover and routes column toggles", async () => {
+    const user = userEvent.setup();
+    const onToggle = vi.fn();
+    render(<ArticleColumnPicker visibleColumns={defaultArticleTableColumns} onToggle={onToggle} />);
+
+    await user.click(screen.getByRole("button", { name: "Tabellenspalten auswählen" }));
+    expect(screen.getByRole("group", { name: "Tabellenspalten" })).toBeInTheDocument();
+    expect(screen.getAllByRole("checkbox")).toHaveLength(9);
+
+    await user.click(screen.getByRole("checkbox", { name: "Hersteller" }));
+    expect(onToggle).toHaveBeenCalledWith("manufacturer");
+  });
+
+  it("locks the final visible identity column", async () => {
+    const user = userEvent.setup();
+    const visible = new Set<ArticleTableColumn>(["name", "stock"]);
+    render(<ArticleColumnPicker visibleColumns={visible} onToggle={vi.fn()} />);
+
+    await user.click(screen.getByRole("button", { name: "Tabellenspalten auswählen" }));
+    expect(screen.getByRole("checkbox", { name: "Name" })).toBeDisabled();
+    expect(screen.getByRole("checkbox", { name: "Inventarnummer" })).not.toBeDisabled();
+  });
+
+  it("closes on Escape and restores focus to its trigger", async () => {
+    const user = userEvent.setup();
+    render(<ArticleColumnPicker visibleColumns={defaultArticleTableColumns} onToggle={vi.fn()} />);
+    const trigger = screen.getByRole("button", { name: "Tabellenspalten auswählen" });
+
+    await user.click(trigger);
+    await user.keyboard("{Escape}");
+
+    expect(screen.queryByRole("group", { name: "Tabellenspalten" })).not.toBeInTheDocument();
+    expect(trigger).toHaveFocus();
+  });
+
+  it("closes on an outside pointer action", async () => {
+    const user = userEvent.setup();
+    render(<div>
+      <ArticleColumnPicker visibleColumns={defaultArticleTableColumns} onToggle={vi.fn()} />
+      <button type="button">Außerhalb</button>
+    </div>);
+
+    await user.click(screen.getByRole("button", { name: "Tabellenspalten auswählen" }));
+    await user.click(screen.getByRole("button", { name: "Außerhalb" }));
+
+    expect(screen.queryByRole("group", { name: "Tabellenspalten" })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/accessories/ArticleColumnPicker.tsx
+++ b/frontend/src/features/accessories/ArticleColumnPicker.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useRef, useState } from "react";
+import { Columns3 } from "lucide-react";
+
+import { useI18n } from "../../shared/i18n";
+import { articleTableColumns, type ArticleTableColumn } from "./articleTableColumns";
+
+type ArticleColumnPickerProps = {
+  visibleColumns: ReadonlySet<ArticleTableColumn>;
+  onToggle: (column: ArticleTableColumn) => void;
+};
+
+export function ArticleColumnPicker({ visibleColumns, onToggle }: ArticleColumnPickerProps) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const { t } = useI18n();
+
+  useEffect(() => {
+    if (!open) return;
+    const closeOutside = (event: PointerEvent) => {
+      if (event.target instanceof Node && rootRef.current?.contains(event.target)) return;
+      setOpen(false);
+    };
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      setOpen(false);
+      triggerRef.current?.focus();
+    };
+    document.addEventListener("pointerdown", closeOutside);
+    document.addEventListener("keydown", closeOnEscape);
+    return () => {
+      document.removeEventListener("pointerdown", closeOutside);
+      document.removeEventListener("keydown", closeOnEscape);
+    };
+  }, [open]);
+
+  const identityLocked = (column: ArticleTableColumn) => visibleColumns.has(column) &&
+    ((column === "inventoryNumber" && !visibleColumns.has("name")) ||
+      (column === "name" && !visibleColumns.has("inventoryNumber")));
+
+  return (
+    <div ref={rootRef} className="article-column-picker">
+      <button
+        ref={triggerRef}
+        type="button"
+        className={`icon-button${open ? " active" : ""}`}
+        aria-label={t("accessories.view.columns")}
+        title={t("accessories.view.columns")}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        onClick={() => setOpen((current) => !current)}
+      >
+        <Columns3 size={16} aria-hidden="true" />
+      </button>
+      {open ? (
+        <div
+          className="article-column-picker-popover"
+          role="group"
+          aria-label={t("accessories.view.columnsGroup")}
+        >
+          {articleTableColumns.map((column) => (
+            <label key={column}>
+              <input
+                type="checkbox"
+                checked={visibleColumns.has(column)}
+                disabled={identityLocked(column)}
+                onChange={() => onToggle(column)}
+              />
+              <span>{t(`accessories.table.${column}`)}</span>
+            </label>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/features/accessories/ArticleCompactList.test.tsx
+++ b/frontend/src/features/accessories/ArticleCompactList.test.tsx
@@ -52,6 +52,19 @@ describe("ArticleCompactList", () => {
 
     expect(screen.getAllByRole("button", { name: /Artikel ansehen/ }).length).toBeGreaterThan(0);
     expect(screen.queryByRole("button", { name: /Artikel bearbeiten/ })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /Weitere Aktionen/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Artikel archivieren:/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Artikel löschen:/ })).not.toBeInTheDocument();
+  });
+
+  it("renders archive and admin delete as direct compact actions", () => {
+    const article = accessoryArticleFixture();
+    render(<ArticleCompactList items={[article]} articleTypeEntries={accessoryArticleTypes}
+      subtypeEntries={accessorySubtypes} canEdit canDelete onView={vi.fn()} onEdit={vi.fn()}
+      onArchive={vi.fn()} onRestore={vi.fn()} onDelete={vi.fn()} />);
+
+    expect(screen.getByRole("button", { name: "Artikel archivieren: Gerades Modellgleis" }))
+      .toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Artikel löschen: Gerades Modellgleis" }))
+      .toBeInTheDocument();
   });
 });

--- a/frontend/src/features/accessories/ArticleTable.test.tsx
+++ b/frontend/src/features/accessories/ArticleTable.test.tsx
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { AccessoryArticleListItem, MasterDataEntry } from "../../shared/api";
 import { setLanguage } from "../../shared/i18n";
 import { ArticleTable } from "./ArticleTable";
+import type { ArticleTableColumn } from "./articleTableColumns";
 
 const article: AccessoryArticleListItem = {
   id: "article-1",
@@ -144,7 +145,7 @@ describe("ArticleTable", () => {
     expect(screen.queryByText("track:straight")).not.toBeInTheDocument();
   });
 
-  it("uses accessible transparent row actions and archive or restore in overflow", async () => {
+  it("uses accessible transparent direct row actions for archive and restore", async () => {
     const onView = vi.fn();
     const onEdit = vi.fn();
     const onArchive = vi.fn();
@@ -158,13 +159,12 @@ describe("ArticleTable", () => {
     const row = screen.getByRole("row", { name: /Gerades Modellgleis/ });
     const view = within(row).getByRole("button", { name: "Artikel ansehen: Gerades Modellgleis mit besonders langer Bezeichnung" });
     const edit = within(row).getByRole("button", { name: "Artikel bearbeiten: Gerades Modellgleis mit besonders langer Bezeichnung" });
-    const more = within(row).getByRole("button", { name: "Weitere Aktionen: Gerades Modellgleis mit besonders langer Bezeichnung" });
+    const archive = within(row).getByRole("button", { name: "Artikel archivieren: Gerades Modellgleis mit besonders langer Bezeichnung" });
     expect(view).toHaveClass("icon-button", "article-action-button");
     expect(view).toHaveAttribute("title", "Artikel ansehen");
     await user.click(view);
     await user.click(edit);
-    await user.click(more);
-    await user.click(screen.getByRole("menuitem", { name: "Artikel archivieren" }));
+    await user.click(archive);
     expect(onView).toHaveBeenCalledWith(article);
     expect(onEdit).toHaveBeenCalledWith(article);
     expect(onArchive).toHaveBeenCalledWith(article);
@@ -173,9 +173,9 @@ describe("ArticleTable", () => {
       <ArticleTable items={[{ ...article, archived: true }]} sort="article" direction="asc" canEdit
         onSort={vi.fn()} onView={onView} onEdit={onEdit} onArchive={onArchive} onRestore={onRestore} />
     );
-    await user.click(screen.getByRole("button", { name: /Weitere Aktionen/ }));
-    await user.click(screen.getByRole("menuitem", { name: "Artikel wiederherstellen" }));
+    await user.click(screen.getByRole("button", { name: /Artikel wiederherstellen:/ }));
     expect(onRestore).toHaveBeenCalledWith(expect.objectContaining({ id: "article-1", archived: true }));
+    expect(screen.queryByRole("button", { name: /Weitere Aktionen/ })).not.toBeInTheDocument();
   });
 
   it("keeps full long values accessible while visually truncating them", () => {
@@ -188,52 +188,37 @@ describe("ArticleTable", () => {
     expect(screen.getByText(article.manufacturer)).toHaveAttribute("title", article.manufacturer);
     expect(screen.getByText(article.locationNames[0]!)).toHaveAttribute("title", article.locationNames[0]);
     expect(screen.queryByRole("button", { name: /bearbeiten/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /Weitere Aktionen/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Artikel archivieren:/ })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Artikel ansehen/ })).toBeInTheDocument();
   });
 
-  it("moves focus into the correct row menu and returns it on Escape", async () => {
-    const user = userEvent.setup();
+  it("renders direct admin delete in the correct table row", () => {
     render(
-      <ArticleTable items={[article, secondArticle]} sort="article" direction="asc" canEdit
-        onSort={vi.fn()} onView={vi.fn()} onEdit={vi.fn()} onArchive={vi.fn()} onRestore={vi.fn()} />
+      <ArticleTable items={[article, secondArticle]} sort="article" direction="asc" canEdit canDelete
+        onSort={vi.fn()} onView={vi.fn()} onEdit={vi.fn()} onArchive={vi.fn()} onRestore={vi.fn()}
+        onDelete={vi.fn()} />
     );
-    const triggers = screen.getAllByRole("button", { name: /Weitere Aktionen/ });
 
-    await user.click(triggers[1]!);
-    const menuItem = screen.getByRole("menuitem", { name: "Artikel archivieren" });
-    expect(menuItem).toHaveFocus();
-    expect(menuItem).toHaveAttribute("tabindex", "0");
-    expect(screen.getByRole("menu").closest(".article-table-wrap")).not.toBeNull();
-
-    await user.keyboard("{ArrowDown}{ArrowUp}{Home}{End}");
-    expect(menuItem).toHaveFocus();
-    await user.keyboard("{Escape}");
-    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
-    expect(triggers[1]).toHaveFocus();
+    const rows = screen.getAllByRole("row");
+    expect(within(rows[1]!).getByRole("button", { name: /Artikel löschen: Gerades/ })).toBeInTheDocument();
+    expect(within(rows[2]!).getByRole("button", { name: /Artikel löschen: Lichtsignal/ })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Weitere Aktionen/ })).not.toBeInTheDocument();
   });
 
-  it("closes the menu on Tab or outside click without returning focus to the old trigger", async () => {
-    const user = userEvent.setup();
+  it("hides matching headers and cells while retaining selection and actions", () => {
+    const visibleColumns = new Set<ArticleTableColumn>(["inventoryNumber", "name"]);
     render(
-      <div>
-        <ArticleTable items={[article]} sort="article" direction="asc" canEdit onSort={vi.fn()}
-          onView={vi.fn()} onEdit={vi.fn()} onArchive={vi.fn()} onRestore={vi.fn()} />
-        <button type="button">Nach Tabelle</button>
-      </div>
+      <ArticleTable items={[article]} visibleColumns={visibleColumns}
+        sort="article" direction="asc" canEdit onSort={vi.fn()} onView={vi.fn()}
+        onArchive={vi.fn()} onRestore={vi.fn()} />
     );
-    const trigger = screen.getByRole("button", { name: /Weitere Aktionen/ });
 
-    await user.click(trigger);
-    expect(screen.getByRole("menuitem")).toHaveFocus();
-    await user.tab();
-    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
-    expect(trigger).not.toHaveFocus();
-
-    await user.click(trigger);
-    expect(screen.getByRole("menuitem")).toHaveFocus();
-    await user.click(screen.getByRole("button", { name: "Nach Tabelle" }));
-    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Nach Tabelle" })).toHaveFocus();
+    expect(screen.queryByRole("columnheader", { name: "Hersteller" })).not.toBeInTheDocument();
+    expect(screen.queryByText(article.manufacturer)).not.toBeInTheDocument();
+    expect(screen.getByText(article.inventoryNumber)).toBeInTheDocument();
+    expect(screen.getByText(article.name)).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Auswahl" })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Aktionen" })).toBeInTheDocument();
+    expect(screen.getByRole("table")).toHaveStyle("--article-table-min-width: 524px");
   });
 });

--- a/frontend/src/features/accessories/ArticleTable.tsx
+++ b/frontend/src/features/accessories/ArticleTable.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { type CSSProperties, useEffect, useRef } from "react";
 import { ChevronDown, ChevronUp } from "lucide-react";
 
 import type {
@@ -9,6 +9,10 @@ import type {
 } from "../../shared/api";
 import { useI18n } from "../../shared/i18n";
 import { ArticleActions } from "./ArticleActions";
+import {
+  defaultArticleTableColumns,
+  type ArticleTableColumn
+} from "./articleTableColumns";
 import { articleSubtypeLabel } from "./articleSubtypes";
 import { articleTypeLabel } from "./articleTypes";
 
@@ -29,9 +33,10 @@ type ArticleTableProps = {
   onArchive: (article: AccessoryArticleListItem) => void | Promise<void>;
   onRestore: (article: AccessoryArticleListItem) => void | Promise<void>;
   onDelete?: (article: AccessoryArticleListItem) => void;
+  visibleColumns?: ReadonlySet<ArticleTableColumn>;
 };
 
-const sortableColumns: Array<{ sort: AccessoryArticleSort; key: string }> = [
+const sortableColumns: Array<{ sort: AccessoryArticleSort; key: ArticleTableColumn }> = [
   { sort: "image", key: "image" },
   { sort: "inventoryNumber", key: "inventoryNumber" },
   { sort: "manufacturer", key: "manufacturer" },
@@ -42,6 +47,25 @@ const sortableColumns: Array<{ sort: AccessoryArticleSort; key: string }> = [
   { sort: "stock", key: "stock" },
   { sort: "storage", key: "storage" }
 ];
+
+const articleColumnWidths: Record<ArticleTableColumn, number> = {
+  image: 86,
+  inventoryNumber: 142,
+  manufacturer: 150,
+  articleNumber: 126,
+  name: 210,
+  type: 175,
+  gauge: 80,
+  stock: 210,
+  storage: 170
+};
+
+function articleTableStyle(visibleColumns: ReadonlySet<ArticleTableColumn>) {
+  const dataWidth = [...visibleColumns]
+    .reduce((total, column) => total + articleColumnWidths[column], 0);
+  const minimumWidth = Math.max(420, 44 + 128 + dataWidth);
+  return { "--article-table-min-width": `${minimumWidth}px` } as CSSProperties;
+}
 
 export function ArticleTable({
   items,
@@ -59,7 +83,8 @@ export function ArticleTable({
   onEdit,
   onArchive,
   onRestore,
-  onDelete
+  onDelete,
+  visibleColumns = defaultArticleTableColumns
 }: ArticleTableProps) {
   const selectAllRef = useRef<HTMLInputElement | null>(null);
   const { t } = useI18n();
@@ -70,11 +95,15 @@ export function ArticleTable({
     if (selectAllRef.current) selectAllRef.current.indeterminate = someSelected && !allSelected;
   }, [allSelected, someSelected]);
 
-  const renderSortHeader = ({ sort: columnSort, key }: { sort: AccessoryArticleSort; key: string }) => {
+  const renderSortHeader = ({
+    sort: columnSort,
+    key
+  }: { sort: AccessoryArticleSort; key: ArticleTableColumn }) => {
     const active = sort === columnSort;
     const label = t(`accessories.table.${key}`);
     return (
-      <th key={columnSort} aria-sort={active ? (direction === "asc" ? "ascending" : "descending") : "none"}>
+      <th key={columnSort} className={`article-${key}-cell`}
+        aria-sort={active ? (direction === "asc" ? "ascending" : "descending") : "none"}>
         <button
           type="button"
           className={active ? "article-sort-button active" : "article-sort-button"}
@@ -93,7 +122,7 @@ export function ArticleTable({
 
   return (
     <div className="table-wrap article-table-wrap">
-      <table className="inventory-table article-table">
+      <table className="inventory-table article-table" style={articleTableStyle(visibleColumns)}>
         <thead>
           <tr>
             <th className="select-cell" aria-label={t("accessories.table.select")}>
@@ -103,7 +132,7 @@ export function ArticleTable({
                   onChange={() => onToggleAll?.()} />
               </label>
             </th>
-            {sortableColumns.map(renderSortHeader)}
+            {sortableColumns.filter(({ key }) => visibleColumns.has(key)).map(renderSortHeader)}
             <th className="actions-cell">{t("accessories.table.actions")}</th>
           </tr>
         </thead>
@@ -123,50 +152,52 @@ export function ArticleTable({
                       onChange={() => onToggleSelection?.(article.id)} />
                   </label>
                 </td>
-                <td className="article-image-cell">
+                {visibleColumns.has("image") ? <td className="article-image-cell">
                   {article.primaryImageUrl
                     ? <img className="inventory-thumb" src={article.primaryImageUrl} alt="" />
                     : <div className="image-placeholder">{t("exhibition.noPreview")}</div>}
-                </td>
-                <td className="article-inventory-cell">
+                </td> : null}
+                {visibleColumns.has("inventoryNumber") ? <td className="article-inventoryNumber-cell article-inventory-cell">
                   <span className="article-truncate" title={article.inventoryNumber}>{article.inventoryNumber}</span>
-                </td>
-                <td className="article-manufacturer-cell">
+                </td> : null}
+                {visibleColumns.has("manufacturer") ? <td className="article-manufacturer-cell">
                   <span className="article-truncate" title={article.manufacturer}>{article.manufacturer}</span>
-                </td>
-                <td className="article-number-cell">
+                </td> : null}
+                {visibleColumns.has("articleNumber") ? <td className="article-articleNumber-cell article-number-cell">
                   <span className="article-truncate" title={article.articleNumber || undefined}>
                     {article.articleNumber || t("common.none")}
                   </span>
-                </td>
-                <td className="article-main-cell">
+                </td> : null}
+                {visibleColumns.has("name") ? <td className="article-name-cell article-main-cell">
                   {onView ? <button type="button" className="article-name-button" onClick={() => onView(article)}>
                     <strong className="article-truncate" title={article.name}>{article.name}</strong>
                   </button> : <div className="article-name-content">
                     <strong className="article-truncate" title={article.name}>{article.name}</strong>
                   </div>}
-                </td>
-                <td>
+                </td> : null}
+                {visibleColumns.has("type") ? <td className="article-type-cell">
                   <strong>{articleTypeLabel(article.articleType, articleTypeEntries, t)}</strong>
                   <small>{article.subtype
                     ? articleSubtypeLabel(article.articleType, article.subtype, subtypeEntries, t)
                     : t("common.none")}</small>
-                </td>
-                <td>{article.gauges.length ? article.gauges.join(", ") : t("common.none")}</td>
-                <td className="article-stock-cell">
+                </td> : null}
+                {visibleColumns.has("gauge") ? <td className="article-gauge-cell">
+                  {article.gauges.length ? article.gauges.join(", ") : t("common.none")}
+                </td> : null}
+                {visibleColumns.has("stock") ? <td className="article-stock-cell">
                   <strong>{t("accessories.table.stockOwned", { count: article.owned })}</strong>
                   <small>{t("accessories.table.stockBreakdown", {
                     available: article.available,
                     reserved: article.reserved,
                     installed: article.installed
                   })}</small>
-                </td>
-                <td className="article-storage-cell">
+                </td> : null}
+                {visibleColumns.has("storage") ? <td className="article-storage-cell">
                   <span className="article-truncate" title={storageTitle || primaryLocation}>{primaryLocation}</span>
                   {article.locationNames.length > 1 ? (
                     <small>{t("accessories.table.moreLocations", { count: article.locationNames.length - 1 })}</small>
                   ) : null}
-                </td>
+                </td> : null}
                 <td className="actions-cell">
                   <ArticleActions article={article} canEdit={canEdit} canDelete={canDelete}
                     onView={onView} onEdit={onEdit} onArchive={onArchive} onRestore={onRestore}

--- a/frontend/src/features/accessories/ArticleToolbar.tsx
+++ b/frontend/src/features/accessories/ArticleToolbar.tsx
@@ -3,6 +3,11 @@ import { Grid2X2, Search, Table2, X } from "lucide-react";
 import type { AccessoryArticleFilterOptions, MasterDataEntry } from "../../shared/api";
 import { useI18n } from "../../shared/i18n";
 import { AppSelect } from "../../shared/ui/AppSelect";
+import { ArticleColumnPicker } from "./ArticleColumnPicker";
+import {
+  defaultArticleTableColumns,
+  type ArticleTableColumn
+} from "./articleTableColumns";
 import type { ArticleViewMode } from "./articleViewMode";
 import type { ArticleOverviewFilters } from "./useArticleOverview";
 import { articleTypeLabel, articleTypeOrder } from "./articleTypes";
@@ -33,6 +38,8 @@ export function ArticleToolbar({
   viewMode,
   hasActiveFilters,
   onViewModeChange,
+  visibleColumns = defaultArticleTableColumns,
+  onToggleColumn = () => undefined,
   onFilterChange,
   onReset
 }: {
@@ -43,6 +50,8 @@ export function ArticleToolbar({
   viewMode: ArticleViewMode;
   hasActiveFilters: boolean;
   onViewModeChange: (mode: ArticleViewMode) => void;
+  visibleColumns?: ReadonlySet<ArticleTableColumn>;
+  onToggleColumn?: (column: ArticleTableColumn) => void;
   onFilterChange: <Key extends keyof ArticleOverviewFilters>(key: Key, value: ArticleOverviewFilters[Key]) => void;
   onReset: () => void;
 }) {
@@ -85,6 +94,9 @@ export function ArticleToolbar({
           >
             <Grid2X2 size={16} aria-hidden="true" />
           </button>
+          {viewMode === "table" ? (
+            <ArticleColumnPicker visibleColumns={visibleColumns} onToggle={onToggleColumn} />
+          ) : null}
         </span>
       </div>
       <div className="article-filter-row">

--- a/frontend/src/features/accessories/accessoriesResponsive.test.ts
+++ b/frontend/src/features/accessories/accessoriesResponsive.test.ts
@@ -19,11 +19,12 @@ describe("article editor responsive tabs", () => {
     expect(responsiveCss).toMatch(/\.article-editor-tabs button\s*\{[^}]*flex:\s*0 0 auto/s);
   });
 
-  it("keeps the eleven-column article table horizontally reachable at every width", () => {
-    expect(accessoriesCss).toMatch(/\.article-table\s*\{[^}]*min-width:\s*14[0-9]{2}px/s);
-    expect(accessoriesCss).toMatch(/\.article-table th\.actions-cell,[\s\S]*?width:\s*9[0-9]px/s);
+  it("keeps the configurable article table horizontally reachable at every width", () => {
+    expect(accessoriesCss).toMatch(/\.article-table\s*\{[^}]*min-width:\s*var\(--article-table-min-width\)/s);
+    expect(accessoriesCss).toMatch(/\.article-table th\.actions-cell,[\s\S]*?width:\s*13[0-9]px/s);
     expect(accessoriesCss).toMatch(/\.article-table-wrap\s*\{[^}]*overflow-x:\s*auto/s);
     expect(accessoriesCss).toMatch(/\.article-table \.select-cell\s*\{[^}]*width:\s*4[0-9]px/s);
+    expect(accessoriesCss).not.toMatch(/\.article-table th:nth-child/);
   });
 
   it("loads focused overview styles and switches presentations at the mobile breakpoint", () => {
@@ -49,10 +50,14 @@ describe("article editor responsive tabs", () => {
     );
   });
 
-  it("opens the mobile row action menu above the bottom-edge controls", () => {
+  it("positions the column picker and removes obsolete action-menu styles", () => {
+    expect(articleOverviewCss).toMatch(/\.article-column-picker\s*\{[^}]*position:\s*relative/s);
     expect(articleOverviewCss).toMatch(
-      /\.article-mobile-actions \.article-action-menu\s*\{[^}]*top:\s*auto;[^}]*bottom:\s*calc\(100% \+ 3px\)/s
+      /\.article-column-picker-popover\s*\{[^}]*position:\s*absolute/s
     );
+    expect(articleOverviewCss).not.toMatch(/\.article-action-menu/);
+    expect(accessoriesCss).not.toMatch(/\.article-action-menu/);
+    expect(accessoriesCss).not.toMatch(/\.article-overflow/);
   });
 
   it("keeps stacked article filters compact on narrow screens", () => {

--- a/frontend/src/features/accessories/articleTableColumns.test.ts
+++ b/frontend/src/features/accessories/articleTableColumns.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  articleTableColumns,
+  articleTableColumnSettingKey,
+  persistArticleTableColumns,
+  storedArticleTableColumns,
+  toggleArticleTableColumn,
+  type ArticleTableColumn
+} from "./articleTableColumns";
+
+describe("article table columns", () => {
+  beforeEach(() => window.localStorage.clear());
+
+  it("defaults missing or malformed preferences to every supported column", () => {
+    expect([...storedArticleTableColumns()]).toEqual(articleTableColumns);
+
+    window.localStorage.setItem(articleTableColumnSettingKey, "not-json");
+    expect([...storedArticleTableColumns()]).toEqual(articleTableColumns);
+  });
+
+  it("filters stale values and restores an identity column", () => {
+    window.localStorage.setItem(
+      articleTableColumnSettingKey,
+      JSON.stringify(["image", "unknown"])
+    );
+
+    expect([...storedArticleTableColumns()]).toEqual(["image", "inventoryNumber"]);
+  });
+
+  it("does not hide the final visible identity column", () => {
+    const current = new Set<ArticleTableColumn>(["name", "stock"]);
+
+    expect([...toggleArticleTableColumn(current, "name")]).toEqual(["name", "stock"]);
+  });
+
+  it("allows either identity column to be hidden when the other remains visible", () => {
+    const current = new Set<ArticleTableColumn>(["inventoryNumber", "name", "stock"]);
+
+    expect([...toggleArticleTableColumn(current, "inventoryNumber")]).toEqual(["name", "stock"]);
+    expect([...toggleArticleTableColumn(current, "name")]).toEqual(["inventoryNumber", "stock"]);
+  });
+
+  it("persists columns in stable table order", () => {
+    persistArticleTableColumns(new Set<ArticleTableColumn>(["storage", "name"]));
+
+    expect(window.localStorage.getItem(articleTableColumnSettingKey)).toBe('["name","storage"]');
+  });
+});

--- a/frontend/src/features/accessories/articleTableColumns.ts
+++ b/frontend/src/features/accessories/articleTableColumns.ts
@@ -1,0 +1,72 @@
+export const articleTableColumns = [
+  "image",
+  "inventoryNumber",
+  "manufacturer",
+  "articleNumber",
+  "name",
+  "type",
+  "gauge",
+  "stock",
+  "storage"
+] as const;
+
+export type ArticleTableColumn = typeof articleTableColumns[number];
+
+export const articleTableColumnSettingKey = "railkeeper.accessories.tableColumns";
+export const defaultArticleTableColumns = new Set<ArticleTableColumn>(articleTableColumns);
+
+type ColumnStorage = Pick<Storage, "getItem" | "setItem">;
+
+function isArticleTableColumn(value: unknown): value is ArticleTableColumn {
+  return typeof value === "string" && articleTableColumns.some((column) => column === value);
+}
+
+export function normalizeArticleTableColumns(values: Iterable<unknown>) {
+  const requested = new Set([...values].filter(isArticleTableColumn));
+  if (!requested.has("inventoryNumber") && !requested.has("name")) {
+    requested.add("inventoryNumber");
+  }
+  return new Set(articleTableColumns.filter((column) => requested.has(column)));
+}
+
+export function storedArticleTableColumns(
+  storage: Pick<ColumnStorage, "getItem"> = window.localStorage
+) {
+  const raw = storage.getItem(articleTableColumnSettingKey);
+  if (!raw) return new Set<ArticleTableColumn>(articleTableColumns);
+
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed)
+      ? normalizeArticleTableColumns(parsed)
+      : new Set<ArticleTableColumn>(articleTableColumns);
+  } catch {
+    return new Set<ArticleTableColumn>(articleTableColumns);
+  }
+}
+
+export function persistArticleTableColumns(
+  columns: ReadonlySet<ArticleTableColumn>,
+  storage: Pick<ColumnStorage, "setItem"> = window.localStorage
+) {
+  const normalized = normalizeArticleTableColumns(columns);
+  storage.setItem(articleTableColumnSettingKey, JSON.stringify([...normalized]));
+}
+
+export function toggleArticleTableColumn(
+  columns: ReadonlySet<ArticleTableColumn>,
+  column: ArticleTableColumn
+) {
+  const next = new Set(columns);
+  if (!next.has(column)) {
+    next.add(column);
+    return normalizeArticleTableColumns(next);
+  }
+
+  const hidesFinalIdentity = (column === "inventoryNumber" && !next.has("name")) ||
+    (column === "name" && !next.has("inventoryNumber"));
+  if (hidesFinalIdentity) return new Set(columns);
+
+  next.delete(column);
+  return normalizeArticleTableColumns(next);
+}

--- a/frontend/src/shared/i18n/de.ts
+++ b/frontend/src/shared/i18n/de.ts
@@ -1534,6 +1534,8 @@ export const deTranslations: Record<string, string> = {
     "accessories.view.label": "Ansicht wechseln",
     "accessories.view.table": "Tabellenansicht",
     "accessories.view.cards": "Kachelansicht",
+    "accessories.view.columns": "Tabellenspalten auswählen",
+    "accessories.view.columnsGroup": "Tabellenspalten",
     "accessories.view.cardsLabel": "Artikel-Kachelansicht",
     "accessories.view.mobileLabel": "Kompakte Artikelliste",
     "accessories.toolbar.articleType": "Artikelart",
@@ -1576,6 +1578,9 @@ export const deTranslations: Record<string, string> = {
     "accessories.actions.archive": "Artikel archivieren",
     "accessories.actions.restore": "Artikel wiederherstellen",
     "accessories.actions.delete": "Artikel löschen",
+    "accessories.actions.archiveNamed": "Artikel archivieren: {name}",
+    "accessories.actions.restoreNamed": "Artikel wiederherstellen: {name}",
+    "accessories.actions.deleteNamed": "Artikel löschen: {name}",
     "accessories.delete.title": "Artikel endgültig löschen",
     "accessories.delete.body":
       "Soll {inventoryNumber}: {name} endgültig gelöscht werden? Dies ist nur bei vollständig unbenutzten Artikeln möglich.",

--- a/frontend/src/shared/i18n/en.ts
+++ b/frontend/src/shared/i18n/en.ts
@@ -1534,6 +1534,8 @@ export const enTranslations: Record<string, string> = {
     "accessories.view.label": "Change view",
     "accessories.view.table": "Table view",
     "accessories.view.cards": "Card view",
+    "accessories.view.columns": "Choose table columns",
+    "accessories.view.columnsGroup": "Table columns",
     "accessories.view.cardsLabel": "Article card view",
     "accessories.view.mobileLabel": "Compact article list",
     "accessories.toolbar.articleType": "Article type",
@@ -1576,6 +1578,9 @@ export const enTranslations: Record<string, string> = {
     "accessories.actions.archive": "Archive article",
     "accessories.actions.restore": "Restore article",
     "accessories.actions.delete": "Delete article",
+    "accessories.actions.archiveNamed": "Archive article: {name}",
+    "accessories.actions.restoreNamed": "Restore article: {name}",
+    "accessories.actions.deleteNamed": "Delete article: {name}",
     "accessories.delete.title": "Permanently delete article",
     "accessories.delete.body":
       "Permanently delete {inventoryNumber}: {name}? This is only possible for completely unused articles.",

--- a/frontend/src/styles/accessories.css
+++ b/frontend/src/styles/accessories.css
@@ -75,17 +75,9 @@
   overflow-x: auto;
 }
 
-.article-table-wrap:has(.article-action-menu) {
-  padding-bottom: 48px;
-}
-
-.article-table-wrap:has(.article-action-menu) .article-table {
-  overflow: visible;
-}
-
 .article-table {
   width: 100%;
-  min-width: 1460px;
+  min-width: var(--article-table-min-width);
   border-collapse: collapse;
   table-layout: fixed;
 }
@@ -100,52 +92,54 @@
   text-align: center;
 }
 
-.article-table th:nth-child(2),
+.article-table th.article-image-cell,
 .article-table td.article-image-cell {
   width: 86px;
 }
 
-.article-table th:nth-child(3),
+.article-table th.article-inventoryNumber-cell,
 .article-table td.article-inventory-cell {
   width: 142px;
 }
 
-.article-table th:nth-child(4),
+.article-table th.article-manufacturer-cell,
 .article-table td.article-manufacturer-cell {
   width: 150px;
 }
 
-.article-table th:nth-child(5),
+.article-table th.article-articleNumber-cell,
 .article-table td.article-number-cell {
   width: 126px;
 }
 
-.article-table th:nth-child(6),
+.article-table th.article-name-cell,
 .article-table td.article-main-cell {
   width: 210px;
 }
 
-.article-table th:nth-child(7) {
+.article-table th.article-type-cell,
+.article-table td.article-type-cell {
   width: 175px;
 }
 
-.article-table th:nth-child(8) {
+.article-table th.article-gauge-cell,
+.article-table td.article-gauge-cell {
   width: 80px;
 }
 
-.article-table th:nth-child(9),
+.article-table th.article-stock-cell,
 .article-table td.article-stock-cell {
   width: 210px;
 }
 
-.article-table th:nth-child(10),
+.article-table th.article-storage-cell,
 .article-table td.article-storage-cell {
   width: 170px;
 }
 
 .article-table th.actions-cell,
 .article-table td.actions-cell {
-  width: 96px;
+  width: 136px;
   text-align: right;
 }
 
@@ -258,48 +252,6 @@
   border-color: transparent;
   background: transparent;
   color: var(--accent-strong);
-}
-
-.article-overflow {
-  position: relative;
-}
-
-.article-action-menu {
-  position: absolute;
-  z-index: 40;
-  top: calc(100% + 3px);
-  right: 0;
-  min-width: 180px;
-  border: 1px solid var(--line);
-  border-radius: 6px;
-  padding: 4px;
-  background: var(--panel);
-  box-shadow: var(--shadow);
-}
-
-.article-action-menu button {
-  width: 100%;
-  border: 0;
-  border-radius: 4px;
-  padding: 7px 9px;
-  background: transparent;
-  color: inherit;
-  cursor: pointer;
-  font: inherit;
-  text-align: left;
-}
-
-.article-action-menu button:hover,
-.article-action-menu button:focus-visible {
-  background: color-mix(in srgb, var(--accent) 8%, transparent);
-  color: var(--accent-strong);
-  outline: none;
-}
-
-.article-action-menu .danger-menu-item,
-.article-action-menu .danger-menu-item:hover,
-.article-action-menu .danger-menu-item:focus-visible {
-  color: var(--danger);
 }
 
 .article-table tr.archived {

--- a/frontend/src/styles/article-overview.css
+++ b/frontend/src/styles/article-overview.css
@@ -39,6 +39,47 @@
   box-shadow: inset 0 -2px var(--accent);
 }
 
+.article-column-picker {
+  position: relative;
+}
+
+.article-column-picker-popover {
+  position: absolute;
+  z-index: 40;
+  top: calc(100% + 4px);
+  right: 0;
+  display: grid;
+  min-width: 210px;
+  gap: 2px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 6px;
+  background: var(--panel);
+  box-shadow: var(--shadow);
+}
+
+.article-column-picker-popover label {
+  display: flex;
+  min-height: 30px;
+  align-items: center;
+  gap: 8px;
+  border-radius: 4px;
+  padding: 5px 7px;
+  color: var(--text);
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+  white-space: nowrap;
+}
+
+.article-column-picker-popover label:hover {
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
+}
+
+.article-column-picker-popover label:has(input:disabled) {
+  color: var(--muted);
+  cursor: not-allowed;
+}
+
 .article-desktop-content {
   min-width: 0;
 }
@@ -60,10 +101,6 @@
   border-radius: 8px;
   background: var(--panel);
   color: var(--text);
-}
-
-.article-card:has(.article-action-menu) {
-  z-index: 5;
 }
 
 .article-card:hover {
@@ -198,10 +235,6 @@
   background: var(--panel);
 }
 
-.article-mobile-item:has(.article-action-menu) {
-  z-index: 5;
-}
-
 .article-mobile-media {
   display: grid;
   grid-area: image;
@@ -272,11 +305,6 @@
 
 .article-mobile-actions .article-row-actions {
   justify-content: flex-end;
-}
-
-.article-mobile-actions .article-action-menu {
-  top: auto;
-  bottom: calc(100% + 3px);
 }
 
 @media (max-width: 920px) {


### PR DESCRIPTION
## Summary

- add a persistent column picker to the accessory table, while keeping at least the inventory number or name visible
- replace the accessory three-dot menu with direct archive, restore, and admin-only delete actions in every overview mode
- prepare RailKeeper v0.1.17.3, including synchronized version references, changelogs, and bilingual release notes

## User impact

Users can reduce wide accessory tables for smaller screens and access lifecycle actions directly. Existing server-side deletion restrictions and confirmations remain unchanged.

## Validation

- `go test ./...`
- `npm.cmd run test:run` (82 files, 446 tests)
- `npm.cmd run build`
- browser QA on the accessory table, card, and compact views at desktop, 1024 px, and 800 px widths
