### PR TITLE
Prepare v0.1.17.5 release

### DIFF
--- a/CHANGELOG.de.md
+++ b/CHANGELOG.de.md
@@ -6,6 +6,13 @@ Diese Datei dokumentiert alle wesentlichen Änderungen an RailKeeper.
 
 ## Unveröffentlicht
 
+## [0.1.17.5] - 2026-08-15
+
+### Geändert
+
+- Der Anlagen-Arbeitsbereich bleibt über den Direktzugriff verfügbar, wird aber nicht mehr in der
+  Hauptnavigation angezeigt.
+
 ## [0.1.17.4] - 2026-08-14
 
 ### Behoben
@@ -169,6 +176,7 @@ Diese Datei dokumentiert alle wesentlichen Änderungen an RailKeeper.
 - Die Vorprüfung der Backup-Wiederherstellung bleibt konservativ, Authentifizierungsdaten bleiben
   aus Exporten ausgeschlossen.
 
+[0.1.17.5]: https://github.com/ichwars/RailKeeper/compare/v0.1.17.4...v0.1.17.5
 [0.1.17.4]: https://github.com/ichwars/RailKeeper/compare/v0.1.17.3...v0.1.17.4
 [0.1.17.3]: https://github.com/ichwars/RailKeeper/compare/v0.1.17.2...v0.1.17.3
 [0.1.17.2]: https://github.com/ichwars/RailKeeper/compare/v0.1.17.1...v0.1.17.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to RailKeeper are documented in this file.
 
 ## Unreleased
 
+## [0.1.17.5] - 2026-08-15
+
+### Changed
+
+- The layout workspace remains available by direct URL but is no longer shown in the main
+  navigation.
+
 ## [0.1.17.4] - 2026-08-14
 
 ### Fixed
@@ -157,6 +164,7 @@ All notable changes to RailKeeper are documented in this file.
 - Tightened API validation and protected master-data import invariants.
 - Kept backup restore preflight conservative and authentication data excluded from exports.
 
+[0.1.17.5]: https://github.com/ichwars/RailKeeper/compare/v0.1.17.4...v0.1.17.5
 [0.1.17.4]: https://github.com/ichwars/RailKeeper/compare/v0.1.17.3...v0.1.17.4
 [0.1.17.3]: https://github.com/ichwars/RailKeeper/compare/v0.1.17.2...v0.1.17.3
 [0.1.17.2]: https://github.com/ichwars/RailKeeper/compare/v0.1.17.1...v0.1.17.2

--- a/README.de.md
+++ b/README.de.md
@@ -40,7 +40,9 @@ Importprüfung, ECoS-Auslesung und die Suche nach neuen Releases.
 - Lokaler Bestand mit SQLite, Uploads und JSON-Backups
 - Fahrzeugdatensätze mit Modelldaten, technischen Feldern, Eigentumsangaben, Bildern, Anhängen, QR-Codes und übersichtlichen Leseansichten
 - Artikelbestand mit generierten Inventarnummern, sortierbarer Auswahlspalte, Mengen- oder Einzelverfolgung, Lagerortbeständen, Reservierungen, Einbauten, Dokumenten und Nutzungshistorie
-- Fundament für Anlagen, Module, Aufbauten und Planrevisionen mit Versionskonfliktschutz; der Eintrag in der Hauptnavigation bleibt vorübergehend deaktiviert, solange der Arbeitsbereich weiter verfeinert wird
+- Fundament für Anlagen, Module, Aufbauten und Planrevisionen mit Versionskonfliktschutz; der
+  Arbeitsbereich bleibt vorübergehend aus der Hauptnavigation ausgeblendet, solange er weiter
+  verfeinert wird
 - Websuche nach Artikeldaten mit konfigurierbaren Quellen, Barcode-/EAN-Eingabe,
   ZXing-Kamerascanner, typisierten Gleis-Fachangaben und ausdrücklicher feldweiser Prüfung
 - PDF-Berichtsdialog für Bestandsübersicht und Detaillisten mit auswählbaren Fahrzeugen, QR-Codes und Bildern
@@ -127,7 +129,7 @@ SQLite-Datenbank, Uploads und lokale Dateien bleiben im Docker-Volume `railkeepe
 Um statt `latest` ein bestimmtes Release festzulegen, trage Folgendes in `.env` ein:
 
 ```env
-RAILKEEPER_IMAGE=ghcr.io/ichwars/railkeeper:v0.1.17.4
+RAILKEEPER_IMAGE=ghcr.io/ichwars/railkeeper:v0.1.17.5
 ```
 
 Wenn du bewusst den ausgecheckten Quellstand bauen möchtest, verwende:

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ The project is designed for private collections, clubs and small workshops that 
 - Local-first inventory with SQLite, uploads and JSON backups
 - Vehicle records with model data, technical fields, ownership details, images, attachments, QR codes and clean read-only detail views
 - Article inventory with generated inventory numbers, sortable selection-first overview, quantity or individual tracking, storage-location stock, reservations, installations, documents and usage history
-- Layout, module, setup and plan-revision foundation with version-conflict protection; its main-navigation entry remains temporarily disabled while the workspace is refined
+- Layout, module, setup and plan-revision foundation with version-conflict protection; the workspace
+  remains temporarily hidden from the main navigation while it is refined
 - Article data web search with configurable sources, barcode/EAN entry, ZXing-based camera scanning,
   typed track details, and explicit field-by-field review
 - PDF report dialog for inventory overview and detail lists with selectable vehicles, QR codes and images
@@ -117,7 +118,7 @@ The SQLite database, uploads and local files stay in the `railkeeper_data` Docke
 To pin a specific release instead of `latest`, set this in `.env`:
 
 ```env
-RAILKEEPER_IMAGE=ghcr.io/ichwars/railkeeper:v0.1.17.4
+RAILKEEPER_IMAGE=ghcr.io/ichwars/railkeeper:v0.1.17.5
 ```
 
 If you intentionally want to build the checked-out source tree, use:

--- a/backend/cmd/railkeeper/main.go
+++ b/backend/cmd/railkeeper/main.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	version               = "0.1.17.4"
+	version               = "0.1.17.5"
 	defaultUpdateCheckURL = "https://api.github.com/repos/ichwars/RailKeeper/releases/latest"
 )
 

--- a/docs/releases/v0.1.17.5.md
+++ b/docs/releases/v0.1.17.5.md
@@ -1,0 +1,20 @@
+# RailKeeper v0.1.17.5
+
+## Deutsch
+
+RailKeeper 0.1.17.5 entfernt den Eintrag „Anlage“ vollständig aus der Hauptnavigation. Der noch in
+Arbeit befindliche Anlagen-Arbeitsbereich bleibt technisch und über den Direktzugriff verfügbar,
+wird Benutzern aber nicht mehr im Menü angeboten.
+
+Weitere Details stehen im
+[deutschen Änderungsprotokoll](https://github.com/ichwars/RailKeeper/blob/v0.1.17.5/CHANGELOG.de.md).
+
+## English
+
+RailKeeper 0.1.17.5 removes the Layout item completely from the main navigation. The layout
+workspace remains technically available and accessible by direct URL while it is still being
+refined, but it is no longer offered to users in the menu.
+
+See the
+[English changelog](https://github.com/ichwars/RailKeeper/blob/v0.1.17.5/CHANGELOG.md)
+for details.

--- a/frontend/src/app/Shell.test.tsx
+++ b/frontend/src/app/Shell.test.tsx
@@ -55,20 +55,18 @@ describe("Shell article navigation", () => {
     await waitFor(() => expect(api.profileSettings).toHaveBeenCalledOnce());
   });
 
-  it("exposes the singular layout item as a link", async () => {
+  it("does not expose the layout workspace in the navigation", async () => {
     render(
       <Shell username="editor" roles={["Editor"]} activeView="accessories" onLogout={vi.fn()}>
         <p>Inhalt</p>
       </Shell>
     );
 
-    const link = screen.getByRole("link", { name: "Anlage" });
-    expect(link).toHaveAttribute("href", "/layouts");
-    expect(link).not.toHaveAttribute("aria-disabled");
+    expect(screen.queryByRole("link", { name: "Anlage" })).not.toBeInTheDocument();
     await waitFor(() => expect(api.profileSettings).toHaveBeenCalledOnce());
   });
 
-  it("uses the singular English layout label", async () => {
+  it("does not expose the layout workspace in the English navigation", async () => {
     window.localStorage.setItem("railkeeper.settings.language", "en");
     render(
       <Shell username="editor" roles={["Editor"]} activeView="accessories" onLogout={vi.fn()}>
@@ -76,9 +74,7 @@ describe("Shell article navigation", () => {
       </Shell>
     );
 
-    const link = screen.getByRole("link", { name: "Layout" });
-    expect(link).toHaveAttribute("href", "/layouts");
-    expect(link).not.toHaveAttribute("aria-disabled");
+    expect(screen.queryByRole("link", { name: "Layout" })).not.toBeInTheDocument();
     await waitFor(() => expect(api.profileSettings).toHaveBeenCalledOnce());
   });
 });

--- a/frontend/src/app/Shell.tsx
+++ b/frontend/src/app/Shell.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
-import { BarChart3, Box, Boxes, Bug, CalendarDays, ChevronLeft, ChevronRight, FileInput, LayoutTemplate, LogOut, Menu, Monitor, Moon, Settings, Sun, X } from "lucide-react";
+import { BarChart3, Box, Boxes, Bug, CalendarDays, ChevronLeft, ChevronRight, FileInput, LogOut, Menu, Monitor, Moon, Settings, Sun, X } from "lucide-react";
 import type { AppView } from "./App";
 import { api } from "../shared/api";
 import { useI18n } from "../shared/i18n";
@@ -11,7 +11,6 @@ const navItems = [
   { view: "overview", href: "/overview", labelKey: "nav.overview", icon: BarChart3 },
   { view: "vehicles", href: "/vehicles", labelKey: "nav.vehicles", icon: Box },
   { view: "accessories", href: "/accessories", labelKey: "nav.accessories", icon: Boxes },
-  { view: "layouts", href: "/layouts", labelKey: "nav.layouts", icon: LayoutTemplate },
   { view: "exhibition", href: "/exhibition", labelKey: "nav.exhibition", icon: CalendarDays },
   { view: "importExport", href: "/import-export", labelKey: "nav.importExport", icon: FileInput },
   { view: "settings", href: "/settings", labelKey: "nav.settings", icon: Settings }


### PR DESCRIPTION
## Änderung

- entfernt den Menülink „Anlage“ vollständig aus der Hauptnavigation
- lässt Direktzugriff, Arbeitsbereich und API unverändert
- aktualisiert Versionsnummer, Changelogs, README-Verweise und Release-Notiz für v0.1.17.5

## Grund

Der Anlagen-Arbeitsbereich soll bis zur weiteren Verfeinerung nicht in der Hauptnavigation angeboten werden.

## Prüfung

- `go test ./...`
- `npm.cmd run test:run` (82 Testdateien, 447 Tests)
- `npm.cmd run build`
- `git diff --check`