### PR TITLE
Fix accessory table column widths and prepare v0.1.17.4

### DIFF
--- a/CHANGELOG.de.md
+++ b/CHANGELOG.de.md
@@ -6,6 +6,13 @@ Diese Datei dokumentiert alle wesentlichen Änderungen an RailKeeper.
 
 ## Unveröffentlicht
 
+## [0.1.17.4] - 2026-08-14
+
+### Behoben
+
+- Die Spaltenüberschriften für Hersteller, Artikelnummer und Lagerung behalten ihre vorgesehenen
+  Breiten und überlagern sich in der konfigurierbaren Zubehör-Tabelle nicht mehr.
+
 ## [0.1.17.3] - 2026-08-14
 
 ### Hinzugefügt
@@ -162,6 +169,7 @@ Diese Datei dokumentiert alle wesentlichen Änderungen an RailKeeper.
 - Die Vorprüfung der Backup-Wiederherstellung bleibt konservativ, Authentifizierungsdaten bleiben
   aus Exporten ausgeschlossen.
 
+[0.1.17.4]: https://github.com/ichwars/RailKeeper/compare/v0.1.17.3...v0.1.17.4
 [0.1.17.3]: https://github.com/ichwars/RailKeeper/compare/v0.1.17.2...v0.1.17.3
 [0.1.17.2]: https://github.com/ichwars/RailKeeper/compare/v0.1.17.1...v0.1.17.2
 [0.1.17.1]: https://github.com/ichwars/RailKeeper/compare/v0.1.17...v0.1.17.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to RailKeeper are documented in this file.
 
 ## Unreleased
 
+## [0.1.17.4] - 2026-08-14
+
+### Fixed
+
+- Manufacturer, article number, and storage headers retain their intended widths and no longer
+  overlap in the configurable accessory table.
+
 ## [0.1.17.3] - 2026-08-14
 
 ### Added
@@ -150,6 +157,7 @@ All notable changes to RailKeeper are documented in this file.
 - Tightened API validation and protected master-data import invariants.
 - Kept backup restore preflight conservative and authentication data excluded from exports.
 
+[0.1.17.4]: https://github.com/ichwars/RailKeeper/compare/v0.1.17.3...v0.1.17.4
 [0.1.17.3]: https://github.com/ichwars/RailKeeper/compare/v0.1.17.2...v0.1.17.3
 [0.1.17.2]: https://github.com/ichwars/RailKeeper/compare/v0.1.17.1...v0.1.17.2
 [0.1.17.1]: https://github.com/ichwars/RailKeeper/compare/v0.1.17...v0.1.17.1

--- a/README.de.md
+++ b/README.de.md
@@ -127,7 +127,7 @@ SQLite-Datenbank, Uploads und lokale Dateien bleiben im Docker-Volume `railkeepe
 Um statt `latest` ein bestimmtes Release festzulegen, trage Folgendes in `.env` ein:
 
 ```env
-RAILKEEPER_IMAGE=ghcr.io/ichwars/railkeeper:v0.1.17.3
+RAILKEEPER_IMAGE=ghcr.io/ichwars/railkeeper:v0.1.17.4
 ```
 
 Wenn du bewusst den ausgecheckten Quellstand bauen möchtest, verwende:

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ The SQLite database, uploads and local files stay in the `railkeeper_data` Docke
 To pin a specific release instead of `latest`, set this in `.env`:
 
 ```env
-RAILKEEPER_IMAGE=ghcr.io/ichwars/railkeeper:v0.1.17.3
+RAILKEEPER_IMAGE=ghcr.io/ichwars/railkeeper:v0.1.17.4
 ```
 
 If you intentionally want to build the checked-out source tree, use:

--- a/backend/cmd/railkeeper/main.go
+++ b/backend/cmd/railkeeper/main.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	version               = "0.1.17.3"
+	version               = "0.1.17.4"
 	defaultUpdateCheckURL = "https://api.github.com/repos/ichwars/RailKeeper/releases/latest"
 )
 

--- a/docs/releases/v0.1.17.4.md
+++ b/docs/releases/v0.1.17.4.md
@@ -1,0 +1,25 @@
+# RailKeeper v0.1.17.4
+
+## Deutsch
+
+RailKeeper 0.1.17.4 korrigiert die Spaltenbreiten in der konfigurierbaren Zubehör-Tabelle.
+Hersteller, Artikelnummer und Lagerung behalten ihre vorgesehenen Breiten, sodass die
+Spaltenüberschriften und Inhalte nicht mehr ineinanderlaufen.
+
+Ein Regressionstest schützt die Tabellenüberschriften künftig vor den ausschließlich für
+Datenzellen vorgesehenen Kürzungsregeln.
+
+Weitere Details stehen im
+[deutschen Änderungsprotokoll](https://github.com/ichwars/RailKeeper/blob/v0.1.17.4/CHANGELOG.de.md).
+
+## English
+
+RailKeeper 0.1.17.4 corrects column widths in the configurable accessory table. Manufacturer,
+article number, and storage retain their intended widths so headers and contents no longer
+overlap.
+
+A regression test now protects table headers from truncation rules intended only for data cells.
+
+See the
+[English changelog](https://github.com/ichwars/RailKeeper/blob/v0.1.17.4/CHANGELOG.md)
+for details.

--- a/frontend/src/features/accessories/accessoriesResponsive.test.ts
+++ b/frontend/src/features/accessories/accessoriesResponsive.test.ts
@@ -27,6 +27,17 @@ describe("article editor responsive tabs", () => {
     expect(accessoriesCss).not.toMatch(/\.article-table th:nth-child/);
   });
 
+  it("keeps truncation constraints off configurable table headers", () => {
+    expect(accessoriesCss).toContain(`.article-table td.article-main-cell,
+.article-table td.article-inventory-cell,
+.article-table td.article-manufacturer-cell,
+.article-table td.article-number-cell,
+.article-table td.article-storage-cell {
+  min-width: 0;
+  max-width: 0;
+}`);
+  });
+
   it("loads focused overview styles and switches presentations at the mobile breakpoint", () => {
     expect(appCss).toContain('@import "../styles/article-overview.css";');
     expect(articleOverviewCss).toMatch(/\.article-mobile-list\s*\{[^}]*display:\s*none/s);

--- a/frontend/src/styles/accessories.css
+++ b/frontend/src/styles/accessories.css
@@ -169,11 +169,11 @@
   border-radius: 2px;
 }
 
-.article-main-cell,
-.article-inventory-cell,
-.article-manufacturer-cell,
-.article-number-cell,
-.article-storage-cell {
+.article-table td.article-main-cell,
+.article-table td.article-inventory-cell,
+.article-table td.article-manufacturer-cell,
+.article-table td.article-number-cell,
+.article-table td.article-storage-cell {
   min-width: 0;
   max-width: 0;
 }


### PR DESCRIPTION
## What changed

- scopes article-table truncation rules to data cells so sortable headers retain their configured widths
- adds a regression test for the header selector boundary
- prepares version `0.1.17.4`, changelogs, README image pins, and bilingual release notes

## Why

Semantic column classes introduced for the configurable accessory table also matched a broad `max-width: 0` rule. This collapsed the manufacturer and storage headers and allowed labels to overlap neighboring columns.

## Validation

- `go test ./...`
- `npm.cmd run test:run` (447 tests)
- `npm.cmd run build`
- browser verification on `/accessories`, including column toggle behavior and measured header widths