### PR TITLE
docs: add bilingual RailKeeper handbook foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,3 +84,22 @@ jobs:
       - name: Test API contract
         working-directory: backend
         run: go test ./internal/api -run OpenAPI -count=1
+
+  documentation:
+    name: Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: docs/package-lock.json
+      - name: Install documentation dependencies
+        working-directory: docs
+        run: npm ci
+      - name: Check documentation
+        working-directory: docs
+        run: npm run check

--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -1,0 +1,53 @@
+name: Documentation Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "frontend/public/brand/**"
+      - ".github/workflows/docs-pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: documentation-pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: docs/package-lock.json
+      - uses: actions/configure-pages@v4
+      - name: Install documentation dependencies
+        working-directory: docs
+        run: npm ci
+      - name: Build documentation
+        working-directory: docs
+        run: npm run check
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/.vitepress/dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy documentation
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,12 @@ frontend/coverage/
 frontend/*.tsbuildinfo
 dist/
 
+# Documentation site
+docs/node_modules/
+docs/.vitepress/cache/
+docs/.vitepress/dist/
+.superpowers/
+
 # Runtime data
 data/
 backend/data/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,15 @@ Run `gofmt` after Go changes. Keep backend routes, frontend API types, and
 `openapi/railkeeper.yaml` aligned when the API changes. Update German and English translations
 together.
 
+## Documentation changes
+
+- Update the English and German page in the same pull request when behavior changes.
+- Keep identical relative paths below `docs/site/` and `docs/site/de/`.
+- Run `cd docs` followed by `npm run check` before opening the pull request.
+- Update `docs/coverage.json` when a route, API area, translation namespace, configuration value,
+  or documentation topic is introduced.
+- A one-language-only change is allowed only for a wording correction that does not change meaning.
+
 ## Pull Requests
 
 Explain the problem, the chosen solution, and the verification performed. Include screenshots for

--- a/README.de.md
+++ b/README.de.md
@@ -20,7 +20,8 @@
 </p>
 
 <p align="center">
-  <a href="README.md">English</a> · <strong>Deutsch</strong>
+  <a href="README.md">English</a> · <strong>Deutsch</strong> ·
+  <a href="https://ichwars.github.io/RailKeeper/de/">Dokumentation</a>
 </p>
 
 ## Überblick
@@ -34,6 +35,9 @@ Das Projekt richtet sich an private Sammlungen, Vereine und kleine Werkstätten,
 Bestandssystem ohne Cloud-Abhängigkeit benötigen. RailKeeper hält Daten, Uploads und Backups unter
 deiner Kontrolle und bietet gleichzeitig moderne Abläufe wie Artikelsuche im Web, strukturierte
 Importprüfung, ECoS-Auslesung und die Suche nach neuen Releases.
+
+Das Handbuch bündelt die vollständige Anleitung für Benutzer, Betrieb und Entwicklung. Die
+Abdeckung wird in englischer und deutscher Sprache direkt gegen die Projektquellen geprüft.
 
 ## Funktionsumfang
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@
 </p>
 
 <p align="center">
-  <strong>English</strong> · <a href="README.de.md">Deutsch</a>
+  <strong>English</strong> · <a href="README.de.md">Deutsch</a> ·
+  <a href="https://ichwars.github.io/RailKeeper/">Documentation</a>
 </p>
 
 ## Overview
@@ -28,6 +29,9 @@
 RailKeeper is a complete self-hosted application for managing model railway vehicles, decoder data, images, documents, maintenance, exhibition lists and imports in one local-first workspace. It runs as a single Go service with an integrated React frontend and stores all operational data in SQLite.
 
 The project is designed for private collections, clubs and small workshops that want a serious inventory system without a cloud dependency. RailKeeper keeps data, uploads and backups under your control while still offering modern workflows such as article web search, structured import review, ECoS readout and release update checks.
+
+The handbook brings together complete user, operator, and developer guidance, with coverage tracked
+against the project sources in both English and German.
 
 ## Highlights
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -2,6 +2,10 @@
 
 RailKeeper is maintained as a free, self-hosted open-source project.
 
+Consult the [English handbook](https://ichwars.github.io/RailKeeper/) or the
+[German handbook](https://ichwars.github.io/RailKeeper/de/) first for installation, operation, and
+troubleshooting guidance. If the handbook does not resolve the problem:
+
 - Report reproducible defects through [GitHub Issues](https://github.com/ichwars/RailKeeper/issues).
 - Discuss usage questions and feature ideas in
   [GitHub Discussions](https://github.com/ichwars/RailKeeper/discussions).

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -91,7 +91,10 @@ export default defineConfig({
           "/reference/": [
             {
               text: "Reference",
-              items: [{ text: "Overview", link: "/reference/" }],
+              items: [
+                { text: "Overview", link: "/reference/" },
+                { text: "Documentation Coverage", link: "/reference/coverage" },
+              ],
             },
           ],
         },
@@ -127,7 +130,10 @@ export default defineConfig({
           "/de/reference/": [
             {
               text: "Referenz",
-              items: [{ text: "Überblick", link: "/de/reference/" }],
+              items: [
+                { text: "Überblick", link: "/de/reference/" },
+                { text: "Dokumentationsabdeckung", link: "/de/reference/coverage" },
+              ],
             },
           ],
         },

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,0 +1,143 @@
+import { fileURLToPath, URL } from "node:url";
+
+import { defineConfig } from "vitepress";
+
+const repositoryUrl = "https://github.com/ichwars/RailKeeper";
+
+export default defineConfig({
+  title: "RailKeeper",
+  description: "Documentation for the local-first model railway inventory and operations tool.",
+  base: "/RailKeeper/",
+  srcDir: "site",
+  cleanUrls: true,
+  lastUpdated: true,
+  vite: {
+    publicDir: fileURLToPath(new URL("../../frontend/public", import.meta.url)),
+  },
+  locales: {
+    root: { label: "English", lang: "en" },
+    de: {
+      label: "Deutsch",
+      lang: "de",
+      link: "/de/",
+      description: "Dokumentation für RailKeeper.",
+    },
+  },
+  themeConfig: {
+    logo: "/brand/railkeeper-mark.svg",
+    siteTitle: "RailKeeper Docs",
+    socialLinks: [{ icon: "github", link: repositoryUrl }],
+    editLink: {
+      pattern: `${repositoryUrl}/edit/main/docs/site/:path`,
+      text: "Edit this page on GitHub",
+    },
+    search: {
+      provider: "local",
+      options: {
+        locales: {
+          de: {
+            translations: {
+              button: {
+                buttonText: "Suchen",
+                buttonAriaLabel: "Dokumentation durchsuchen",
+              },
+              modal: {
+                displayDetails: "Detaillierte Liste anzeigen",
+                resetButtonTitle: "Suche zurücksetzen",
+                backButtonTitle: "Suche schließen",
+                noResultsText: "Keine Ergebnisse gefunden für",
+                footer: {
+                  selectText: "Auswählen",
+                  selectKeyAriaLabel: "Eingabetaste",
+                  navigateText: "Navigieren",
+                  navigateUpKeyAriaLabel: "Pfeil nach oben",
+                  navigateDownKeyAriaLabel: "Pfeil nach unten",
+                  closeText: "Schließen",
+                  closeKeyAriaLabel: "Escape-Taste",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    locales: {
+      root: {
+        nav: [
+          { text: "User Guide", link: "/guide/" },
+          { text: "Administration", link: "/administration/" },
+          { text: "Development", link: "/development/" },
+          { text: "Reference", link: "/reference/" },
+        ],
+        sidebar: {
+          "/guide/": [
+            {
+              text: "User Guide",
+              items: [{ text: "Overview", link: "/guide/" }],
+            },
+          ],
+          "/administration/": [
+            {
+              text: "Administration",
+              items: [{ text: "Overview", link: "/administration/" }],
+            },
+          ],
+          "/development/": [
+            {
+              text: "Development",
+              items: [{ text: "Overview", link: "/development/" }],
+            },
+          ],
+          "/reference/": [
+            {
+              text: "Reference",
+              items: [{ text: "Overview", link: "/reference/" }],
+            },
+          ],
+        },
+        outlineTitle: "On this page",
+        lastUpdated: { text: "Last reviewed" },
+      },
+      de: {
+        nav: [
+          { text: "Benutzerhandbuch", link: "/de/guide/" },
+          { text: "Administration", link: "/de/administration/" },
+          { text: "Entwicklung", link: "/de/development/" },
+          { text: "Referenz", link: "/de/reference/" },
+        ],
+        sidebar: {
+          "/de/guide/": [
+            {
+              text: "Benutzerhandbuch",
+              items: [{ text: "Überblick", link: "/de/guide/" }],
+            },
+          ],
+          "/de/administration/": [
+            {
+              text: "Administration",
+              items: [{ text: "Überblick", link: "/de/administration/" }],
+            },
+          ],
+          "/de/development/": [
+            {
+              text: "Entwicklung",
+              items: [{ text: "Überblick", link: "/de/development/" }],
+            },
+          ],
+          "/de/reference/": [
+            {
+              text: "Referenz",
+              items: [{ text: "Überblick", link: "/de/reference/" }],
+            },
+          ],
+        },
+        editLink: {
+          pattern: `${repositoryUrl}/edit/main/docs/site/:path`,
+          text: "Diese Seite auf GitHub bearbeiten",
+        },
+        outlineTitle: "Auf dieser Seite",
+        lastUpdated: { text: "Zuletzt geprüft" },
+      },
+    },
+  },
+});

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -8,6 +8,16 @@ export default defineConfig({
   title: "RailKeeper",
   description: "Documentation for the local-first model railway inventory and operations tool.",
   base: "/RailKeeper/",
+  head: [
+    [
+      "link",
+      {
+        rel: "icon",
+        type: "image/svg+xml",
+        href: "/RailKeeper/brand/railkeeper-mark.svg",
+      },
+    ],
+  ],
   srcDir: "site",
   cleanUrls: true,
   lastUpdated: true,
@@ -21,87 +31,7 @@ export default defineConfig({
       lang: "de",
       link: "/de/",
       description: "Dokumentation für RailKeeper.",
-    },
-  },
-  themeConfig: {
-    logo: "/brand/railkeeper-mark.svg",
-    siteTitle: "RailKeeper Docs",
-    socialLinks: [{ icon: "github", link: repositoryUrl }],
-    editLink: {
-      pattern: `${repositoryUrl}/edit/main/docs/site/:path`,
-      text: "Edit this page on GitHub",
-    },
-    search: {
-      provider: "local",
-      options: {
-        locales: {
-          de: {
-            translations: {
-              button: {
-                buttonText: "Suchen",
-                buttonAriaLabel: "Dokumentation durchsuchen",
-              },
-              modal: {
-                displayDetails: "Detaillierte Liste anzeigen",
-                resetButtonTitle: "Suche zurücksetzen",
-                backButtonTitle: "Suche schließen",
-                noResultsText: "Keine Ergebnisse gefunden für",
-                footer: {
-                  selectText: "Auswählen",
-                  selectKeyAriaLabel: "Eingabetaste",
-                  navigateText: "Navigieren",
-                  navigateUpKeyAriaLabel: "Pfeil nach oben",
-                  navigateDownKeyAriaLabel: "Pfeil nach unten",
-                  closeText: "Schließen",
-                  closeKeyAriaLabel: "Escape-Taste",
-                },
-              },
-            },
-          },
-        },
-      },
-    },
-    locales: {
-      root: {
-        nav: [
-          { text: "User Guide", link: "/guide/" },
-          { text: "Administration", link: "/administration/" },
-          { text: "Development", link: "/development/" },
-          { text: "Reference", link: "/reference/" },
-        ],
-        sidebar: {
-          "/guide/": [
-            {
-              text: "User Guide",
-              items: [{ text: "Overview", link: "/guide/" }],
-            },
-          ],
-          "/administration/": [
-            {
-              text: "Administration",
-              items: [{ text: "Overview", link: "/administration/" }],
-            },
-          ],
-          "/development/": [
-            {
-              text: "Development",
-              items: [{ text: "Overview", link: "/development/" }],
-            },
-          ],
-          "/reference/": [
-            {
-              text: "Reference",
-              items: [
-                { text: "Overview", link: "/reference/" },
-                { text: "Documentation Coverage", link: "/reference/coverage" },
-              ],
-            },
-          ],
-        },
-        outlineTitle: "On this page",
-        lastUpdated: { text: "Last reviewed" },
-      },
-      de: {
+      themeConfig: {
         nav: [
           { text: "Benutzerhandbuch", link: "/de/guide/" },
           { text: "Administration", link: "/de/administration/" },
@@ -141,8 +71,95 @@ export default defineConfig({
           pattern: `${repositoryUrl}/edit/main/docs/site/:path`,
           text: "Diese Seite auf GitHub bearbeiten",
         },
+        darkModeSwitchLabel: "Darstellung",
+        lightModeSwitchTitle: "Zum hellen Design wechseln",
+        darkModeSwitchTitle: "Zum dunklen Design wechseln",
+        sidebarMenuLabel: "Menü",
+        returnToTopLabel: "Nach oben",
+        langMenuLabel: "Sprache wechseln",
+        skipToContentLabel: "Zum Inhalt springen",
+        docFooter: {
+          prev: "Vorherige Seite",
+          next: "Nächste Seite",
+        },
         outlineTitle: "Auf dieser Seite",
         lastUpdated: { text: "Zuletzt geprüft" },
+      },
+    },
+  },
+  themeConfig: {
+    logo: "/brand/railkeeper-mark.svg",
+    siteTitle: "RailKeeper Docs",
+    socialLinks: [{ icon: "github", link: repositoryUrl }],
+    editLink: {
+      pattern: `${repositoryUrl}/edit/main/docs/site/:path`,
+      text: "Edit this page on GitHub",
+    },
+    nav: [
+      { text: "User Guide", link: "/guide/" },
+      { text: "Administration", link: "/administration/" },
+      { text: "Development", link: "/development/" },
+      { text: "Reference", link: "/reference/" },
+    ],
+    sidebar: {
+      "/guide/": [
+        {
+          text: "User Guide",
+          items: [{ text: "Overview", link: "/guide/" }],
+        },
+      ],
+      "/administration/": [
+        {
+          text: "Administration",
+          items: [{ text: "Overview", link: "/administration/" }],
+        },
+      ],
+      "/development/": [
+        {
+          text: "Development",
+          items: [{ text: "Overview", link: "/development/" }],
+        },
+      ],
+      "/reference/": [
+        {
+          text: "Reference",
+          items: [
+            { text: "Overview", link: "/reference/" },
+            { text: "Documentation Coverage", link: "/reference/coverage" },
+          ],
+        },
+      ],
+    },
+    outlineTitle: "On this page",
+    lastUpdated: { text: "Last reviewed" },
+    search: {
+      provider: "local",
+      options: {
+        locales: {
+          de: {
+            translations: {
+              button: {
+                buttonText: "Suchen",
+                buttonAriaLabel: "Dokumentation durchsuchen",
+              },
+              modal: {
+                displayDetails: "Detaillierte Liste anzeigen",
+                resetButtonTitle: "Suche zurücksetzen",
+                backButtonTitle: "Suche schließen",
+                noResultsText: "Keine Ergebnisse gefunden für",
+                footer: {
+                  selectText: "Auswählen",
+                  selectKeyAriaLabel: "Eingabetaste",
+                  navigateText: "Navigieren",
+                  navigateUpKeyAriaLabel: "Pfeil nach oben",
+                  navigateDownKeyAriaLabel: "Pfeil nach unten",
+                  closeText: "Schließen",
+                  closeKeyAriaLabel: "Escape-Taste",
+                },
+              },
+            },
+          },
+        },
       },
     },
   },

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,0 +1,33 @@
+:root {
+  --vp-c-brand-1: #419310;
+  --vp-c-brand-2: #1c621b;
+  --vp-c-brand-3: #154d15;
+  --vp-c-brand-soft: #e9f8df;
+  --vp-c-bg: #edf2f1;
+  --vp-c-bg-soft: #f5f8f6;
+  --vp-c-divider: #d5dfdc;
+  --vp-c-text-1: #0b1e26;
+  --vp-c-text-2: #4f6869;
+  --vp-font-family-base: "Segoe UI", Arial, sans-serif;
+}
+
+.dark {
+  --vp-c-brand-1: #a5ec60;
+  --vp-c-brand-2: #8ad449;
+  --vp-c-brand-3: #70ba32;
+  --vp-c-brand-soft: rgb(165 236 96 / 13%);
+  --vp-c-bg: #0f1314;
+  --vp-c-bg-soft: #171c1f;
+  --vp-c-divider: #273235;
+  --vp-c-text-1: #f5f8f6;
+  --vp-c-text-2: #a8b7b3;
+}
+
+.VPNavBarTitle .logo {
+  height: 28px;
+  width: 28px;
+}
+
+.VPHero .name {
+  color: var(--vp-c-text-1);
+}

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -31,3 +31,18 @@
 .VPHero .name {
   color: var(--vp-c-text-1);
 }
+
+@media (min-width: 768px) and (max-width: 1099px) {
+  .VPNavBarMenu,
+  .VPNavBarExtra {
+    display: none !important;
+  }
+
+  .VPNavBarHamburger {
+    display: flex !important;
+  }
+
+  .VPNavScreen {
+    display: block !important;
+  }
+}

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,0 +1,5 @@
+import DefaultTheme from "vitepress/theme";
+
+import "./custom.css";
+
+export default DefaultTheme;

--- a/docs/coverage.json
+++ b/docs/coverage.json
@@ -1,0 +1,275 @@
+{
+  "schemaVersion": 1,
+  "topics": [
+    {
+      "id": "setup-auth",
+      "audience": "user",
+      "status": "planned",
+      "englishPath": "guide/getting-started/index.md",
+      "germanPath": "de/guide/getting-started/index.md"
+    },
+    {
+      "id": "overview",
+      "audience": "user",
+      "status": "planned",
+      "englishPath": "guide/overview/index.md",
+      "germanPath": "de/guide/overview/index.md"
+    },
+    {
+      "id": "vehicles-core",
+      "audience": "user",
+      "status": "planned",
+      "englishPath": "guide/vehicles/index.md",
+      "germanPath": "de/guide/vehicles/index.md"
+    },
+    {
+      "id": "vehicle-media",
+      "audience": "user",
+      "status": "planned",
+      "englishPath": "guide/vehicles/media.md",
+      "germanPath": "de/guide/vehicles/media.md"
+    },
+    {
+      "id": "vehicle-maintenance",
+      "audience": "user",
+      "status": "planned",
+      "englishPath": "guide/vehicles/maintenance.md",
+      "germanPath": "de/guide/vehicles/maintenance.md"
+    },
+    {
+      "id": "vehicle-decoder-cv",
+      "audience": "user",
+      "status": "planned",
+      "englishPath": "guide/vehicles/decoder-cv.md",
+      "germanPath": "de/guide/vehicles/decoder-cv.md"
+    },
+    {
+      "id": "vehicle-search-spares",
+      "audience": "user",
+      "status": "planned",
+      "englishPath": "guide/vehicles/search-and-spares.md",
+      "germanPath": "de/guide/vehicles/search-and-spares.md"
+    },
+    {
+      "id": "accessories",
+      "audience": "user",
+      "status": "planned",
+      "englishPath": "guide/accessories/index.md",
+      "germanPath": "de/guide/accessories/index.md"
+    },
+    {
+      "id": "exhibition",
+      "audience": "user",
+      "status": "planned",
+      "englishPath": "guide/exhibition/index.md",
+      "germanPath": "de/guide/exhibition/index.md"
+    },
+    {
+      "id": "import-export",
+      "audience": "user",
+      "status": "planned",
+      "englishPath": "guide/import-export/index.md",
+      "germanPath": "de/guide/import-export/index.md"
+    },
+    {
+      "id": "settings-general",
+      "audience": "user",
+      "status": "planned",
+      "englishPath": "guide/settings/index.md",
+      "germanPath": "de/guide/settings/index.md"
+    },
+    {
+      "id": "master-data",
+      "audience": "admin",
+      "status": "planned",
+      "englishPath": "administration/master-data.md",
+      "germanPath": "de/administration/master-data.md"
+    },
+    {
+      "id": "users-sessions-security",
+      "audience": "admin",
+      "status": "planned",
+      "englishPath": "administration/users-sessions-security.md",
+      "germanPath": "de/administration/users-sessions-security.md"
+    },
+    {
+      "id": "backup-restore",
+      "audience": "admin",
+      "status": "planned",
+      "englishPath": "administration/backup-restore.md",
+      "germanPath": "de/administration/backup-restore.md"
+    },
+    {
+      "id": "digital-centers",
+      "audience": "admin",
+      "status": "planned",
+      "englishPath": "administration/digital-centers.md",
+      "germanPath": "de/administration/digital-centers.md"
+    },
+    {
+      "id": "system-operations",
+      "audience": "admin",
+      "status": "planned",
+      "englishPath": "administration/system-operations.md",
+      "germanPath": "de/administration/system-operations.md"
+    },
+    {
+      "id": "layouts-unpublished",
+      "audience": "developer",
+      "status": "not-published",
+      "englishPath": "development/layouts.md",
+      "germanPath": "de/development/layouts.md"
+    },
+    {
+      "id": "deployment-configuration",
+      "audience": "admin",
+      "status": "planned",
+      "englishPath": "administration/deployment-configuration.md",
+      "germanPath": "de/administration/deployment-configuration.md"
+    },
+    {
+      "id": "development-architecture",
+      "audience": "developer",
+      "status": "planned",
+      "englishPath": "development/architecture.md",
+      "germanPath": "de/development/architecture.md"
+    },
+    {
+      "id": "releases-support",
+      "audience": "reference",
+      "status": "planned",
+      "englishPath": "reference/releases-and-support.md",
+      "germanPath": "de/reference/releases-and-support.md"
+    },
+    {
+      "id": "shared-navigation",
+      "audience": "reference",
+      "status": "planned",
+      "englishPath": "reference/navigation-and-glossary.md",
+      "germanPath": "de/reference/navigation-and-glossary.md"
+    }
+  ],
+  "owners": {
+    "frontendRoutes": {
+      "/overview": "overview",
+      "/vehicles": "vehicles-core",
+      "/accessories": "accessories",
+      "/layouts": "layouts-unpublished",
+      "/exhibition": "exhibition",
+      "/import-export": "import-export",
+      "/settings": "settings-general"
+    },
+    "translationPrefixes": {
+      "accessories": "accessories",
+      "app": "setup-auth",
+      "auth": "setup-auth",
+      "common": "shared-navigation",
+      "exhibition": "exhibition",
+      "importExport": "import-export",
+      "layouts": "layouts-unpublished",
+      "nav": "shared-navigation",
+      "overview": "overview",
+      "settings.articleManagement": "master-data",
+      "settings.articleSearch": "vehicle-search-spares",
+      "settings.audit": "users-sessions-security",
+      "settings.auditAction": "users-sessions-security",
+      "settings.auth": "users-sessions-security",
+      "settings.backup": "backup-restore",
+      "settings.digital": "digital-centers",
+      "settings.inventoryNumbers": "master-data",
+      "settings.master": "master-data",
+      "settings.masterTransfer": "master-data",
+      "settings.password": "users-sessions-security",
+      "settings.role": "users-sessions-security",
+      "settings.roles": "users-sessions-security",
+      "settings.session": "users-sessions-security",
+      "settings.sessions": "users-sessions-security",
+      "settings.smtp": "users-sessions-security",
+      "settings.storage": "system-operations",
+      "settings.updates": "releases-support",
+      "settings.users": "users-sessions-security",
+      "settings": "settings-general",
+      "setup": "setup-auth",
+      "vehicle": "vehicles-core",
+      "vehicles.articleSearch": "vehicle-search-spares",
+      "vehicles.barcode": "vehicle-search-spares",
+      "vehicles.cv": "vehicle-decoder-cv",
+      "vehicles.functionMode": "vehicle-decoder-cv",
+      "vehicles.functionType": "vehicle-decoder-cv",
+      "vehicles.functions": "vehicle-decoder-cv",
+      "vehicles.image": "vehicle-media",
+      "vehicles.imageCare": "vehicle-media",
+      "vehicles.imagePreview": "vehicle-media",
+      "vehicles.maintenance": "vehicle-maintenance",
+      "vehicles.search": "vehicle-search-spares",
+      "vehicles.spareParts": "vehicle-search-spares",
+      "vehicles.speedCurve": "vehicle-decoder-cv",
+      "vehicles.uploads": "vehicle-media",
+      "vehicles": "vehicles-core"
+    },
+    "apiPrefixes": {
+      "/health": "system-operations",
+      "/api/v1/version": "releases-support",
+      "/api/v1/system/digital-settings": "digital-centers",
+      "/api/v1/system/smtp": "users-sessions-security",
+      "/api/v1/system": "system-operations",
+      "/api/v1/setup": "setup-auth",
+      "/api/v1/auth/two-factor": "users-sessions-security",
+      "/api/v1/auth/password": "users-sessions-security",
+      "/api/v1/auth": "setup-auth",
+      "/api/v1/profile": "settings-general",
+      "/api/v1/roles": "users-sessions-security",
+      "/api/v1/users": "users-sessions-security",
+      "/api/v1/sessions": "users-sessions-security",
+      "/api/v1/ecos": "digital-centers",
+      "/api/v1/digital-centers": "digital-centers",
+      "/api/v1/vehicles/{id}/images": "vehicle-media",
+      "/api/v1/vehicles/{id}/attachments": "vehicle-media",
+      "/api/v1/vehicles/{id}/maintenance": "vehicle-maintenance",
+      "/api/v1/vehicles/{id}/spare-parts": "vehicle-search-spares",
+      "/api/v1/vehicles/{id}/functions": "vehicle-decoder-cv",
+      "/api/v1/vehicles/{id}/cv-values": "vehicle-decoder-cv",
+      "/api/v1/vehicles/{id}/cv-files": "vehicle-decoder-cv",
+      "/api/v1/cv-files": "vehicle-decoder-cv",
+      "/api/v1/article-search": "vehicle-search-spares",
+      "/api/v1/vehicles": "vehicles-core",
+      "/api/v1/accessory": "accessories",
+      "/api/v1/storage-locations": "accessories",
+      "/api/v1/layout": "layouts-unpublished",
+      "/api/v1/plan-": "layouts-unpublished",
+      "/api/v1/track-": "layouts-unpublished",
+      "/api/v1/inventory-number-schemes": "master-data",
+      "/api/v1/master-data": "master-data",
+      "/api/v1/backup": "backup-restore",
+      "/api/v1/exhibition-lists": "exhibition"
+    },
+    "environmentVariables": {
+      "RAILKEEPER_ADDR": "deployment-configuration",
+      "RAILKEEPER_ALLOWED_ATTACHMENT_EXTENSIONS": "deployment-configuration",
+      "RAILKEEPER_COOKIE_SECURE": "deployment-configuration",
+      "RAILKEEPER_DATA_DIR": "deployment-configuration",
+      "RAILKEEPER_DEFAULT_PRINTER": "deployment-configuration",
+      "RAILKEEPER_IMAGE": "deployment-configuration",
+      "RAILKEEPER_MAX_ATTACHMENT_MB": "deployment-configuration",
+      "RAILKEEPER_MAX_ATTACHMENT_BYTES": "deployment-configuration",
+      "RAILKEEPER_MAX_IMAGE_MB": "deployment-configuration",
+      "RAILKEEPER_MAX_IMAGE_BYTES": "deployment-configuration",
+      "RAILKEEPER_MIGRATIONS_DIR": "deployment-configuration",
+      "RAILKEEPER_OPEN_BROWSER": "deployment-configuration",
+      "RAILKEEPER_PDF_OCR": "deployment-configuration",
+      "RAILKEEPER_PDF_OCR_MAX_PAGES": "deployment-configuration",
+      "RAILKEEPER_PORTABLE": "deployment-configuration",
+      "RAILKEEPER_PRINTERS": "deployment-configuration",
+      "RAILKEEPER_PUBLIC_URL": "deployment-configuration",
+      "RAILKEEPER_SEEDS_DIR": "deployment-configuration",
+      "RAILKEEPER_SMTP_FROM": "deployment-configuration",
+      "RAILKEEPER_SMTP_HOST": "deployment-configuration",
+      "RAILKEEPER_SMTP_PASSWORD": "deployment-configuration",
+      "RAILKEEPER_SMTP_PORT": "deployment-configuration",
+      "RAILKEEPER_SMTP_TLS": "deployment-configuration",
+      "RAILKEEPER_SMTP_USER": "deployment-configuration",
+      "RAILKEEPER_STATIC_DIR": "deployment-configuration",
+      "RAILKEEPER_UPDATE_CHECK_URL": "deployment-configuration"
+    }
+  }
+}

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,0 +1,1972 @@
+{
+  "name": "railkeeper-documentation",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "railkeeper-documentation",
+      "license": "AGPL-3.0-only",
+      "devDependencies": {
+        "vitepress": "2.0.0-alpha.19"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@docsearch/css": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-4.7.0.tgz",
+      "integrity": "sha512-Sk5xkdRFeE7PeWjG9l4AfTwdvMfr9wHiwNNCpHXT4v4SNyNMKdHGvEILc31BgaVFGDDNbv5u/a73tofRiwbEZw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@docsearch/js": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-4.7.0.tgz",
+      "integrity": "sha512-x5lCqu1tetgsJFkjQ6VSocbHldsRkGEgwg5N98Vx21sq/V5wcmj4u226PY9k+TEpIgQ772zlYbPLTPicWyGnpA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@docsearch/sidepanel-js": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/sidepanel-js/-/sidepanel-js-4.7.0.tgz",
+      "integrity": "sha512-A8r34jCU8kcIk2viECEn2msA28ojUF1BLi/3v5OWWc5G2N3jOuuumBXoeYjfr8dA0UxgFSy5R2bt12dnFJQSyA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@iconify-json/simple-icons": {
+      "version": "1.2.93",
+      "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.93.tgz",
+      "integrity": "sha512-/XhANjfGYOuqvSR3TmUnkQkINvQ4GVjVuukvymRbxtVFBvIq/yiXJqCDycKcQPT401OYT9H2vIY6ihAlz1QIAw==",
+      "dev": true,
+      "license": "CC0-1.0",
+      "dependencies": {
+        "@iconify/types": "*"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.144.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.144.0.tgz",
+      "integrity": "sha512-nuhZIOLuI6TFQ32I/WnUx+SCPY7SdSKwgnFHydAuoS1+Z4BRcaP+RRJmGzl9lw+0OFF7UmaESf7KQRXaNLHypg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.4.tgz",
+      "integrity": "sha512-jHC2cnyKz5xU2fhECtFl8OZ83cYNt13GZQD+0uMJ/X3o+ijmd56okHhTUwxVSHPx1IRVIJEZ1/1pPzeLCU6XKA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-Dc5mPD8F5F/FS8i01syd7FTF6yB2fVthH/TRkjwJkzUK6EpoxHtqvZQP5Zwq80/5z19TWYHIg1KOHboCgVx/aQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-fpDm4oBo6SqLvWUYCmFhdde3U9KH2fRNNMeAnAPAIwxRL345xutL0EtEUcuoxsoazdJGv/MuDBQHlCDrtbvqOg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.4.tgz",
+      "integrity": "sha512-rSJoreDE/HoIzoaib6MTp5jQtCTdMHKIvItAKT/ImS6Y6Ww76oUaeMyp4Vc/fAgd/ehji068IxetHXAnqUwN9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.4.tgz",
+      "integrity": "sha512-/jm8OGHgn7oGaJu3i/qZI9spUGcJ+y/lk43ttQ/iO1tOd9NissG6o97bighBCiL+BKRngmcDuR6ikfwYdJmVuQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.4.tgz",
+      "integrity": "sha512-tIP06BeD9EqvECBrPZ+sqdPlYrT+aYaAiu1wYziVx5elRK/ftm33JxVDy2bXGbr6J0CrtirCkR87/X5a2euEng==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.4.tgz",
+      "integrity": "sha512-Ql1Q0EQqVThvn9VAVlwNzsUvbSFtCMGjLpRRi4pk5i7NZZ4n5ISiLMjHYtus4VQ2PvkSw24zyaCVsiS+sXPj1w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.4.tgz",
+      "integrity": "sha512-GjbjXD4XXfN19D0LZNbmiCBUoDiRACsYHr0yaIbbn8aFsXjHZifcYqu/W5Er5X2X990WjHXFrxarn5chzItorQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.4.tgz",
+      "integrity": "sha512-p5WR0NOwaRmJ/B1b6IjEFLLivwEsf3PrdBIhRbhTCQisbo2SvHHpG4ELB/+FgQNnB88LTOF86upmJmbvZdQ2lw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.4.tgz",
+      "integrity": "sha512-4/GyVjmhR+Tc6HLJvwc1sOhPqAZtySiSMesOZyX6JQ5XBxoTDEMKQzvo07NIK6nTon/SivlZqvhzvuVBNQhObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.4.tgz",
+      "integrity": "sha512-l9eeLsCNvPpmSXUej0etw/J1eqV0Jj1D5G/xG6YTijmE6dkv6E2QezgWbTfQk63v952DPqrjOCoiqxq7Bw0YUQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.4.tgz",
+      "integrity": "sha512-e0F355MSTMm3+UOqtV3L24gFUp2N5m1f8L/7d56deik6va+AXdrt9F8LbzGpeWGWRbZEDq4m8NVnJDeBtf9DZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.4.tgz",
+      "integrity": "sha512-AWLi0uBRYh6QlE7OKhiz+phZC0qwtij2QZmhmOdsLdFn64m7oMpooE9ICE3lhm9xMb4SpDo2WbHcxX1iFLFtqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.4.tgz",
+      "integrity": "sha512-UwSDJOg3dqCAejWdxclJjCsh3Qq4vLYMDxmyHqo1btz3stK2VqgwNd3mm5tuIwzSlGIQ/1H9Hr+Zn09mrezNqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@shikijs/core": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.4.3.tgz",
+      "integrity": "sha512-QCR4q2ZO/ILJEuwiBMel4wdcTDb1JGwfjKTxPDF6x8ixOaluPrVqIn06C99AcRPhmYlBR56d/Fb+GN58GzExpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/primitive": "4.4.3",
+        "@shikijs/types": "4.4.3",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.5",
+        "hast-util-to-html": "^9.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.4.3.tgz",
+      "integrity": "sha512-FbOjFJp9VLdo1Wevs10BBtVxiTWwNLqZh5Gkhjgda/ioL15YOgeSl9n+6XMa3qRlPQzfhFNe641SrynFHYG0nQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.3",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.6"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.4.3.tgz",
+      "integrity": "sha512-EcOQkxdxGQrc1Row/cC2c96/v1dbZqGnEVu1qTuT/MJmp6+cXCvQussowVmCv5Tqr3KuY3c7IbM6HTW3LJ1k9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.3",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.4.3.tgz",
+      "integrity": "sha512-ePic0yfAJGOF83D5wBHK/00EjK65oahBYxFk5epgq33WRv7X9UuxLEV8PtR0szC0z8dl7INIpIodB99JRFlR+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.3"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/primitive": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.4.3.tgz",
+      "integrity": "sha512-m0wBeLDQDeIxRdUmrCPdQqfuUamDwRL5isCfYbguKD6NiaKpVbsv+3J81DyIKgNW5h4WAIIr8T4EkgQrBBxvaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.3",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.4.3.tgz",
+      "integrity": "sha512-w8UHjeUnIR965KMWJHUPXOc2mNJUnK3vpVLYLvw5IYU2mnTTJ89E24OrJDBNiJDQ0qzb0tc4l7mrIXx5cFeIyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.3"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/transformers": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-4.4.3.tgz",
+      "integrity": "sha512-oJSARV6NaWd+rnNJbtnpAdj3Zg0ZVyzsnMgb3vi3HA+35y8lBWUCpOnWsmyiXZIikY+x1BDqrQUgmxfzWh7Jvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "4.4.3",
+        "@shikijs/types": "4.4.3"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.4.3.tgz",
+      "integrity": "sha512-UEJxmRR++MAGR6hugn0vgVS2W/6lWAts84FFSrnlH9sP0LNol7E5+NQ792pH8liWUhyMyjhTgSUH3k7iD7tc5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/web-bluetooth": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+      "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.8.tgz",
+      "integrity": "sha512-0ZjgOg7oO6farnNGup7yvoM/YXZV84OZxHAwtflItNa/6zzQyVb5LNxyea3FEKEX2XlagIKzrlH7wwxkKgtiew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.41.tgz",
+      "integrity": "sha512-q0Xtv/F9w2YO/7htQhtiL+Ev2WCJbe5N2hc+XfgyKkEKqWpSxknmT8QOuGdEKNdjPq0c3F7rNpFkTo3Kfrm7pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@vue/shared": "3.5.41",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.41.tgz",
+      "integrity": "sha512-oKacVfNglLvGjnS6BXOlGL7EyG2h8X03pqXCjzotRZUaXGjbrTJUnVAQjrCqUnS+lyu31nwQjZY/d817GmCnfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.41",
+        "@vue/shared": "3.5.41"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.41.tgz",
+      "integrity": "sha512-XJhip7R2wy6vX3knCxdZN4KracFaZUef58s1KYewqluedHIJaPIVfXoYT7MF1F8nCvv6k8bWWxDC8opMkg1VTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@vue/compiler-core": "3.5.41",
+        "@vue/compiler-dom": "3.5.41",
+        "@vue/compiler-ssr": "3.5.41",
+        "@vue/shared": "3.5.41",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.19",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.41.tgz",
+      "integrity": "sha512-U3v5OejKEGqOI0Wy0+Sz7hGuIFZHA4LSXzrNM3IMIeDyJEBBfTpX26n3SDgToRpP2bLc9FfI2j/kSgcJ8Emq5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.41",
+        "@vue/shared": "3.5.41"
+      }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-8.2.1.tgz",
+      "integrity": "sha512-6u4vXBlIBAC1wMplIZgpyPn7uh/s4Bf6F5bMzvLv+EdJ0aHs/+4B7Ygv864EStQSjRbsRzTko/kUG1A1IejQ3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-kit": "^8.2.1"
+      }
+    },
+    "node_modules/@vue/devtools-kit": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-8.2.1.tgz",
+      "integrity": "sha512-FIGIuq3AWReEpbAHY/cRGeHDfI0qOb8OCQ3YjbEAX04uaxIDbGc9rhkbVcG7rnfHPXE3RsU5KrWOu9V/okd8AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-shared": "^8.2.1",
+        "birpc": "^2.6.1",
+        "hookable": "^5.5.3",
+        "perfect-debounce": "^2.0.0"
+      }
+    },
+    "node_modules/@vue/devtools-shared": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-8.2.1.tgz",
+      "integrity": "sha512-Fkac7lUdGReh6pVOi3AYPRGe82LQqRmAfThW7RRligOAP0ZA/Z1z9XLHDM9dv34pV2HRc79DK8uKPeG2fLnA/g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.41.tgz",
+      "integrity": "sha512-rznsqKM0np0x18EjzF8x88MpEhdNsffbvFbckLL5+oUKz1BxAImEmO7J1ArRYSyo6aQaVoBDp7jEkT91OOxydA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.41"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.41.tgz",
+      "integrity": "sha512-Vcry58hiAKwGen9Z1jUZE0feFsNArPCMOImYI8el48A9Idf6DuQYD0U05zZIF2Iad1hGhPSvcbBbAOhNr55fhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.41",
+        "@vue/shared": "3.5.41"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.41.tgz",
+      "integrity": "sha512-3vVBahVBS9+U6cmXBLyb8nE6/yYo4J/CGI9eVFs3KiMc0YHuudwKyShTD65jtJy/L9PUUxNAFu4cj4LiJ0UFbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.41",
+        "@vue/runtime-core": "3.5.41",
+        "@vue/shared": "3.5.41",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.41.tgz",
+      "integrity": "sha512-n6hx/pNFfbD6SuyeuMVkvqox8bwf/ET9JlA/kAz/imw8sw++wkqKe2mHX5KutjPpbKE4Z56yTHszoOjGMI9igQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.41",
+        "@vue/runtime-dom": "3.5.41",
+        "@vue/shared": "3.5.41"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.41.tgz",
+      "integrity": "sha512-IOnwSCma8j+9xJT6b8H0dEYidC80NsYmNMlZxRsukYcSoGaDBohog5hDxzeUXdFeGWFA++vWvxqOmrr96VlqMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vueuse/core": {
+      "version": "14.4.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-14.4.0.tgz",
+      "integrity": "sha512-X4WHz1HlCzCBoYXesUkifzzWBAcZgXG8Fi5iNPQg/epdzOB3gu8Fawj3hvuwYR1nGcXGnvxwYYcUC/71++svtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.21",
+        "@vueuse/metadata": "14.4.0",
+        "@vueuse/shared": "14.4.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
+    "node_modules/@vueuse/integrations": {
+      "version": "14.4.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-14.4.0.tgz",
+      "integrity": "sha512-oJz9qTgczvA7L1nXQFRU7h8tQbOCoiceqvMMhT9XYMyOGTqLJ2rEa09PON+nD2t48sZUfeOmg4eaWJXV4sZb/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vueuse/core": "14.4.0",
+        "@vueuse/shared": "14.4.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "async-validator": "^4",
+        "axios": "^1",
+        "change-case": "^5",
+        "drauu": "^0.4",
+        "focus-trap": "^7 || ^8",
+        "fuse.js": "^7",
+        "idb-keyval": "^6",
+        "jwt-decode": "^4",
+        "nprogress": "^0.2",
+        "qrcode": "^1.5",
+        "sortablejs": "^1",
+        "universal-cookie": "^7 || ^8",
+        "vue": "^3.5.0"
+      },
+      "peerDependenciesMeta": {
+        "async-validator": {
+          "optional": true
+        },
+        "axios": {
+          "optional": true
+        },
+        "change-case": {
+          "optional": true
+        },
+        "drauu": {
+          "optional": true
+        },
+        "focus-trap": {
+          "optional": true
+        },
+        "fuse.js": {
+          "optional": true
+        },
+        "idb-keyval": {
+          "optional": true
+        },
+        "jwt-decode": {
+          "optional": true
+        },
+        "nprogress": {
+          "optional": true
+        },
+        "qrcode": {
+          "optional": true
+        },
+        "sortablejs": {
+          "optional": true
+        },
+        "universal-cookie": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vueuse/metadata": {
+      "version": "14.4.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-14.4.0.tgz",
+      "integrity": "sha512-swx/255R6JyHZFJhx845iz5CRWDZdCfvkZOpACWc5+c5WHcG24mv8gUT1WIdFQaHt6dq79rvILd9QnCWiyVm9g==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared": {
+      "version": "14.4.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-14.4.0.tgz",
+      "integrity": "sha512-JRgY90Sz8DDtPMsaDflvPMp9xYk69JZAmbuDvAquUVXKr2gEjqtzGNTTthLfckH0BzBqvnu31gb4a8TGLRe79g==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
+    "node_modules/birpc": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
+      "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/focus-trap": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-8.2.2.tgz",
+      "integrity": "sha512-qV0g8hRYBqgACcFOH3f9wXc4zPKhr/0z9RI2a6ZijZ72EeBi4g8oBy8zAWuUR1TsMpOzwpUMFvjdasrC41Joug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tabbable": "^6.5.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hookable": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mark.js": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
+      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/minisearch": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
+      "integrity": "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+      "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+      "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "oniguruma-parser": "^0.12.2",
+        "regex": "^6.1.0",
+        "regex-recursion": "^6.0.2"
+      }
+    },
+    "node_modules/perfect-debounce": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
+      "integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rolldown": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.4.tgz",
+      "integrity": "sha512-rSr7irW0K7QRWzjdJXqZowkcRdDtjRduh43rBltnVKd0VFq839l1lJoDvGJb6gl7+4rTTCrPWu+YfujUL8Ug7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.144.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.2.4",
+        "@rolldown/binding-darwin-arm64": "1.2.4",
+        "@rolldown/binding-darwin-x64": "1.2.4",
+        "@rolldown/binding-freebsd-x64": "1.2.4",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.4",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.4",
+        "@rolldown/binding-linux-arm64-musl": "1.2.4",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.4",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.4",
+        "@rolldown/binding-linux-x64-gnu": "1.2.4",
+        "@rolldown/binding-linux-x64-musl": "1.2.4",
+        "@rolldown/binding-openharmony-arm64": "1.2.4",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.4",
+        "@rolldown/binding-win32-x64-msvc": "1.2.4"
+      }
+    },
+    "node_modules/shiki": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.4.3.tgz",
+      "integrity": "sha512-Mb/GvXPHBAXdgGIcnfU5L3ldpn1XcxrGkPHwqgRx17/I2XRfqlFKk2vGkHWINn1kdXvzJZeuO3is6I9KLPFm0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "4.4.3",
+        "@shikijs/engine-javascript": "4.4.3",
+        "@shikijs/engine-oniguruma": "4.4.3",
+        "@shikijs/langs": "4.4.3",
+        "@shikijs/themes": "4.4.3",
+        "@shikijs/types": "4.4.3",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/tabbable": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
+      "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
+      "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.25",
+        "rolldown": "~1.2.1",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitepress": {
+      "version": "2.0.0-alpha.19",
+      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-2.0.0-alpha.19.tgz",
+      "integrity": "sha512-WnBsb0Bwr43kXKyiis+lld/7ri3hnMbthS8N3hpFtjjwsdLO4IRmiAE08D7aud4q6oMDf9uwRowxzNqRFe/amw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@docsearch/css": "^4.7.0",
+        "@docsearch/js": "^4.7.0",
+        "@docsearch/sidepanel-js": "^4.7.0",
+        "@iconify-json/simple-icons": "^1.2.92",
+        "@shikijs/core": "^4.4.1",
+        "@shikijs/transformers": "^4.4.1",
+        "@shikijs/types": "^4.4.1",
+        "@types/markdown-it": "^14.1.2",
+        "@vitejs/plugin-vue": "^6.0.8",
+        "@vue/devtools-api": "^8.2.1",
+        "@vue/shared": "^3.5.40",
+        "@vueuse/core": "^14.4.0",
+        "@vueuse/integrations": "^14.4.0",
+        "focus-trap": "^8.2.2",
+        "mark.js": "8.11.1",
+        "minisearch": "^7.2.0",
+        "shiki": "^4.4.1",
+        "vite": "^8.2.0",
+        "vue": "^3.5.40"
+      },
+      "bin": {
+        "vitepress": "bin/vitepress.js"
+      },
+      "peerDependencies": {
+        "markdown-it-mathjax3": "^4",
+        "postcss": "^8"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it-mathjax3": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.41.tgz",
+      "integrity": "sha512-2laE0p+aK+/AOPG/XL/WepOs/GlK755LJ1XECi9kDUrz1FKNw8rb2Xzlw9JS1rqEV55nb0ttsKxVlTCcd+R5cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.41",
+        "@vue/compiler-sfc": "3.5.41",
+        "@vue/runtime-dom": "3.5.41",
+        "@vue/server-renderer": "3.5.41",
+        "@vue/shared": "3.5.41"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    }
+  }
+}

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "railkeeper-documentation",
+  "private": true,
+  "license": "AGPL-3.0-only",
+  "scripts": {
+    "dev": "vitepress dev",
+    "build": "vitepress build",
+    "preview": "vitepress preview",
+    "test": "node --test scripts/*.test.mjs",
+    "check": "npm test && node scripts/validate-docs.mjs && vitepress build"
+  },
+  "devDependencies": {
+    "vitepress": "2.0.0-alpha.19"
+  }
+}

--- a/docs/scripts/source-inventory.mjs
+++ b/docs/scripts/source-inventory.mjs
@@ -1,0 +1,250 @@
+import { execFile } from "node:child_process";
+import { readdir, readFile } from "node:fs/promises";
+import { basename, extname, relative, resolve, sep } from "node:path";
+import { promisify } from "node:util";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const execFileAsync = promisify(execFile);
+const excludedSegments = new Set([
+  ".cache",
+  ".git",
+  ".superpowers",
+  "data",
+  "dist",
+  "node_modules",
+]);
+const textExtensions = new Set([
+  ".bat",
+  ".cmd",
+  ".css",
+  ".env",
+  ".go",
+  ".html",
+  ".js",
+  ".json",
+  ".md",
+  ".mjs",
+  ".ps1",
+  ".sh",
+  ".sql",
+  ".toml",
+  ".ts",
+  ".tsx",
+  ".txt",
+  ".yaml",
+  ".yml",
+]);
+const extensionlessTextFiles = new Set([
+  ".gitattributes",
+  ".gitignore",
+  "Dockerfile",
+  "LICENSE",
+  "Makefile",
+]);
+
+function sortUnique(values) {
+  return [...new Set(values)].sort();
+}
+
+export function extractFrontendRoutes(source) {
+  const routes = [];
+  const patterns = [
+    /startsWith\(\s*["'](\/[^"']*)["']\s*\)/g,
+    /\bhref\s*:\s*["'](\/[^"']*)["']/g,
+    /\bhref\s*=\s*["'](\/[^"']*)["']/g,
+  ];
+
+  for (const pattern of patterns) {
+    for (const match of source.matchAll(pattern)) {
+      routes.push(match[1]);
+    }
+  }
+
+  return sortUnique(routes);
+}
+
+export function extractTranslationKeys(source) {
+  return sortUnique([...source.matchAll(/^\s*"([^"]+)"\s*:/gm)].map((match) => match[1]));
+}
+
+export function extractApiRoutes(source) {
+  const routes = [];
+  const routePattern =
+    /\{\s*http\.Method([A-Za-z]+)\s*,\s*"([^"]+)"\s*,\s*routeAccess([A-Za-z]+)\s*,/g;
+
+  for (const match of source.matchAll(routePattern)) {
+    routes.push({
+      access: match[3],
+      method: match[1].toUpperCase(),
+      path: match[2],
+    });
+  }
+
+  return routes.sort((left, right) => {
+    const leftKey = `${left.method} ${left.path} ${left.access}`;
+    const rightKey = `${right.method} ${right.path} ${right.access}`;
+    return leftKey < rightKey ? -1 : leftKey > rightKey ? 1 : 0;
+  });
+}
+
+export function extractOpenApiPaths(source) {
+  const operations = [];
+  const methodPattern = /^    (delete|get|head|options|patch|post|put|trace):\s*(?:#.*)?$/i;
+  let currentPath = "";
+  let inPaths = false;
+
+  for (const line of source.replace(/\r\n/g, "\n").split("\n")) {
+    if (!inPaths) {
+      inPaths = /^paths:\s*(?:#.*)?$/.test(line);
+      continue;
+    }
+    if (/^[^\s#][^:]*:/.test(line)) {
+      break;
+    }
+
+    const pathMatch = line.match(/^  (\/[^:]*):\s*(?:#.*)?$/);
+    if (pathMatch) {
+      currentPath = pathMatch[1];
+      continue;
+    }
+
+    const methodMatch = currentPath ? line.match(methodPattern) : null;
+    if (methodMatch) {
+      operations.push(`${methodMatch[1].toUpperCase()} ${currentPath}`);
+    }
+  }
+
+  return sortUnique(operations);
+}
+
+export function extractEnvironmentVariables(source) {
+  return sortUnique([...source.matchAll(/\bRAILKEEPER_[A-Z0-9][A-Z0-9_]*\b/g)].map((match) => match[0]));
+}
+
+function excludedPath(relativePath) {
+  const segments = relativePath.split("/");
+  if (segments.some((segment) => excludedSegments.has(segment))) {
+    return true;
+  }
+
+  return relativePath.startsWith("docs/scripts/") || relativePath.startsWith("docs/superpowers/");
+}
+
+function isTextFile(relativePath) {
+  return (
+    textExtensions.has(extname(relativePath).toLowerCase()) ||
+    extensionlessTextFiles.has(basename(relativePath))
+  );
+}
+
+async function walkFiles(root, directory, files) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  entries.sort((left, right) => left.name.localeCompare(right.name, "en"));
+
+  for (const entry of entries) {
+    const absolutePath = resolve(directory, entry.name);
+    const relativePath = relative(root, absolutePath).split(sep).join("/");
+    if (excludedPath(relativePath)) {
+      continue;
+    }
+    if (entry.isDirectory()) {
+      await walkFiles(root, absolutePath, files);
+    } else if (entry.isFile()) {
+      files.push(relativePath);
+    }
+  }
+}
+
+async function repositoryFiles(root) {
+  try {
+    const { stdout } = await execFileAsync("git", ["ls-files", "-z"], {
+      cwd: root,
+      encoding: "utf8",
+      maxBuffer: 10 * 1024 * 1024,
+    });
+    return sortUnique(stdout.split("\0").filter(Boolean).filter((path) => !excludedPath(path)));
+  } catch {
+    const files = [];
+    await walkFiles(root, root, files);
+    return sortUnique(files);
+  }
+}
+
+async function readRepositoryFile(root, relativePath) {
+  return readFile(resolve(root, ...relativePath.split("/")), "utf8");
+}
+
+function translationDifference(english, german) {
+  const englishSet = new Set(english);
+  const germanSet = new Set(german);
+  const missingGerman = english.filter((key) => !germanSet.has(key));
+  const missingEnglish = german.filter((key) => !englishSet.has(key));
+
+  if (missingGerman.length === 0 && missingEnglish.length === 0) {
+    return "";
+  }
+
+  return [
+    `missing in German: ${missingGerman.join(", ") || "none"}`,
+    `missing in English: ${missingEnglish.join(", ") || "none"}`,
+  ].join("; ");
+}
+
+export async function buildSourceInventory(repositoryRoot) {
+  const root = resolve(repositoryRoot);
+  const [appSource, shellSource, englishSource, germanSource, apiSource, openApiSource, files] =
+    await Promise.all([
+      readRepositoryFile(root, "frontend/src/app/App.tsx"),
+      readRepositoryFile(root, "frontend/src/app/Shell.tsx"),
+      readRepositoryFile(root, "frontend/src/shared/i18n/en.ts"),
+      readRepositoryFile(root, "frontend/src/shared/i18n/de.ts"),
+      readRepositoryFile(root, "backend/internal/api/routes.go"),
+      readRepositoryFile(root, "openapi/railkeeper.yaml"),
+      repositoryFiles(root),
+    ]);
+
+  const englishKeys = extractTranslationKeys(englishSource);
+  const germanKeys = extractTranslationKeys(germanSource);
+  const difference = translationDifference(englishKeys, germanKeys);
+  if (difference) {
+    throw new Error(`translation keys differ: ${difference}`);
+  }
+
+  const environmentVariables = [];
+  for (const path of files.filter(isTextFile)) {
+    const source = await readRepositoryFile(root, path);
+    environmentVariables.push(...extractEnvironmentVariables(source));
+  }
+
+  const legacyDocuments = files.filter(
+    (path) =>
+      /^README(?:\.[^/]+)?\.md$/.test(path) ||
+      /^docs\/[^/]+\.md$/.test(path) ||
+      /^docs\/releases\/[^/]+\.md$/.test(path),
+  );
+
+  return {
+    schemaVersion: 1,
+    frontendRoutes: sortUnique([
+      ...extractFrontendRoutes(appSource),
+      ...extractFrontendRoutes(shellSource),
+    ]),
+    translationKeys: englishKeys,
+    translationNamespaces: sortUnique(englishKeys.map((key) => key.split(".", 1)[0])),
+    apiRoutes: extractApiRoutes(apiSource),
+    openApiOperations: extractOpenApiPaths(openApiSource),
+    environmentVariables: sortUnique(environmentVariables),
+    legacyDocuments: sortUnique(legacyDocuments),
+  };
+}
+
+async function runCli() {
+  const repositoryRoot = resolve(fileURLToPath(new URL("../..", import.meta.url)));
+  const inventory = await buildSourceInventory(repositoryRoot);
+  process.stdout.write(`${JSON.stringify(inventory, null, 2)}\n`);
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : "";
+if (invokedPath === import.meta.url) {
+  await runCli();
+}

--- a/docs/scripts/source-inventory.test.mjs
+++ b/docs/scripts/source-inventory.test.mjs
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import { after, test } from "node:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import {
+  buildSourceInventory,
+  extractApiRoutes,
+  extractEnvironmentVariables,
+  extractFrontendRoutes,
+  extractOpenApiPaths,
+  extractTranslationKeys,
+} from "./source-inventory.mjs";
+
+const temporaryRoots = [];
+
+after(async () => {
+  await Promise.all(temporaryRoots.map((root) => rm(root, { force: true, recursive: true })));
+});
+
+async function fixture(files) {
+  const root = await mkdtemp(join(tmpdir(), "railkeeper-inventory-"));
+  temporaryRoots.push(root);
+
+  await Promise.all(
+    Object.entries(files).map(async ([relativePath, source]) => {
+      const absolutePath = join(root, relativePath);
+      await mkdir(dirname(absolutePath), { recursive: true });
+      await writeFile(absolutePath, source, "utf8");
+    }),
+  );
+
+  return root;
+}
+
+test("extracts visible frontend routes", () => {
+  assert.deepEqual(extractFrontendRoutes('startsWith("/vehicles")\nhref: "/overview"'), [
+    "/overview",
+    "/vehicles",
+  ]);
+});
+
+test("extracts full translation keys", () => {
+  assert.deepEqual(extractTranslationKeys('  "vehicles.cv.title": "CV",'), [
+    "vehicles.cv.title",
+  ]);
+});
+
+test("extracts API route specifications", () => {
+  assert.deepEqual(
+    extractApiRoutes('{http.MethodGet, "/api/v1/vehicles", routeAccessViewer, handler, nil}'),
+    [{ access: "Viewer", method: "GET", path: "/api/v1/vehicles" }],
+  );
+});
+
+test("extracts only OpenAPI operations below path keys", () => {
+  assert.deepEqual(extractOpenApiPaths("paths:\n  /vehicles:\n    get:\n    post:\n"), [
+    "GET /vehicles",
+    "POST /vehicles",
+  ]);
+
+  assert.deepEqual(
+    extractOpenApiPaths("components:\n  schemas:\n    Vehicle:\n      properties:\n        get:\n"),
+    [],
+  );
+});
+
+test("extracts RailKeeper environment variables", () => {
+  assert.deepEqual(extractEnvironmentVariables('env("RAILKEEPER_ADDR", ":8080")'), [
+    "RAILKEEPER_ADDR",
+  ]);
+});
+
+test("builds a deterministic source inventory when translations match", async () => {
+  const translations = 'export const translations = {\n  "nav.overview": "Overview",\n};\n';
+  const root = await fixture({
+    "frontend/src/app/App.tsx": 'startsWith("/vehicles")',
+    "frontend/src/app/Shell.tsx": 'href: "/overview"',
+    "frontend/src/shared/i18n/en.ts": translations,
+    "frontend/src/shared/i18n/de.ts": translations,
+    "backend/internal/api/routes.go":
+      '{http.MethodGet, "/api/v1/vehicles", routeAccessViewer, handler, nil}',
+    "backend/config.go": 'env("RAILKEEPER_ADDR", ":8080")',
+    "openapi/railkeeper.yaml": "paths:\n  /vehicles:\n    get:\n",
+    "README.md": "# RailKeeper",
+    "README.de.md": "# RailKeeper",
+    "docs/architecture.md": "# Architecture",
+    "docs/releases/v0.1.0.md": "# Release",
+  });
+
+  const first = await buildSourceInventory(root);
+  const second = await buildSourceInventory(root);
+
+  assert.deepEqual(first, second);
+  assert.deepEqual(first.translationKeys, ["nav.overview"]);
+  assert.deepEqual(first.translationNamespaces, ["nav"]);
+  assert.deepEqual(first.legacyDocuments, [
+    "README.de.md",
+    "README.md",
+    "docs/architecture.md",
+    "docs/releases/v0.1.0.md",
+  ]);
+});
+
+test("rejects mismatched English and German translation keys", async () => {
+  const root = await fixture({
+    "frontend/src/app/App.tsx": "",
+    "frontend/src/app/Shell.tsx": "",
+    "frontend/src/shared/i18n/en.ts": '"nav.overview": "Overview",',
+    "frontend/src/shared/i18n/de.ts": '"nav.vehicles": "Fahrzeuge",',
+    "backend/internal/api/routes.go": "",
+    "openapi/railkeeper.yaml": "paths:\n",
+  });
+
+  await assert.rejects(
+    () => buildSourceInventory(root),
+    /translation keys differ: missing in German: nav\.overview; missing in English: nav\.vehicles/,
+  );
+});

--- a/docs/scripts/validate-docs.mjs
+++ b/docs/scripts/validate-docs.mjs
@@ -1,10 +1,14 @@
+import { existsSync } from "node:fs";
 import { readdir, readFile } from "node:fs/promises";
 import { dirname, relative, resolve, sep } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
+import { buildSourceInventory } from "./source-inventory.mjs";
+
 const requiredFields = ["audience", "status", "reviewedVersion", "lastReviewed"];
 const allowedAudiences = ["admin", "developer", "reference", "user"];
 const allowedStatuses = ["development", "stable"];
+const allowedCoverageStatuses = ["documented", "internal", "not-published", "planned"];
 const pairFields = ["audience", "status", "reviewedVersion", "lastReviewed"];
 const unfinishedMarkerPattern = /\b(TODO|TBD|FIXME)\b/;
 
@@ -148,11 +152,110 @@ export async function validateDocumentTree(root, versions) {
   return errors.sort((left, right) => left.localeCompare(right, "en"));
 }
 
+function longestPrefixOwner(value, owners, matches) {
+  const prefixes = Object.keys(owners)
+    .filter((prefix) => matches(value, prefix))
+    .sort((left, right) => right.length - left.length || left.localeCompare(right, "en"));
+  return prefixes.length > 0 ? owners[prefixes[0]] : "";
+}
+
+export function validateCoverage(inventory, manifest, contentRoot) {
+  const errors = [];
+  const topics = Array.isArray(manifest.topics) ? manifest.topics : [];
+  const topicIds = new Set();
+
+  for (const topic of topics) {
+    if (topicIds.has(topic.id)) {
+      errors.push(`duplicate coverage topic ${topic.id}`);
+    }
+    topicIds.add(topic.id);
+
+    if (!allowedAudiences.includes(topic.audience)) {
+      errors.push(`coverage topic ${topic.id} has invalid audience ${topic.audience}`);
+    }
+    if (!allowedCoverageStatuses.includes(topic.status)) {
+      errors.push(`coverage topic ${topic.id} has invalid status ${topic.status}`);
+    }
+
+    if (topic.status === "documented") {
+      const destinations = [
+        ["English", topic.englishPath],
+        ["German", topic.germanPath],
+      ];
+      for (const [language, path] of destinations) {
+        const absolutePath = path
+          ? resolve(contentRoot, ...path.split("/"))
+          : resolve(contentRoot, "__missing__");
+        if (!path || !existsSync(absolutePath)) {
+          errors.push(`coverage topic ${topic.id} references missing ${language} page ${path || ""}`);
+        }
+      }
+    }
+  }
+
+  const owners = manifest.owners ?? {};
+  const frontendOwners = owners.frontendRoutes ?? {};
+  const translationOwners = owners.translationPrefixes ?? {};
+  const apiOwners = owners.apiPrefixes ?? {};
+  const environmentOwners = owners.environmentVariables ?? {};
+  const ownerMaps = [
+    ["frontend route", frontendOwners],
+    ["translation prefix", translationOwners],
+    ["API prefix", apiOwners],
+    ["environment variable", environmentOwners],
+  ];
+
+  for (const [label, ownerMap] of ownerMaps) {
+    for (const [source, topicId] of Object.entries(ownerMap)) {
+      if (!topicIds.has(topicId)) {
+        errors.push(`${label} owner ${source} references unknown topic ${topicId}`);
+      }
+    }
+  }
+
+  for (const route of inventory.frontendRoutes ?? []) {
+    if (!frontendOwners[route]) {
+      errors.push(`frontend route ${route} is not covered`);
+    }
+  }
+  for (const key of inventory.translationKeys ?? []) {
+    const owner = longestPrefixOwner(
+      key,
+      translationOwners,
+      (value, prefix) => value === prefix || value.startsWith(`${prefix}.`),
+    );
+    if (!owner) {
+      errors.push(`translation key ${key} is not covered`);
+    }
+  }
+  for (const route of inventory.apiRoutes ?? []) {
+    const owner = longestPrefixOwner(route.path, apiOwners, (value, prefix) =>
+      value.startsWith(prefix),
+    );
+    if (!owner) {
+      errors.push(`API route ${route.method} ${route.path} is not covered`);
+    }
+  }
+  for (const variable of inventory.environmentVariables ?? []) {
+    if (!environmentOwners[variable]) {
+      errors.push(`environment variable ${variable} is not covered`);
+    }
+  }
+
+  return errors.sort((left, right) => left.localeCompare(right, "en"));
+}
+
 async function runCli() {
   const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+  const repositoryRoot = resolve(scriptDirectory, "../..");
   const contentRoot = resolve(scriptDirectory, "../site");
   const versions = JSON.parse(await readFile(resolve(scriptDirectory, "../versions.json"), "utf8"));
-  const errors = await validateDocumentTree(contentRoot, versions);
+  const manifest = JSON.parse(await readFile(resolve(scriptDirectory, "../coverage.json"), "utf8"));
+  const inventory = await buildSourceInventory(repositoryRoot);
+  const errors = [
+    ...(await validateDocumentTree(contentRoot, versions)),
+    ...validateCoverage(inventory, manifest, contentRoot),
+  ].sort((left, right) => left.localeCompare(right, "en"));
 
   for (const error of errors) {
     console.error(error);

--- a/docs/scripts/validate-docs.mjs
+++ b/docs/scripts/validate-docs.mjs
@@ -1,0 +1,168 @@
+import { readdir, readFile } from "node:fs/promises";
+import { dirname, relative, resolve, sep } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const requiredFields = ["audience", "status", "reviewedVersion", "lastReviewed"];
+const allowedAudiences = ["admin", "developer", "reference", "user"];
+const allowedStatuses = ["development", "stable"];
+const pairFields = ["audience", "status", "reviewedVersion", "lastReviewed"];
+const unfinishedMarkerPattern = /\b(TODO|TBD|FIXME)\b/;
+
+function frontmatterParts(source) {
+  const normalized = source.replace(/^\uFEFF/, "").replace(/\r\n/g, "\n");
+  if (!normalized.startsWith("---\n")) {
+    throw new Error("missing frontmatter");
+  }
+
+  const end = normalized.indexOf("\n---\n", 4);
+  if (end === -1) {
+    throw new Error("unterminated frontmatter");
+  }
+
+  return {
+    body: normalized.slice(end + 5),
+    frontmatter: normalized.slice(4, end),
+  };
+}
+
+export function parseFrontmatter(source) {
+  const { frontmatter } = frontmatterParts(source);
+  const metadata = {};
+
+  for (const line of frontmatter.split("\n")) {
+    if (line.trim() === "") {
+      continue;
+    }
+    if (/^\s/.test(line)) {
+      continue;
+    }
+
+    const separator = line.indexOf(":");
+    if (separator <= 0) {
+      throw new Error(`invalid frontmatter line ${line}`);
+    }
+
+    const key = line.slice(0, separator).trim();
+    const value = line.slice(separator + 1).trim();
+    if (!/^[A-Za-z][A-Za-z0-9]*$/.test(key)) {
+      throw new Error(`invalid frontmatter key ${key}`);
+    }
+    if (Object.hasOwn(metadata, key)) {
+      throw new Error(`duplicate frontmatter key ${key}`);
+    }
+
+    metadata[key] = value;
+  }
+
+  return metadata;
+}
+
+async function collectMarkdownFiles(root, directory, files) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  entries.sort((left, right) => left.name.localeCompare(right.name, "en"));
+
+  for (const entry of entries) {
+    const absolutePath = resolve(directory, entry.name);
+    if (entry.isDirectory()) {
+      await collectMarkdownFiles(root, absolutePath, files);
+    } else if (entry.isFile() && entry.name.endsWith(".md")) {
+      files.push(relative(root, absolutePath).split(sep).join("/"));
+    }
+  }
+}
+
+export async function markdownFiles(root) {
+  const files = [];
+  await collectMarkdownFiles(resolve(root), resolve(root), files);
+  return files.sort((left, right) => left.localeCompare(right, "en"));
+}
+
+function validateMetadata(path, metadata, versions, errors) {
+  for (const field of requiredFields) {
+    if (!metadata[field]) {
+      errors.push(`${path}: missing ${field}`);
+    }
+  }
+
+  if (metadata.audience && !allowedAudiences.includes(metadata.audience)) {
+    errors.push(`${path}: audience must be one of ${allowedAudiences.join(", ")}`);
+  }
+  if (metadata.status && !allowedStatuses.includes(metadata.status)) {
+    errors.push(`${path}: status must be one of ${allowedStatuses.join(", ")}`);
+  }
+  if (metadata.lastReviewed && !/^\d{4}-\d{2}-\d{2}$/.test(metadata.lastReviewed)) {
+    errors.push(`${path}: lastReviewed must use YYYY-MM-DD`);
+  }
+
+  const canonicalVersion = versions[metadata.status];
+  if (canonicalVersion && metadata.reviewedVersion !== canonicalVersion) {
+    errors.push(`${path}: reviewedVersion must be ${canonicalVersion} for ${metadata.status}`);
+  }
+}
+
+export async function validateDocumentTree(root, versions) {
+  const resolvedRoot = resolve(root);
+  const files = await markdownFiles(resolvedRoot);
+  const fileSet = new Set(files);
+  const documents = new Map();
+  const errors = [];
+
+  for (const path of files) {
+    const source = await readFile(resolve(resolvedRoot, ...path.split("/")), "utf8");
+    try {
+      const metadata = parseFrontmatter(source);
+      documents.set(path, metadata);
+      validateMetadata(path, metadata, versions, errors);
+
+      const { body } = frontmatterParts(source);
+      const marker = body.match(unfinishedMarkerPattern)?.[1];
+      if (marker) {
+        errors.push(`${path}: contains unfinished marker ${marker}`);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      errors.push(`${path}: ${message}`);
+    }
+
+    const counterpart = path.startsWith("de/") ? path.slice(3) : `de/${path}`;
+    if (!fileSet.has(counterpart)) {
+      errors.push(`${path}: missing counterpart ${counterpart}`);
+    }
+  }
+
+  for (const path of files.filter((candidate) => !candidate.startsWith("de/"))) {
+    const counterpart = `de/${path}`;
+    const english = documents.get(path);
+    const german = documents.get(counterpart);
+    if (!english || !german) {
+      continue;
+    }
+
+    for (const field of pairFields) {
+      if (english[field] !== german[field]) {
+        errors.push(`${path}: ${field} differs from ${counterpart}`);
+      }
+    }
+  }
+
+  return errors.sort((left, right) => left.localeCompare(right, "en"));
+}
+
+async function runCli() {
+  const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+  const contentRoot = resolve(scriptDirectory, "../site");
+  const versions = JSON.parse(await readFile(resolve(scriptDirectory, "../versions.json"), "utf8"));
+  const errors = await validateDocumentTree(contentRoot, versions);
+
+  for (const error of errors) {
+    console.error(error);
+  }
+  if (errors.length > 0) {
+    process.exitCode = 1;
+  }
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : "";
+if (invokedPath === import.meta.url) {
+  await runCli();
+}

--- a/docs/scripts/validate-docs.test.mjs
+++ b/docs/scripts/validate-docs.test.mjs
@@ -4,7 +4,7 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
-import { parseFrontmatter, validateDocumentTree } from "./validate-docs.mjs";
+import { parseFrontmatter, validateCoverage, validateDocumentTree } from "./validate-docs.mjs";
 
 const versions = {
   stable: "0.1.17.5",
@@ -156,4 +156,112 @@ hero:
       hero: "",
     },
   );
+});
+
+test("coverage validation reports every unmapped source surface", async () => {
+  const contentRoot = await fixture({});
+  const inventory = {
+    frontendRoutes: ["/unmapped"],
+    translationKeys: ["settings.newArea.title"],
+    apiRoutes: [{ access: "Viewer", method: "GET", path: "/api/v1/unmapped" }],
+    environmentVariables: ["RAILKEEPER_UNMAPPED"],
+  };
+  const manifest = {
+    schemaVersion: 1,
+    topics: [
+      {
+        id: "vehicles",
+        audience: "user",
+        status: "documented",
+        englishPath: "guide/vehicles/index.md",
+        germanPath: "de/guide/vehicles/index.md",
+      },
+    ],
+    owners: {
+      frontendRoutes: {},
+      translationPrefixes: {},
+      apiPrefixes: {},
+      environmentVariables: {},
+    },
+  };
+
+  const errors = validateCoverage(inventory, manifest, contentRoot);
+  assert(errors.includes("frontend route /unmapped is not covered"));
+  assert(errors.includes("translation key settings.newArea.title is not covered"));
+  assert(errors.includes("API route GET /api/v1/unmapped is not covered"));
+  assert(errors.includes("environment variable RAILKEEPER_UNMAPPED is not covered"));
+  assert(
+    errors.includes(
+      "coverage topic vehicles references missing English page guide/vehicles/index.md",
+    ),
+  );
+});
+
+test("coverage validation accepts one owner for every source item", async () => {
+  const contentRoot = await fixture({});
+  const inventory = {
+    frontendRoutes: ["/vehicles"],
+    translationKeys: ["vehicles.cv.title"],
+    apiRoutes: [{ access: "Viewer", method: "GET", path: "/api/v1/vehicles" }],
+    environmentVariables: ["RAILKEEPER_ADDR"],
+  };
+  const manifest = {
+    schemaVersion: 1,
+    topics: [
+      {
+        id: "vehicles",
+        audience: "user",
+        status: "planned",
+        englishPath: "guide/vehicles/index.md",
+        germanPath: "de/guide/vehicles/index.md",
+      },
+    ],
+    owners: {
+      frontendRoutes: { "/vehicles": "vehicles" },
+      translationPrefixes: { vehicles: "vehicles", "vehicles.cv": "vehicles" },
+      apiPrefixes: { "/api/v1/vehicles": "vehicles" },
+      environmentVariables: { RAILKEEPER_ADDR: "vehicles" },
+    },
+  };
+
+  assert.deepEqual(validateCoverage(inventory, manifest, contentRoot), []);
+});
+
+test("coverage validation rejects invalid topics and unknown owner references", async () => {
+  const contentRoot = await fixture({});
+  const manifest = {
+    schemaVersion: 1,
+    topics: [
+      {
+        id: "duplicate",
+        audience: "reader",
+        status: "draft",
+        englishPath: "guide/index.md",
+        germanPath: "de/guide/index.md",
+      },
+      {
+        id: "duplicate",
+        audience: "user",
+        status: "planned",
+        englishPath: "guide/index.md",
+        germanPath: "de/guide/index.md",
+      },
+    ],
+    owners: {
+      frontendRoutes: { "/vehicles": "missing" },
+      translationPrefixes: {},
+      apiPrefixes: {},
+      environmentVariables: {},
+    },
+  };
+  const errors = validateCoverage(
+    { frontendRoutes: [], translationKeys: [], apiRoutes: [], environmentVariables: [] },
+    manifest,
+    contentRoot,
+  );
+
+  assert(errors.includes("coverage topic duplicate has invalid audience reader"));
+  assert(errors.includes("coverage topic duplicate has invalid status draft"));
+  assert(errors.includes("duplicate coverage topic duplicate"));
+  assert(errors.includes("frontend route owner /vehicles references unknown topic missing"));
 });

--- a/docs/scripts/validate-docs.test.mjs
+++ b/docs/scripts/validate-docs.test.mjs
@@ -1,0 +1,159 @@
+import assert from "node:assert/strict";
+import { after, test } from "node:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import { parseFrontmatter, validateDocumentTree } from "./validate-docs.mjs";
+
+const versions = {
+  stable: "0.1.17.5",
+  development: "main",
+};
+
+const temporaryRoots = [];
+
+after(async () => {
+  await Promise.all(temporaryRoots.map((root) => rm(root, { force: true, recursive: true })));
+});
+
+async function fixture(files) {
+  const root = await mkdtemp(join(tmpdir(), "railkeeper-docs-"));
+  temporaryRoots.push(root);
+
+  await Promise.all(
+    Object.entries(files).map(async ([relativePath, source]) => {
+      const absolutePath = join(root, relativePath);
+      await mkdir(dirname(absolutePath), { recursive: true });
+      await writeFile(absolutePath, source, "utf8");
+    }),
+  );
+
+  return root;
+}
+
+function page(audience, status, reviewedVersion, overrides = {}) {
+  const values = {
+    title: "Test",
+    description: "Test page.",
+    audience,
+    status,
+    reviewedVersion,
+    lastReviewed: "2026-08-15",
+    ...overrides,
+  };
+
+  return `---
+title: ${values.title}
+description: ${values.description}
+audience: ${values.audience}
+status: ${values.status}
+reviewedVersion: ${values.reviewedVersion}
+lastReviewed: ${values.lastReviewed}
+---
+
+# Test
+`;
+}
+
+test("accepts a complete matching language pair", async () => {
+  const root = await fixture({
+    "index.md": page("reference", "stable", "0.1.17.5"),
+    "de/index.md": page("reference", "stable", "0.1.17.5"),
+  });
+  assert.deepEqual(await validateDocumentTree(root, versions), []);
+});
+
+test("reports a missing German counterpart", async () => {
+  const root = await fixture({ "guide/index.md": page("user", "stable", "0.1.17.5") });
+  assert.deepEqual(await validateDocumentTree(root, versions), [
+    "guide/index.md: missing counterpart de/guide/index.md",
+  ]);
+});
+
+test("reports a missing English counterpart", async () => {
+  const root = await fixture({
+    "de/administration/index.md": page("admin", "stable", "0.1.17.5"),
+  });
+  assert.deepEqual(await validateDocumentTree(root, versions), [
+    "de/administration/index.md: missing counterpart administration/index.md",
+  ]);
+});
+
+test("reports missing and mismatched metadata", async () => {
+  const root = await fixture({
+    "index.md": page("reference", "stable", "0.1.17.5"),
+    "de/index.md": page("developer", "development", "main"),
+  });
+  const errors = await validateDocumentTree(root, versions);
+  assert(errors.includes("index.md: audience differs from de/index.md"));
+  assert(errors.includes("index.md: status differs from de/index.md"));
+  assert(errors.includes("index.md: reviewedVersion differs from de/index.md"));
+});
+
+test("enforces the canonical version for each status", async () => {
+  const root = await fixture({
+    "index.md": page("reference", "stable", "0.1.14"),
+    "de/index.md": page("reference", "stable", "0.1.14"),
+  });
+  assert((await validateDocumentTree(root, versions)).some((error) =>
+    error.includes("reviewedVersion must be 0.1.17.5"),
+  ));
+});
+
+test("rejects invalid metadata and unfinished markers", async () => {
+  const invalid = page("reader", "draft", "next", { lastReviewed: "15.08.2026" }).replace(
+    "# Test",
+    "# Test\n\nTBD",
+  );
+  const root = await fixture({ "index.md": invalid, "de/index.md": invalid });
+  const errors = await validateDocumentTree(root, versions);
+
+  assert(errors.includes("index.md: audience must be one of admin, developer, reference, user"));
+  assert(errors.includes("index.md: status must be one of development, stable"));
+  assert(errors.includes("index.md: lastReviewed must use YYYY-MM-DD"));
+  assert(errors.includes("index.md: contains unfinished marker TBD"));
+});
+
+test("requires every contract field", async () => {
+  const incomplete = `---
+title: Test
+description: Test page.
+---
+
+# Test
+`;
+  const root = await fixture({ "index.md": incomplete, "de/index.md": incomplete });
+  const errors = await validateDocumentTree(root, versions);
+
+  for (const field of ["audience", "status", "reviewedVersion", "lastReviewed"]) {
+    assert(errors.includes(`index.md: missing ${field}`));
+  }
+});
+
+test("frontmatter parsing rejects duplicate keys and unterminated blocks", () => {
+  assert.throws(
+    () => parseFrontmatter("---\naudience: user\naudience: admin\n---\n"),
+    /duplicate frontmatter key audience/,
+  );
+  assert.throws(() => parseFrontmatter("---\naudience: user\n"), /unterminated frontmatter/);
+});
+
+test("frontmatter parsing ignores nested VitePress theme data", () => {
+  assert.deepEqual(
+    parseFrontmatter(`---
+layout: home
+audience: reference
+hero:
+  name: RailKeeper
+  actions:
+    - theme: brand
+---
+`),
+    {
+      layout: "home",
+      audience: "reference",
+      hero: "",
+    },
+  );
+});

--- a/docs/scripts/validate-docs.test.mjs
+++ b/docs/scripts/validate-docs.test.mjs
@@ -7,7 +7,7 @@ import { dirname, join } from "node:path";
 import { parseFrontmatter, validateCoverage, validateDocumentTree } from "./validate-docs.mjs";
 
 const versions = {
-  stable: "0.1.17.5",
+  stable: "0.1.17.6",
   development: "main",
 };
 
@@ -58,14 +58,14 @@ lastReviewed: ${values.lastReviewed}
 
 test("accepts a complete matching language pair", async () => {
   const root = await fixture({
-    "index.md": page("reference", "stable", "0.1.17.5"),
-    "de/index.md": page("reference", "stable", "0.1.17.5"),
+    "index.md": page("reference", "stable", "0.1.17.6"),
+    "de/index.md": page("reference", "stable", "0.1.17.6"),
   });
   assert.deepEqual(await validateDocumentTree(root, versions), []);
 });
 
 test("reports a missing German counterpart", async () => {
-  const root = await fixture({ "guide/index.md": page("user", "stable", "0.1.17.5") });
+  const root = await fixture({ "guide/index.md": page("user", "stable", "0.1.17.6") });
   assert.deepEqual(await validateDocumentTree(root, versions), [
     "guide/index.md: missing counterpart de/guide/index.md",
   ]);
@@ -73,7 +73,7 @@ test("reports a missing German counterpart", async () => {
 
 test("reports a missing English counterpart", async () => {
   const root = await fixture({
-    "de/administration/index.md": page("admin", "stable", "0.1.17.5"),
+    "de/administration/index.md": page("admin", "stable", "0.1.17.6"),
   });
   assert.deepEqual(await validateDocumentTree(root, versions), [
     "de/administration/index.md: missing counterpart administration/index.md",
@@ -82,7 +82,7 @@ test("reports a missing English counterpart", async () => {
 
 test("reports missing and mismatched metadata", async () => {
   const root = await fixture({
-    "index.md": page("reference", "stable", "0.1.17.5"),
+    "index.md": page("reference", "stable", "0.1.17.6"),
     "de/index.md": page("developer", "development", "main"),
   });
   const errors = await validateDocumentTree(root, versions);
@@ -97,7 +97,7 @@ test("enforces the canonical version for each status", async () => {
     "de/index.md": page("reference", "stable", "0.1.14"),
   });
   assert((await validateDocumentTree(root, versions)).some((error) =>
-    error.includes("reviewedVersion must be 0.1.17.5"),
+    error.includes("reviewedVersion must be 0.1.17.6"),
   ));
 });
 

--- a/docs/site/administration/index.md
+++ b/docs/site/administration/index.md
@@ -3,7 +3,7 @@ title: Installation and Administration
 description: Install, configure, secure, and operate RailKeeper.
 audience: admin
 status: stable
-reviewedVersion: 0.1.17.5
+reviewedVersion: 0.1.17.6
 lastReviewed: 2026-08-15
 ---
 
@@ -13,5 +13,5 @@ This section covers Windows Portable and Docker installation, runtime configurat
 roles, SMTP, backups and restores, updates, TLS, uploads, OCR, printers, operational checks, and
 conservative troubleshooting.
 
-Administration guidance describes the stable v0.1.17.5 runtime and preserves RailKeeper's
+Administration guidance describes the stable v0.1.17.6 runtime and preserves RailKeeper's
 local-first, self-hosted security model.

--- a/docs/site/administration/index.md
+++ b/docs/site/administration/index.md
@@ -1,0 +1,17 @@
+---
+title: Installation and Administration
+description: Install, configure, secure, and operate RailKeeper.
+audience: admin
+status: stable
+reviewedVersion: 0.1.17.5
+lastReviewed: 2026-08-15
+---
+
+# Installation and Administration
+
+This section covers Windows Portable and Docker installation, runtime configuration, users and
+roles, SMTP, backups and restores, updates, TLS, uploads, OCR, printers, operational checks, and
+conservative troubleshooting.
+
+Administration guidance describes the stable v0.1.17.5 runtime and preserves RailKeeper's
+local-first, self-hosted security model.

--- a/docs/site/de/administration/index.md
+++ b/docs/site/de/administration/index.md
@@ -3,7 +3,7 @@ title: Installation und Administration
 description: RailKeeper installieren, konfigurieren, absichern und betreiben.
 audience: admin
 status: stable
-reviewedVersion: 0.1.17.5
+reviewedVersion: 0.1.17.6
 lastReviewed: 2026-08-15
 ---
 
@@ -13,5 +13,5 @@ Dieser Bereich behandelt Windows Portable, Docker, Laufzeitkonfiguration, Benutz
 SMTP, Backup und Wiederherstellung, Updates, TLS, Uploads, OCR, Drucker, Betriebsprüfungen und
 konservative Fehlerbehebung.
 
-Die Administrationsanleitungen beschreiben die stabile Laufzeit v0.1.17.5 und erhalten das lokale,
+Die Administrationsanleitungen beschreiben die stabile Laufzeit v0.1.17.6 und erhalten das lokale,
 selbst gehostete Sicherheitsmodell von RailKeeper.

--- a/docs/site/de/administration/index.md
+++ b/docs/site/de/administration/index.md
@@ -10,8 +10,8 @@ lastReviewed: 2026-08-15
 # Installation und Administration
 
 Dieser Bereich behandelt Windows Portable, Docker, Laufzeitkonfiguration, Benutzer und Rollen,
-SMTP, Backup und Wiederherstellung, Updates, TLS, Uploads, OCR, Drucker, Betriebsprüfungen und
-konservative Fehlerbehebung.
+SMTP, Sicherung und Wiederherstellung, Updates, TLS, Uploads, OCR, Drucker,
+Betriebsprüfungen und konservative Fehlerbehebung.
 
 Die Administrationsanleitungen beschreiben die stabile Laufzeit v0.1.17.6 und erhalten das lokale,
 selbst gehostete Sicherheitsmodell von RailKeeper.

--- a/docs/site/de/administration/index.md
+++ b/docs/site/de/administration/index.md
@@ -1,0 +1,17 @@
+---
+title: Installation und Administration
+description: RailKeeper installieren, konfigurieren, absichern und betreiben.
+audience: admin
+status: stable
+reviewedVersion: 0.1.17.5
+lastReviewed: 2026-08-15
+---
+
+# Installation und Administration
+
+Dieser Bereich behandelt Windows Portable, Docker, Laufzeitkonfiguration, Benutzer und Rollen,
+SMTP, Backup und Wiederherstellung, Updates, TLS, Uploads, OCR, Drucker, Betriebsprüfungen und
+konservative Fehlerbehebung.
+
+Die Administrationsanleitungen beschreiben die stabile Laufzeit v0.1.17.5 und erhalten das lokale,
+selbst gehostete Sicherheitsmodell von RailKeeper.

--- a/docs/site/de/development/index.md
+++ b/docs/site/de/development/index.md
@@ -1,0 +1,17 @@
+---
+title: Entwicklung und Architektur
+description: RailKeeper verstehen und weiterentwickeln.
+audience: developer
+status: development
+reviewedVersion: main
+lastReviewed: 2026-08-15
+---
+
+# Entwicklung und Architektur
+
+Dieser Bereich dokumentiert den aktuellen Stand von `main`: lokale Einrichtung, Grenzen des
+modularen Monolithen, Backend- und Frontend-Verantwortung, OpenAPI, SQLite-Migrationen,
+Dateispeicher, Authentifizierung, Backupformate, Tests, Builds, Releases und Beitragsregeln.
+
+Stabiles Benutzerverhalten bleibt getrennt dokumentiert, damit unveröffentlichte Entwicklung nie
+als allgemein verfügbare Funktion erscheint.

--- a/docs/site/de/guide/index.md
+++ b/docs/site/de/guide/index.md
@@ -1,0 +1,17 @@
+---
+title: Benutzerhandbuch
+description: Alle stabilen Arbeitsabläufe in RailKeeper kennenlernen.
+audience: user
+status: stable
+reviewedVersion: 0.1.17.5
+lastReviewed: 2026-08-15
+---
+
+# Benutzerhandbuch
+
+Dieses Handbuch erklärt den vollständigen veröffentlichten RailKeeper-Arbeitsablauf für Sammler,
+Vereine und kleine Werkstätten. Es umfasst Ersteinrichtung, Navigation, Fahrzeuge, Zubehör,
+Decoderdaten, Wartung, Dokumente, Berichte, Ausstellungen sowie kontrollierten Import und Export.
+
+Die Inhalte dieses Bereichs beschreiben RailKeeper v0.1.17.5. Der Anlagen-Arbeitsbereich befindet
+sich noch in Entwicklung und wird deshalb nicht als stabile Benutzerfunktion dargestellt.

--- a/docs/site/de/guide/index.md
+++ b/docs/site/de/guide/index.md
@@ -3,7 +3,7 @@ title: Benutzerhandbuch
 description: Alle stabilen Arbeitsabläufe in RailKeeper kennenlernen.
 audience: user
 status: stable
-reviewedVersion: 0.1.17.5
+reviewedVersion: 0.1.17.6
 lastReviewed: 2026-08-15
 ---
 
@@ -13,5 +13,5 @@ Dieses Handbuch erklärt den vollständigen veröffentlichten RailKeeper-Arbeits
 Vereine und kleine Werkstätten. Es umfasst Ersteinrichtung, Navigation, Fahrzeuge, Zubehör,
 Decoderdaten, Wartung, Dokumente, Berichte, Ausstellungen sowie kontrollierten Import und Export.
 
-Die Inhalte dieses Bereichs beschreiben RailKeeper v0.1.17.5. Der Anlagen-Arbeitsbereich befindet
+Die Inhalte dieses Bereichs beschreiben RailKeeper v0.1.17.6. Der Anlagen-Arbeitsbereich befindet
 sich noch in Entwicklung und wird deshalb nicht als stabile Benutzerfunktion dargestellt.

--- a/docs/site/de/index.md
+++ b/docs/site/de/index.md
@@ -4,12 +4,12 @@ title: RailKeeper-Dokumentation
 description: Vollständige Benutzer-, Administrations- und Entwicklungsdokumentation für RailKeeper.
 audience: reference
 status: stable
-reviewedVersion: 0.1.17.5
+reviewedVersion: 0.1.17.6
 lastReviewed: 2026-08-15
 hero:
   name: RailKeeper-Dokumentation
   text: Werkstattwissen direkt beim Projekt
-  tagline: Das Handbuch folgt v0.1.17.5, die Entwicklungsdokumentation dem Stand von main.
+  tagline: Das Handbuch folgt v0.1.17.6, die Entwicklungsdokumentation dem Stand von main.
   image:
     src: /brand/railkeeper-mark.svg
     alt: RailKeeper

--- a/docs/site/de/index.md
+++ b/docs/site/de/index.md
@@ -1,0 +1,33 @@
+---
+layout: home
+title: RailKeeper-Dokumentation
+description: Vollständige Benutzer-, Administrations- und Entwicklungsdokumentation für RailKeeper.
+audience: reference
+status: stable
+reviewedVersion: 0.1.17.5
+lastReviewed: 2026-08-15
+hero:
+  name: RailKeeper-Dokumentation
+  text: Werkstattwissen direkt beim Projekt
+  tagline: Das Handbuch folgt v0.1.17.5, die Entwicklungsdokumentation dem Stand von main.
+  image:
+    src: /brand/railkeeper-mark.svg
+    alt: RailKeeper
+  actions:
+    - theme: brand
+      text: Benutzerhandbuch öffnen
+      link: /de/guide/
+    - theme: alt
+      text: Installieren und betreiben
+      link: /de/administration/
+features:
+  - title: Benutzerhandbuch
+    details: Alle veröffentlichten Abläufe für Fahrzeuge, Zubehör, Wartung und Ausstellungen.
+    link: /de/guide/
+  - title: Installation und Administration
+    details: RailKeeper installieren, absichern, aktualisieren, sichern und wiederherstellen.
+    link: /de/administration/
+  - title: Entwicklung und Architektur
+    details: Modularen Monolithen, Verträge, Speicher, Tests und Beitragsprozess verstehen.
+    link: /de/development/
+---

--- a/docs/site/de/reference/coverage.md
+++ b/docs/site/de/reference/coverage.md
@@ -1,0 +1,85 @@
+---
+title: Dokumentationsabdeckung
+description: Zuordnung der RailKeeper-Quellflächen zum zweisprachigen Handbuch.
+audience: reference
+status: development
+reviewedVersion: main
+lastReviewed: 2026-08-15
+---
+
+# Dokumentationsabdeckung
+
+RailKeeper behandelt die Dokumentationsabdeckung als geprüften Vertrag. Eine schreibgeschützte
+Inventur erfasst sichtbare Frontend-Routen, englische und deutsche Übersetzungsschlüssel,
+registrierte Go-API-Routen, OpenAPI-Operationen, versionierte Konfigurationsvariablen und bestehende
+Projektdokumente. Der Coverage-Validator verlangt anschließend für jede Frontend-Route, jeden
+Übersetzungsschlüssel, jede API-Route und jede Umgebungsvariable genau ein verantwortliches Thema.
+
+Die geprüften Zuordnungen stehen in
+[`docs/coverage.json`](https://github.com/ichwars/RailKeeper/blob/main/docs/coverage.json). Die
+Inventur entsteht nur während der Prüfung und wird nicht als zweite Wahrheitsquelle eingecheckt.
+
+## Abdeckungsstatus
+
+- `planned`: Ziel und Verantwortung stehen fest, das vollständige Seitenpaar folgt in einer
+  späteren Dokumentationsetappe.
+- `documented`: Die englische und die deutsche Zielseite existieren und erfüllen den Seitenstandard.
+- `internal`: Das Thema bleibt absichtlich auf Informationen für Maintainer beschränkt.
+- `not-published`: Die Quellfläche existiert, darf aber nicht als stabile öffentliche Funktion
+  dargestellt werden.
+
+Ein Thema erhält erst dann den Status `documented`, wenn beide Zielseiten unter identischen relativen
+Pfaden liegen, übereinstimmende Prüfmetadaten tragen und die Dokumentationsprüfung bestehen. Die
+Anlagenplanung bleibt `not-published`, weil sie nicht zum stabilen, öffentlich dokumentierten
+Produktumfang gehört.
+
+## Geprüfte Themen
+
+Die erste Matrix umfasst 21 Themen.
+
+### Benutzerabläufe
+
+- `setup-auth`
+- `overview`
+- `vehicles-core`
+- `vehicle-media`
+- `vehicle-maintenance`
+- `vehicle-decoder-cv`
+- `vehicle-search-spares`
+- `accessories`
+- `exhibition`
+- `import-export`
+- `settings-general`
+
+### Administration
+
+- `master-data`
+- `users-sessions-security`
+- `backup-restore`
+- `digital-centers`
+- `system-operations`
+- `deployment-configuration`
+
+### Entwicklung
+
+- `layouts-unpublished`
+- `development-architecture`
+
+### Gemeinsame Referenz
+
+- `releases-support`
+- `shared-navigation`
+
+## Ablauf für Beiträge
+
+Wenn sich eine Route, ein API-Bereich, ein Übersetzungsnamensraum, eine Umgebungsvariable oder ein
+Handbuchthema ändert, muss `docs/coverage.json` im selben Pull Request angepasst werden. Die
+vollständige Prüfung startet im Repository mit:
+
+```powershell
+cd docs
+npm.cmd run check
+```
+
+Der Befehl prüft beide Sprachen, die Prüfmetadaten, die Coverage-Zuordnung und den produktiven
+Website-Build.

--- a/docs/site/de/reference/index.md
+++ b/docs/site/de/reference/index.md
@@ -1,0 +1,15 @@
+---
+title: Referenz
+description: Dokumentationsabdeckung und gemeinsame RailKeeper-Referenzen.
+audience: reference
+status: development
+reviewedVersion: main
+lastReviewed: 2026-08-15
+---
+
+# Referenz
+
+Dieser Bereich stellt die gemeinsame Dokumentationsabdeckung dar und wird Glossar,
+Fehlerbehebungsindex und Release-Referenzen enthalten. Er verbindet stabile Benutzer- und
+Betreiberanleitungen mit der aktuellen Entwicklungsdokumentation, ohne deren maßgebliche
+Erklärungen zu duplizieren.

--- a/docs/site/development/index.md
+++ b/docs/site/development/index.md
@@ -1,0 +1,17 @@
+---
+title: Development and Architecture
+description: Understand and contribute to RailKeeper.
+audience: developer
+status: development
+reviewedVersion: main
+lastReviewed: 2026-08-15
+---
+
+# Development and Architecture
+
+This section documents the current `main` branch: local setup, modular-monolith boundaries,
+backend and frontend responsibilities, OpenAPI, SQLite migrations, file storage, authentication,
+backup formats, tests, builds, releases, and contribution rules.
+
+Stable user behavior remains documented separately so that unreleased development work is never
+presented as generally available.

--- a/docs/site/guide/index.md
+++ b/docs/site/guide/index.md
@@ -1,0 +1,17 @@
+---
+title: User Guide
+description: Learn every stable RailKeeper workflow.
+audience: user
+status: stable
+reviewedVersion: 0.1.17.5
+lastReviewed: 2026-08-15
+---
+
+# User Guide
+
+This guide explains the complete published RailKeeper workflow for collectors, clubs, and small
+workshops. It covers first setup, navigation, vehicles, accessories, decoder data, maintenance,
+documents, reports, exhibitions, and controlled import and export.
+
+Content in this section describes stable RailKeeper v0.1.17.5. The layout workspace is still under
+development and is therefore not presented as a stable user feature.

--- a/docs/site/guide/index.md
+++ b/docs/site/guide/index.md
@@ -3,7 +3,7 @@ title: User Guide
 description: Learn every stable RailKeeper workflow.
 audience: user
 status: stable
-reviewedVersion: 0.1.17.5
+reviewedVersion: 0.1.17.6
 lastReviewed: 2026-08-15
 ---
 
@@ -13,5 +13,5 @@ This guide explains the complete published RailKeeper workflow for collectors, c
 workshops. It covers first setup, navigation, vehicles, accessories, decoder data, maintenance,
 documents, reports, exhibitions, and controlled import and export.
 
-Content in this section describes stable RailKeeper v0.1.17.5. The layout workspace is still under
+Content in this section describes stable RailKeeper v0.1.17.6. The layout workspace is still under
 development and is therefore not presented as a stable user feature.

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -4,12 +4,12 @@ title: RailKeeper Documentation
 description: Complete user, administration, and development documentation for RailKeeper.
 audience: reference
 status: stable
-reviewedVersion: 0.1.17.5
+reviewedVersion: 0.1.17.6
 lastReviewed: 2026-08-15
 hero:
   name: RailKeeper Documentation
   text: Workshop knowledge, kept with the project
-  tagline: User guidance follows stable v0.1.17.5. Development documentation follows main.
+  tagline: User guidance follows stable v0.1.17.6. Development documentation follows main.
   image:
     src: /brand/railkeeper-mark.svg
     alt: RailKeeper

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -1,0 +1,33 @@
+---
+layout: home
+title: RailKeeper Documentation
+description: Complete user, administration, and development documentation for RailKeeper.
+audience: reference
+status: stable
+reviewedVersion: 0.1.17.5
+lastReviewed: 2026-08-15
+hero:
+  name: RailKeeper Documentation
+  text: Workshop knowledge, kept with the project
+  tagline: User guidance follows stable v0.1.17.5. Development documentation follows main.
+  image:
+    src: /brand/railkeeper-mark.svg
+    alt: RailKeeper
+  actions:
+    - theme: brand
+      text: Open the User Guide
+      link: /guide/
+    - theme: alt
+      text: Install and operate
+      link: /administration/
+features:
+  - title: User Guide
+    details: Learn every published workflow for vehicles, accessories, maintenance, and exhibitions.
+    link: /guide/
+  - title: Installation and Administration
+    details: Install, secure, update, back up, restore, and troubleshoot a RailKeeper instance.
+    link: /administration/
+  - title: Development and Architecture
+    details: Understand the modular monolith, contracts, storage, tests, and contribution workflow.
+    link: /development/
+---

--- a/docs/site/reference/coverage.md
+++ b/docs/site/reference/coverage.md
@@ -1,0 +1,82 @@
+---
+title: Documentation Coverage
+description: See how RailKeeper source surfaces map to the bilingual handbook.
+audience: reference
+status: development
+reviewedVersion: main
+lastReviewed: 2026-08-15
+---
+
+# Documentation coverage
+
+RailKeeper treats documentation coverage as a reviewed contract. A read-only inventory scans
+visible frontend routes, English and German translation keys, registered Go API routes, OpenAPI
+operations, tracked configuration variables, and existing project documents. The coverage
+validator then requires every frontend route, translation key, API route, and environment variable
+to have one owning topic.
+
+The reviewed assignments live in
+[`docs/coverage.json`](https://github.com/ichwars/RailKeeper/blob/main/docs/coverage.json). The
+inventory is generated during validation and is not committed as a second source of truth.
+
+## Coverage states
+
+- `planned`: The destination and owner are agreed, but the complete page pair belongs to a later
+  documentation stage.
+- `documented`: Both English and German destination pages exist and pass the page standard.
+- `internal`: The topic is intentionally limited to maintainer-facing material.
+- `not-published`: The source exists, but it must not be presented as a stable public feature.
+
+A topic can move to `documented` only after both destination pages use identical relative paths,
+carry matching review metadata, and pass the documentation check. Layout planning remains
+`not-published` because it is not part of the stable user-facing product scope.
+
+## Reviewed topics
+
+The initial matrix contains 21 topics.
+
+### User workflows
+
+- `setup-auth`
+- `overview`
+- `vehicles-core`
+- `vehicle-media`
+- `vehicle-maintenance`
+- `vehicle-decoder-cv`
+- `vehicle-search-spares`
+- `accessories`
+- `exhibition`
+- `import-export`
+- `settings-general`
+
+### Administration
+
+- `master-data`
+- `users-sessions-security`
+- `backup-restore`
+- `digital-centers`
+- `system-operations`
+- `deployment-configuration`
+
+### Development
+
+- `layouts-unpublished`
+- `development-architecture`
+
+### Shared reference
+
+- `releases-support`
+- `shared-navigation`
+
+## Contributor workflow
+
+When a route, API area, translation namespace, environment variable, or handbook topic changes,
+update `docs/coverage.json` in the same pull request. Run the complete check from the repository:
+
+```powershell
+cd docs
+npm.cmd run check
+```
+
+The command verifies both languages, review metadata, coverage ownership, and the production site
+build.

--- a/docs/site/reference/index.md
+++ b/docs/site/reference/index.md
@@ -1,0 +1,14 @@
+---
+title: Reference
+description: Documentation coverage and shared RailKeeper references.
+audience: reference
+status: development
+reviewedVersion: main
+lastReviewed: 2026-08-15
+---
+
+# Reference
+
+This section provides the shared documentation coverage view and will contain the glossary,
+troubleshooting index, and release references. It connects stable user and operator guidance with
+the current development documentation without duplicating their canonical explanations.

--- a/docs/superpowers/plans/2026-08-15-railkeeper-documentation-foundation.md
+++ b/docs/superpowers/plans/2026-08-15-railkeeper-documentation-foundation.md
@@ -5,11 +5,14 @@
 **Goal:** Build the bilingual VitePress foundation, automated documentation checks, coverage
 inventory, and GitHub Pages deployment for the RailKeeper handbook.
 
-**Architecture:** VitePress 1.6.4 runs as an isolated Node 24 workspace under `docs/`, with authored
-content in `docs/site/`. English uses the site root and German uses `/de/`. Small dependency-free
-Node scripts enforce paired pages and map repository surfaces into a reviewed coverage manifest.
+**Architecture:** VitePress 2.0.0-alpha.19 runs as an isolated Node 24 workspace under `docs/`, with
+the prerelease version pinned exactly after explicit approval. The stable VitePress 1.6.4 line was
+rejected because its Vite 5 dependency has an unresolved high-severity Windows path vulnerability.
+Authored content lives in `docs/site/`. English uses the site root and German uses `/de/`. Small
+dependency-free Node scripts enforce paired pages and map repository surfaces into a reviewed
+coverage manifest.
 
-**Tech Stack:** Node.js 24, npm, VitePress 1.6.4, Markdown, CSS, Node's built-in test runner,
+**Tech Stack:** Node.js 24, npm, VitePress 2.0.0-alpha.19, Markdown, CSS, Node's built-in test runner,
 GitHub Actions, GitHub Pages.
 
 ## Global Constraints
@@ -115,7 +118,7 @@ Create `docs/package.json`:
     "check": "npm test && node scripts/validate-docs.mjs && vitepress build"
   },
   "devDependencies": {
-    "vitepress": "1.6.4"
+    "vitepress": "2.0.0-alpha.19"
   }
 }
 ```
@@ -129,8 +132,8 @@ cd docs
 npm.cmd install
 ```
 
-Expected: `docs/package-lock.json` is created, `npm audit` reports no unresolved high or critical
-finding, and no root-level `package.json` is introduced.
+Expected: `docs/package-lock.json` is created, `npm audit` reports no high or critical finding, and
+no root-level `package.json` is introduced.
 
 - [ ] **Step 4: Create the VitePress configuration**
 

--- a/docs/superpowers/plans/2026-08-15-railkeeper-documentation-foundation.md
+++ b/docs/superpowers/plans/2026-08-15-railkeeper-documentation-foundation.md
@@ -18,7 +18,7 @@ GitHub Actions, GitHub Pages.
 ## Global Constraints
 
 - English is the public default; German is complete and equal, with identical paths below `/de/`.
-- User and administration pages describe stable RailKeeper v0.1.17.5.
+- User and administration pages describe stable RailKeeper v0.1.17.6.
 - Development and architecture pages describe `main`.
 - Every published page has `audience`, `status`, `reviewedVersion`, and `lastReviewed` metadata.
 - Search remains local in the browser. Do not add analytics, cookies, or an external search service.
@@ -305,7 +305,7 @@ Create `docs/.vitepress/theme/custom.css`:
 - [ ] **Step 6: Create paired landing pages with real scope statements**
 
 Create the page pairs below. Every file starts with the listed metadata. Use `status: stable` and
-`reviewedVersion: 0.1.17.5` for home, guide, and administration. Use `status: development` and
+`reviewedVersion: 0.1.17.6` for home, guide, and administration. Use `status: development` and
 `reviewedVersion: main` for development and reference. All use `lastReviewed: 2026-08-15`.
 
 - `site/index.md` and `site/de/index.md`, audience `reference`: use the headings
@@ -330,7 +330,7 @@ title: User Guide
 description: Learn every stable RailKeeper workflow.
 audience: user
 status: stable
-reviewedVersion: 0.1.17.5
+reviewedVersion: 0.1.17.6
 lastReviewed: 2026-08-15
 ---
 ```
@@ -379,7 +379,7 @@ Create `docs/versions.json`:
 
 ```json
 {
-  "stable": "0.1.17.5",
+  "stable": "0.1.17.6",
   "development": "main"
 }
 ```
@@ -392,14 +392,14 @@ Create `docs/scripts/validate-docs.test.mjs`. Use `node:test`, `node:assert/stri
 ```js
 test("accepts a complete matching language pair", async () => {
   const root = await fixture({
-    "index.md": page("reference", "stable", "0.1.17.5"),
-    "de/index.md": page("reference", "stable", "0.1.17.5"),
+    "index.md": page("reference", "stable", "0.1.17.6"),
+    "de/index.md": page("reference", "stable", "0.1.17.6"),
   });
   assert.deepEqual(await validateDocumentTree(root, versions), []);
 });
 
 test("reports a missing German counterpart", async () => {
-  const root = await fixture({ "guide/index.md": page("user", "stable", "0.1.17.5") });
+  const root = await fixture({ "guide/index.md": page("user", "stable", "0.1.17.6") });
   assert.deepEqual(await validateDocumentTree(root, versions), [
     "guide/index.md: missing counterpart de/guide/index.md",
   ]);
@@ -407,7 +407,7 @@ test("reports a missing German counterpart", async () => {
 
 test("reports missing and mismatched metadata", async () => {
   const root = await fixture({
-    "index.md": page("reference", "stable", "0.1.17.5"),
+    "index.md": page("reference", "stable", "0.1.17.6"),
     "de/index.md": page("developer", "development", "main"),
   });
   const errors = await validateDocumentTree(root, versions);
@@ -422,7 +422,7 @@ test("enforces the canonical version for each status", async () => {
     "de/index.md": page("reference", "stable", "0.1.14"),
   });
   assert((await validateDocumentTree(root, versions)).some((error) =>
-    error.includes("reviewedVersion must be 0.1.17.5"),
+    error.includes("reviewedVersion must be 0.1.17.6"),
   ));
 });
 ```
@@ -1032,26 +1032,29 @@ entry points.
 
 **Interfaces:**
 
-- Consumes: tag `v0.1.17.5`, `.github/workflows/windows-portable.yml`, public GitHub Releases, and
+- Consumes: tag `v0.1.17.6`, `.github/workflows/windows-portable.yml`, public GitHub Releases, and
   the deployed Pages site.
-- Produces: verified public latest release `v0.1.17.5` and an accepted Etappe 1 deployment.
+- Produces: verified public latest release `v0.1.17.6` and an accepted Etappe 1 deployment.
+
+Execution update: RailKeeper v0.1.17.6 was published while this foundation was being implemented.
+It supersedes the earlier v0.1.17.5 baseline and is therefore the canonical stable version below.
 
 - [ ] **Step 1: Verify the local and remote tag before changing GitHub state**
 
 Run:
 
 ```powershell
-git show -s --format="%H %D %cs %s" v0.1.17.5
-git ls-remote --tags origin refs/tags/v0.1.17.5
-gh release view v0.1.17.5 --repo ichwars/RailKeeper --json tagName,isDraft,isPrerelease,assets,url
+git show -s --format="%H %D %cs %s" v0.1.17.6
+git ls-remote --tags origin refs/tags/v0.1.17.6
+gh release view v0.1.17.6 --repo ichwars/RailKeeper --json tagName,isDraft,isPrerelease,assets,url
 ```
 
-Expected: the local tag resolves to commit `9e81856313c759f733d97405bb9fa606d47e74b5`; the remote tag
+Expected: the local tag resolves to commit `4be00148dc1a99b8249d4fd831ecd749afc1bc9c`; the remote tag
 exists; the release is non-draft and non-prerelease with the portable ZIP asset. If the remote tag
 is absent, confirm the local tag still points to that exact reviewed commit, then run:
 
 ```powershell
-git push origin refs/tags/v0.1.17.5
+git push origin refs/tags/v0.1.17.6
 ```
 
 Stop instead of pushing if the commit differs.
@@ -1061,23 +1064,23 @@ Stop instead of pushing if the commit differs.
 If the release or portable ZIP is missing, run:
 
 ```powershell
-gh workflow run windows-portable.yml --repo ichwars/RailKeeper --ref v0.1.17.5
+gh workflow run windows-portable.yml --repo ichwars/RailKeeper --ref v0.1.17.6
 $releaseRunId = gh run list --repo ichwars/RailKeeper `
   --workflow windows-portable.yml --limit 1 --json databaseId --jq '.[0].databaseId'
 gh run watch --repo ichwars/RailKeeper $releaseRunId --exit-status
 ```
 
-Expected: the workflow succeeds and publishes the ZIP to a non-prerelease v0.1.17.5 release. Do
+Expected: the workflow succeeds and publishes the ZIP to a non-prerelease v0.1.17.6 release. Do
 not upload an unverified local ZIP manually.
 
 - [ ] **Step 3: Mark the verified release as latest and confirm the public API**
 
 ```powershell
-gh release edit v0.1.17.5 --repo ichwars/RailKeeper --latest
+gh release edit v0.1.17.6 --repo ichwars/RailKeeper --latest
 gh api repos/ichwars/RailKeeper/releases/latest --jq .tag_name
 ```
 
-Expected: `v0.1.17.5`.
+Expected: `v0.1.17.6`.
 
 - [ ] **Step 4: Enable GitHub Pages from Actions if not already enabled**
 
@@ -1130,7 +1133,7 @@ Update the implementation pull request description with:
 - GitHub Pages deployment: passed
 - English/German path parity: passed
 - Light/dark and 390/768/1440 px visual checks: passed
-- Latest stable GitHub Release: v0.1.17.5
+- Latest stable GitHub Release: v0.1.17.6
 - Remaining content work: Etappen 2 through 5 from the approved design specification
 ```
 

--- a/docs/superpowers/plans/2026-08-15-railkeeper-documentation-foundation.md
+++ b/docs/superpowers/plans/2026-08-15-railkeeper-documentation-foundation.md
@@ -1,0 +1,1134 @@
+# RailKeeper Documentation Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the bilingual VitePress foundation, automated documentation checks, coverage
+inventory, and GitHub Pages deployment for the RailKeeper handbook.
+
+**Architecture:** VitePress 1.6.4 runs as an isolated Node 24 workspace under `docs/`, with authored
+content in `docs/site/`. English uses the site root and German uses `/de/`. Small dependency-free
+Node scripts enforce paired pages and map repository surfaces into a reviewed coverage manifest.
+
+**Tech Stack:** Node.js 24, npm, VitePress 1.6.4, Markdown, CSS, Node's built-in test runner,
+GitHub Actions, GitHub Pages.
+
+## Global Constraints
+
+- English is the public default; German is complete and equal, with identical paths below `/de/`.
+- User and administration pages describe stable RailKeeper v0.1.17.5.
+- Development and architecture pages describe `main`.
+- Every published page has `audience`, `status`, `reviewedVersion`, and `lastReviewed` metadata.
+- Search remains local in the browser. Do not add analytics, cookies, or an external search service.
+- Reuse the existing RailKeeper SVG brand assets and the existing color tokens.
+- Do not publish generated output, caches, local credentials, private data, or `.superpowers/`.
+- Preserve the current `docs/*.md`, `docs/releases/`, and `docs/screenshots/` files until their
+  content is deliberately migrated in later stages.
+- Do not document the hidden layout workspace as a stable user feature.
+- This plan implements Etappe 1 only. Benutzerhandbuch, Administration, Entwicklung, and final
+  content audit receive separate plans after this foundation is accepted.
+
+---
+
+## File Map
+
+| Path | Responsibility |
+| --- | --- |
+| `docs/package.json` | Isolated documentation commands and pinned VitePress dependency |
+| `docs/package-lock.json` | Reproducible dependency graph |
+| `docs/.vitepress/config.mts` | Routing, locales, navigation, local search, shared brand assets |
+| `docs/.vitepress/theme/index.ts` | Default-theme extension |
+| `docs/.vitepress/theme/custom.css` | Restrained RailKeeper visual tokens |
+| `docs/site/` | Published English pages and mirrored `de/` tree |
+| `docs/versions.json` | Canonical stable and development documentation versions |
+| `docs/coverage.json` | Reviewed mapping from repository surfaces to documentation topics |
+| `docs/scripts/validate-docs.mjs` | Pairing, metadata, and coverage validation CLI |
+| `docs/scripts/validate-docs.test.mjs` | Validator regression tests |
+| `docs/scripts/source-inventory.mjs` | Read-only source discovery for routes, API, i18n, config, and docs |
+| `docs/scripts/source-inventory.test.mjs` | Inventory parser regression tests |
+| `.github/workflows/ci.yml` | Pull-request documentation quality gate |
+| `.github/workflows/docs-pages.yml` | GitHub Pages build and deployment |
+
+## Reference Documents
+
+- Design: `docs/superpowers/specs/2026-08-15-railkeeper-bilingual-documentation-design.md`
+- Existing overview: `README.md` and `README.de.md`
+- Existing operations: `docs/production-runbook.md`
+- Existing architecture: `docs/architecture.md`
+- Existing security model: `docs/security.md`
+- VitePress i18n: <https://vitepress.dev/guide/i18n>
+- VitePress local search: <https://vitepress.dev/reference/default-theme-search>
+- VitePress GitHub Pages deployment: <https://vitepress.dev/guide/deploy>
+
+### Task 1: Scaffold the isolated bilingual VitePress site
+
+**Files:**
+
+- Modify: `.gitignore`
+- Create: `docs/package.json`
+- Create: `docs/package-lock.json`
+- Create: `docs/.vitepress/config.mts`
+- Create: `docs/.vitepress/theme/index.ts`
+- Create: `docs/.vitepress/theme/custom.css`
+- Create: `docs/site/index.md`
+- Create: `docs/site/de/index.md`
+- Create: `docs/site/guide/index.md`
+- Create: `docs/site/de/guide/index.md`
+- Create: `docs/site/administration/index.md`
+- Create: `docs/site/de/administration/index.md`
+- Create: `docs/site/development/index.md`
+- Create: `docs/site/de/development/index.md`
+- Create: `docs/site/reference/index.md`
+- Create: `docs/site/de/reference/index.md`
+
+**Interfaces:**
+
+- Consumes: `frontend/public/brand/railkeeper-mark.svg` and repository Git history.
+- Produces: `npm run dev`, `npm run build`, and `npm run preview` in `docs/`; stable paths `/`,
+  `/guide/`, `/administration/`, `/development/`, `/reference/`, and their `/de/` counterparts.
+
+- [ ] **Step 1: Ignore only documentation dependencies and generated build state**
+
+Append this block to `.gitignore`:
+
+```gitignore
+# Documentation site
+docs/node_modules/
+docs/.vitepress/cache/
+docs/.vitepress/dist/
+.superpowers/
+```
+
+- [ ] **Step 2: Create the isolated package manifest**
+
+Create `docs/package.json`:
+
+```json
+{
+  "name": "railkeeper-documentation",
+  "private": true,
+  "license": "AGPL-3.0-only",
+  "scripts": {
+    "dev": "vitepress dev",
+    "build": "vitepress build",
+    "preview": "vitepress preview",
+    "test": "node --test scripts/*.test.mjs",
+    "check": "npm test && node scripts/validate-docs.mjs && vitepress build"
+  },
+  "devDependencies": {
+    "vitepress": "1.6.4"
+  }
+}
+```
+
+- [ ] **Step 3: Generate the lockfile without sharing frontend dependencies**
+
+Run:
+
+```powershell
+cd docs
+npm.cmd install
+```
+
+Expected: `docs/package-lock.json` is created, `npm audit` reports no unresolved high or critical
+finding, and no root-level `package.json` is introduced.
+
+- [ ] **Step 4: Create the VitePress configuration**
+
+Create `docs/.vitepress/config.mts` with these exact behaviors:
+
+```ts
+import { fileURLToPath, URL } from "node:url";
+import { defineConfig } from "vitepress";
+
+const repositoryUrl = "https://github.com/ichwars/RailKeeper";
+
+export default defineConfig({
+  title: "RailKeeper",
+  description: "Documentation for the local-first model railway inventory and operations tool.",
+  base: "/RailKeeper/",
+  srcDir: "site",
+  cleanUrls: true,
+  lastUpdated: true,
+  vite: {
+    publicDir: fileURLToPath(new URL("../../frontend/public", import.meta.url)),
+  },
+  locales: {
+    root: { label: "English", lang: "en" },
+    de: {
+      label: "Deutsch",
+      lang: "de",
+      link: "/de/",
+      description: "Dokumentation für RailKeeper.",
+    },
+  },
+  themeConfig: {
+    logo: "/brand/railkeeper-mark.svg",
+    siteTitle: "RailKeeper Docs",
+    socialLinks: [{ icon: "github", link: repositoryUrl }],
+    editLink: {
+      pattern: `${repositoryUrl}/edit/main/docs/site/:path`,
+      text: "Edit this page on GitHub",
+    },
+    search: {
+      provider: "local",
+      options: {
+        locales: {
+          de: {
+            translations: {
+              button: { buttonText: "Suchen", buttonAriaLabel: "Dokumentation durchsuchen" },
+              modal: {
+                displayDetails: "Detaillierte Liste anzeigen",
+                resetButtonTitle: "Suche zurücksetzen",
+                backButtonTitle: "Suche schließen",
+                noResultsText: "Keine Ergebnisse gefunden für",
+                footer: {
+                  selectText: "Auswählen",
+                  selectKeyAriaLabel: "Eingabetaste",
+                  navigateText: "Navigieren",
+                  navigateUpKeyAriaLabel: "Pfeil nach oben",
+                  navigateDownKeyAriaLabel: "Pfeil nach unten",
+                  closeText: "Schließen",
+                  closeKeyAriaLabel: "Escape-Taste",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    locales: {
+      root: {
+        nav: [
+          { text: "User Guide", link: "/guide/" },
+          { text: "Administration", link: "/administration/" },
+          { text: "Development", link: "/development/" },
+          { text: "Reference", link: "/reference/" },
+        ],
+        sidebar: {
+          "/guide/": [{ text: "User Guide", items: [{ text: "Overview", link: "/guide/" }] }],
+          "/administration/": [
+            { text: "Administration", items: [{ text: "Overview", link: "/administration/" }] },
+          ],
+          "/development/": [
+            { text: "Development", items: [{ text: "Overview", link: "/development/" }] },
+          ],
+          "/reference/": [{ text: "Reference", items: [{ text: "Overview", link: "/reference/" }] }],
+        },
+        outlineTitle: "On this page",
+        lastUpdated: { text: "Last reviewed" },
+      },
+      de: {
+        nav: [
+          { text: "Benutzerhandbuch", link: "/de/guide/" },
+          { text: "Administration", link: "/de/administration/" },
+          { text: "Entwicklung", link: "/de/development/" },
+          { text: "Referenz", link: "/de/reference/" },
+        ],
+        sidebar: {
+          "/de/guide/": [
+            { text: "Benutzerhandbuch", items: [{ text: "Überblick", link: "/de/guide/" }] },
+          ],
+          "/de/administration/": [
+            { text: "Administration", items: [{ text: "Überblick", link: "/de/administration/" }] },
+          ],
+          "/de/development/": [
+            { text: "Entwicklung", items: [{ text: "Überblick", link: "/de/development/" }] },
+          ],
+          "/de/reference/": [
+            { text: "Referenz", items: [{ text: "Überblick", link: "/de/reference/" }] },
+          ],
+        },
+        editLink: {
+          pattern: `${repositoryUrl}/edit/main/docs/site/:path`,
+          text: "Diese Seite auf GitHub bearbeiten",
+        },
+        outlineTitle: "Auf dieser Seite",
+        lastUpdated: { text: "Zuletzt geprüft" },
+      },
+    },
+  },
+});
+```
+
+- [ ] **Step 5: Extend the default theme with RailKeeper tokens**
+
+Create `docs/.vitepress/theme/index.ts`:
+
+```ts
+import DefaultTheme from "vitepress/theme";
+import "./custom.css";
+
+export default DefaultTheme;
+```
+
+Create `docs/.vitepress/theme/custom.css`:
+
+```css
+:root {
+  --vp-c-brand-1: #419310;
+  --vp-c-brand-2: #1c621b;
+  --vp-c-brand-3: #154d15;
+  --vp-c-brand-soft: #e9f8df;
+  --vp-c-bg: #edf2f1;
+  --vp-c-bg-soft: #f5f8f6;
+  --vp-c-divider: #d5dfdc;
+  --vp-c-text-1: #0b1e26;
+  --vp-c-text-2: #4f6869;
+  --vp-font-family-base: "Segoe UI", Arial, sans-serif;
+}
+
+.dark {
+  --vp-c-brand-1: #a5ec60;
+  --vp-c-brand-2: #8ad449;
+  --vp-c-brand-3: #70ba32;
+  --vp-c-brand-soft: rgb(165 236 96 / 13%);
+  --vp-c-bg: #0f1314;
+  --vp-c-bg-soft: #171c1f;
+  --vp-c-divider: #273235;
+  --vp-c-text-1: #f5f8f6;
+  --vp-c-text-2: #a8b7b3;
+}
+
+.VPNavBarTitle .logo {
+  height: 28px;
+  width: 28px;
+}
+
+.VPHero .name {
+  color: var(--vp-c-text-1);
+}
+```
+
+- [ ] **Step 6: Create paired landing pages with real scope statements**
+
+Create the page pairs below. Every file starts with the listed metadata. Use `status: stable` and
+`reviewedVersion: 0.1.17.5` for home, guide, and administration. Use `status: development` and
+`reviewedVersion: main` for development and reference. All use `lastReviewed: 2026-08-15`.
+
+- `site/index.md` and `site/de/index.md`, audience `reference`: use the headings
+  `RailKeeper Documentation` and `RailKeeper-Dokumentation`, link all three audiences, and state the
+  stable version.
+- `site/guide/index.md` and `site/de/guide/index.md`, audience `user`: use `User Guide` and
+  `Benutzerhandbuch`, and define the stable end-user scope.
+- `site/administration/index.md` and `site/de/administration/index.md`, audience `admin`: use
+  `Installation and Administration` and `Installation und Administration`, and define the operator
+  scope.
+- `site/development/index.md` and `site/de/development/index.md`, audience `developer`: use
+  `Development and Architecture` and `Entwicklung und Architektur`, and state that content follows
+  `main`.
+- `site/reference/index.md` and `site/de/reference/index.md`, audience `reference`: use `Reference`
+  and `Referenz`, and name coverage, glossary, troubleshooting, and releases as later destinations.
+
+Use this exact frontmatter shape on each non-home page:
+
+```yaml
+---
+title: User Guide
+description: Learn every stable RailKeeper workflow.
+audience: user
+status: stable
+reviewedVersion: 0.1.17.5
+lastReviewed: 2026-08-15
+---
+```
+
+Use VitePress `layout: home`, a single restrained hero, and three audience feature cards on both
+home pages. Do not use marketing claims, oversized typography, telemetry, or remote images.
+
+- [ ] **Step 7: Build and preview the site**
+
+Run:
+
+```powershell
+cd docs
+npm.cmd run build
+npm.cmd run preview -- --host 127.0.0.1
+```
+
+Expected: the build exits 0; the preview serves under `/RailKeeper/`; all five English paths and
+five German paths return HTML; the language switch preserves the matching page path.
+
+- [ ] **Step 8: Commit the foundation**
+
+```powershell
+git add .gitignore docs/package.json docs/package-lock.json docs/.vitepress docs/site
+git commit -m "docs: scaffold bilingual VitePress site"
+```
+
+### Task 2: Enforce language pairing, metadata, and version consistency
+
+**Files:**
+
+- Create: `docs/versions.json`
+- Create: `docs/scripts/validate-docs.mjs`
+- Create: `docs/scripts/validate-docs.test.mjs`
+- Modify: `docs/package.json`
+
+**Interfaces:**
+
+- Consumes: Markdown files below `docs/site/` and `docs/versions.json`.
+- Produces: `validateDocumentTree(root, versions): Promise<string[]>`; CLI exit 0 for a valid tree,
+  exit 1 with one line per defect otherwise.
+
+- [ ] **Step 1: Add the canonical documentation versions**
+
+Create `docs/versions.json`:
+
+```json
+{
+  "stable": "0.1.17.5",
+  "development": "main"
+}
+```
+
+- [ ] **Step 2: Write validator tests first**
+
+Create `docs/scripts/validate-docs.test.mjs`. Use `node:test`, `node:assert/strict`,
+`fs/promises.mkdtemp`, and `os.tmpdir`. Cover these exact cases:
+
+```js
+test("accepts a complete matching language pair", async () => {
+  const root = await fixture({
+    "index.md": page("reference", "stable", "0.1.17.5"),
+    "de/index.md": page("reference", "stable", "0.1.17.5"),
+  });
+  assert.deepEqual(await validateDocumentTree(root, versions), []);
+});
+
+test("reports a missing German counterpart", async () => {
+  const root = await fixture({ "guide/index.md": page("user", "stable", "0.1.17.5") });
+  assert.deepEqual(await validateDocumentTree(root, versions), [
+    "guide/index.md: missing counterpart de/guide/index.md",
+  ]);
+});
+
+test("reports missing and mismatched metadata", async () => {
+  const root = await fixture({
+    "index.md": page("reference", "stable", "0.1.17.5"),
+    "de/index.md": page("developer", "development", "main"),
+  });
+  const errors = await validateDocumentTree(root, versions);
+  assert(errors.includes("index.md: audience differs from de/index.md"));
+  assert(errors.includes("index.md: status differs from de/index.md"));
+  assert(errors.includes("index.md: reviewedVersion differs from de/index.md"));
+});
+
+test("enforces the canonical version for each status", async () => {
+  const root = await fixture({
+    "index.md": page("reference", "stable", "0.1.14"),
+    "de/index.md": page("reference", "stable", "0.1.14"),
+  });
+  assert((await validateDocumentTree(root, versions)).some((error) =>
+    error.includes("reviewedVersion must be 0.1.17.5"),
+  ));
+});
+```
+
+The local `fixture` helper writes exactly the supplied files. The local `page` helper emits valid
+frontmatter with `lastReviewed: 2026-08-15` and a `# Test` body.
+
+- [ ] **Step 3: Run tests and verify the expected failure**
+
+Run:
+
+```powershell
+cd docs
+npm.cmd test
+```
+
+Expected: FAIL because `validate-docs.mjs` does not exist.
+
+- [ ] **Step 4: Implement the validator**
+
+Implement these exported functions in `docs/scripts/validate-docs.mjs`:
+
+```js
+export function parseFrontmatter(source) // returns Record<string, string>
+export async function markdownFiles(root) // returns sorted POSIX-style relative paths
+export async function validateDocumentTree(root, versions) // returns sorted string[]
+```
+
+`validateDocumentTree` must:
+
+1. pair every English path with `de/<path>` and every German path with its English path;
+2. require `audience`, `status`, `reviewedVersion`, and `lastReviewed`;
+3. allow audiences `user`, `admin`, `developer`, and `reference`;
+4. allow statuses `stable` and `development`;
+5. require ISO date syntax `YYYY-MM-DD` for `lastReviewed`;
+6. require `versions.stable` for stable pages and `versions.development` for development pages;
+7. require matching audience, status, reviewed version, and review date across each pair;
+8. reject `TODO`, `TBD`, and `FIXME` in published Markdown;
+9. print each error to stderr and set `process.exitCode = 1` when invoked as a CLI.
+
+Do not add a YAML dependency. Parse only the flat scalar frontmatter contract above and fail on
+duplicate keys or an unterminated block.
+
+- [ ] **Step 5: Run validator tests and the real tree check**
+
+```powershell
+cd docs
+npm.cmd test
+node scripts/validate-docs.mjs
+```
+
+Expected: all validator tests PASS and the real-tree command exits 0 without stderr.
+
+- [ ] **Step 6: Make validation part of the existing check command**
+
+Keep this exact script in `docs/package.json`:
+
+```json
+"check": "npm test && node scripts/validate-docs.mjs && vitepress build"
+```
+
+- [ ] **Step 7: Commit the contract**
+
+```powershell
+git add docs/versions.json docs/scripts/validate-docs.mjs docs/scripts/validate-docs.test.mjs docs/package.json
+git commit -m "test: enforce bilingual documentation contract"
+```
+
+### Task 3: Discover repository documentation surfaces deterministically
+
+**Files:**
+
+- Create: `docs/scripts/source-inventory.mjs`
+- Create: `docs/scripts/source-inventory.test.mjs`
+
+**Interfaces:**
+
+- Consumes: `frontend/src/app/App.tsx`, `frontend/src/app/Shell.tsx`, both translation maps,
+  `backend/internal/api/routes.go`, `openapi/railkeeper.yaml`, tracked source files, and legacy docs.
+- Produces: `buildSourceInventory(repositoryRoot): Promise<SourceInventory>` and deterministic JSON
+  on stdout. It writes no repository file.
+
+- [ ] **Step 1: Write parser tests first**
+
+Create tests that assert these exact transformations:
+
+```js
+assert.deepEqual(extractFrontendRoutes('startsWith("/vehicles")\nhref: "/overview"'), [
+  "/overview",
+  "/vehicles",
+]);
+assert.deepEqual(extractTranslationKeys('  "vehicles.cv.title": "CV",'), ["vehicles.cv.title"]);
+assert.deepEqual(
+  extractApiRoutes('{http.MethodGet, "/api/v1/vehicles", routeAccessViewer, handler, nil}'),
+  [{ access: "Viewer", method: "GET", path: "/api/v1/vehicles" }],
+);
+assert.deepEqual(extractOpenApiPaths("paths:\n  /vehicles:\n    get:\n    post:\n"), [
+  "GET /vehicles",
+  "POST /vehicles",
+]);
+assert.deepEqual(extractEnvironmentVariables('env("RAILKEEPER_ADDR", ":8080")'), [
+  "RAILKEEPER_ADDR",
+]);
+```
+
+Add one integration fixture proving that English and German translation key sets must match and
+that the returned object is stable across two runs.
+
+- [ ] **Step 2: Run tests and verify the expected failure**
+
+```powershell
+cd docs
+npm.cmd test
+```
+
+Expected: FAIL because `source-inventory.mjs` does not exist.
+
+- [ ] **Step 3: Implement the read-only inventory builder**
+
+Export these functions from `docs/scripts/source-inventory.mjs`:
+
+```js
+export function extractFrontendRoutes(source)
+export function extractTranslationKeys(source)
+export function extractApiRoutes(source)
+export function extractOpenApiPaths(source)
+export function extractEnvironmentVariables(source)
+export async function buildSourceInventory(repositoryRoot)
+```
+
+Return this exact top-level shape, with every array deduplicated and sorted and without timestamps:
+
+```json
+{
+  "schemaVersion": 1,
+  "frontendRoutes": [],
+  "translationKeys": [],
+  "translationNamespaces": [],
+  "apiRoutes": [],
+  "openApiOperations": [],
+  "environmentVariables": [],
+  "legacyDocuments": []
+}
+```
+
+Implementation rules:
+
+- Collect routes from both `App.tsx` `startsWith()` calls and `Shell.tsx` `href` values.
+- Keep full translation keys and derive top-level namespaces from the first dot-separated segment.
+- Throw `English and German translation keys differ` and list both missing sets if they diverge.
+- Convert Go method constants to uppercase HTTP names and strip `routeAccess` from access names.
+- Parse only method keys below OpenAPI path keys; ignore schema properties named like methods.
+- Discover `RAILKEEPER_*` names from tracked text files while excluding `.git`, `node_modules`,
+  `dist`, `.cache`, `data`, and `.superpowers`.
+- List the root README files, stable `docs/*.md`, and `docs/releases/*.md` as legacy documents.
+- When invoked directly, resolve the repository root two levels above the script and print formatted
+  JSON to stdout. Do not write a generated inventory into the repository.
+
+- [ ] **Step 4: Run the parser and inspect real-source invariants**
+
+```powershell
+cd docs
+npm.cmd test
+node scripts/source-inventory.mjs
+```
+
+Expected: tests PASS; English and German translation counts are equal and nonzero, 185 API route
+specifications are present at the current committed baseline, all 140 OpenAPI path groups are
+represented after method expansion, and every visible/direct app route and tracked
+`RAILKEEPER_*` variable appears. Do not encode observed counts in the implementation.
+
+- [ ] **Step 5: Commit the inventory tool**
+
+```powershell
+git add docs/scripts/source-inventory.mjs docs/scripts/source-inventory.test.mjs
+git commit -m "test: inventory documentation source surfaces"
+```
+
+### Task 4: Add the reviewed coverage manifest and public coverage view
+
+**Files:**
+
+- Create: `docs/coverage.json`
+- Modify: `docs/scripts/validate-docs.mjs`
+- Modify: `docs/scripts/validate-docs.test.mjs`
+- Create: `docs/site/reference/coverage.md`
+- Create: `docs/site/de/reference/coverage.md`
+- Modify: `docs/.vitepress/config.mts`
+
+**Interfaces:**
+
+- Consumes: `buildSourceInventory()` from Task 3 and ownership maps from
+  `docs/coverage.json`.
+- Produces: `validateCoverage(inventory, manifest): string[]`; public coverage status pages at
+  `/reference/coverage` and `/de/reference/coverage`.
+
+- [ ] **Step 1: Write failing coverage tests**
+
+Add tests proving that `validateCoverage` reports:
+
+```text
+frontend route /unmapped is not covered
+translation key settings.newArea.title is not covered
+API route GET /api/v1/unmapped is not covered
+environment variable RAILKEEPER_UNMAPPED is not covered
+coverage topic vehicles references missing English page guide/vehicles/index.md
+```
+
+Also add one passing fixture in which each source item matches exactly one topic.
+
+- [ ] **Step 2: Run the focused test and verify failure**
+
+```powershell
+cd docs
+node --test scripts/validate-docs.test.mjs
+```
+
+Expected: FAIL because `validateCoverage` is not exported.
+
+- [ ] **Step 3: Create the initial reviewed manifest**
+
+Create `docs/coverage.json` with `schemaVersion: 1` and these exact topic IDs:
+
+```text
+setup-auth, overview, vehicles-core, vehicle-media, vehicle-maintenance,
+vehicle-decoder-cv, vehicle-search-spares, accessories, exhibition,
+import-export, settings-general, master-data, users-sessions-security,
+backup-restore, digital-centers, system-operations, layouts-unpublished,
+deployment-configuration, development-architecture, releases-support,
+shared-navigation
+```
+
+Each topic object contains only ownership metadata and its paired destination:
+
+```json
+{
+  "id": "vehicles-core",
+  "audience": "user",
+  "status": "planned",
+  "englishPath": "guide/vehicles/index.md",
+  "germanPath": "de/guide/vehicles/index.md"
+}
+```
+
+Add a top-level `owners` object. Use exact matching for frontend routes, top-level translation
+prefixes, and environment variables. Use longest-prefix matching for API paths and detailed
+translation prefixes. Include these complete owner assignments:
+
+```json
+{
+  "frontendRoutes": {
+    "/overview": "overview",
+    "/vehicles": "vehicles-core",
+    "/accessories": "accessories",
+    "/layouts": "layouts-unpublished",
+    "/exhibition": "exhibition",
+    "/import-export": "import-export",
+    "/settings": "settings-general"
+  },
+  "translationPrefixes": {
+    "accessories": "accessories",
+    "app": "setup-auth",
+    "auth": "setup-auth",
+    "common": "shared-navigation",
+    "exhibition": "exhibition",
+    "importExport": "import-export",
+    "layouts": "layouts-unpublished",
+    "nav": "shared-navigation",
+    "overview": "overview",
+    "settings.articleManagement": "master-data",
+    "settings.articleSearch": "vehicle-search-spares",
+    "settings.audit": "users-sessions-security",
+    "settings.auditAction": "users-sessions-security",
+    "settings.auth": "users-sessions-security",
+    "settings.backup": "backup-restore",
+    "settings.digital": "digital-centers",
+    "settings.inventoryNumbers": "master-data",
+    "settings.master": "master-data",
+    "settings.masterTransfer": "master-data",
+    "settings.password": "users-sessions-security",
+    "settings.role": "users-sessions-security",
+    "settings.roles": "users-sessions-security",
+    "settings.session": "users-sessions-security",
+    "settings.sessions": "users-sessions-security",
+    "settings.smtp": "users-sessions-security",
+    "settings.storage": "system-operations",
+    "settings.updates": "releases-support",
+    "settings.users": "users-sessions-security",
+    "settings": "settings-general",
+    "setup": "setup-auth",
+    "vehicle": "vehicles-core",
+    "vehicles.articleSearch": "vehicle-search-spares",
+    "vehicles.barcode": "vehicle-search-spares",
+    "vehicles.cv": "vehicle-decoder-cv",
+    "vehicles.functionMode": "vehicle-decoder-cv",
+    "vehicles.functionType": "vehicle-decoder-cv",
+    "vehicles.functions": "vehicle-decoder-cv",
+    "vehicles.image": "vehicle-media",
+    "vehicles.imageCare": "vehicle-media",
+    "vehicles.imagePreview": "vehicle-media",
+    "vehicles.maintenance": "vehicle-maintenance",
+    "vehicles.search": "vehicle-search-spares",
+    "vehicles.spareParts": "vehicle-search-spares",
+    "vehicles.speedCurve": "vehicle-decoder-cv",
+    "vehicles.uploads": "vehicle-media",
+    "vehicles": "vehicles-core"
+  },
+  "apiPrefixes": {
+    "/health": "system-operations",
+    "/api/v1/version": "releases-support",
+    "/api/v1/system/digital-settings": "digital-centers",
+    "/api/v1/system/smtp": "users-sessions-security",
+    "/api/v1/system": "system-operations",
+    "/api/v1/setup": "setup-auth",
+    "/api/v1/auth/two-factor": "users-sessions-security",
+    "/api/v1/auth/password": "users-sessions-security",
+    "/api/v1/auth": "setup-auth",
+    "/api/v1/profile": "settings-general",
+    "/api/v1/roles": "users-sessions-security",
+    "/api/v1/users": "users-sessions-security",
+    "/api/v1/sessions": "users-sessions-security",
+    "/api/v1/ecos": "digital-centers",
+    "/api/v1/digital-centers": "digital-centers",
+    "/api/v1/vehicles/{id}/images": "vehicle-media",
+    "/api/v1/vehicles/{id}/attachments": "vehicle-media",
+    "/api/v1/vehicles/{id}/maintenance": "vehicle-maintenance",
+    "/api/v1/vehicles/{id}/spare-parts": "vehicle-search-spares",
+    "/api/v1/vehicles/{id}/functions": "vehicle-decoder-cv",
+    "/api/v1/vehicles/{id}/cv-values": "vehicle-decoder-cv",
+    "/api/v1/vehicles/{id}/cv-files": "vehicle-decoder-cv",
+    "/api/v1/cv-files": "vehicle-decoder-cv",
+    "/api/v1/article-search": "vehicle-search-spares",
+    "/api/v1/vehicles": "vehicles-core",
+    "/api/v1/accessory": "accessories",
+    "/api/v1/storage-locations": "accessories",
+    "/api/v1/layout": "layouts-unpublished",
+    "/api/v1/plan-": "layouts-unpublished",
+    "/api/v1/track-": "layouts-unpublished",
+    "/api/v1/inventory-number-schemes": "master-data",
+    "/api/v1/master-data": "master-data",
+    "/api/v1/backup": "backup-restore",
+    "/api/v1/exhibition-lists": "exhibition"
+  },
+  "environmentVariables": {
+    "RAILKEEPER_ADDR": "deployment-configuration",
+    "RAILKEEPER_ALLOWED_ATTACHMENT_EXTENSIONS": "deployment-configuration",
+    "RAILKEEPER_COOKIE_SECURE": "deployment-configuration",
+    "RAILKEEPER_DATA_DIR": "deployment-configuration",
+    "RAILKEEPER_DEFAULT_PRINTER": "deployment-configuration",
+    "RAILKEEPER_IMAGE": "deployment-configuration",
+    "RAILKEEPER_MAX_ATTACHMENT_MB": "deployment-configuration",
+    "RAILKEEPER_MAX_ATTACHMENT_BYTES": "deployment-configuration",
+    "RAILKEEPER_MAX_IMAGE_MB": "deployment-configuration",
+    "RAILKEEPER_MAX_IMAGE_BYTES": "deployment-configuration",
+    "RAILKEEPER_MIGRATIONS_DIR": "deployment-configuration",
+    "RAILKEEPER_OPEN_BROWSER": "deployment-configuration",
+    "RAILKEEPER_PDF_OCR": "deployment-configuration",
+    "RAILKEEPER_PDF_OCR_MAX_PAGES": "deployment-configuration",
+    "RAILKEEPER_PORTABLE": "deployment-configuration",
+    "RAILKEEPER_PRINTERS": "deployment-configuration",
+    "RAILKEEPER_PUBLIC_URL": "deployment-configuration",
+    "RAILKEEPER_SEEDS_DIR": "deployment-configuration",
+    "RAILKEEPER_SMTP_FROM": "deployment-configuration",
+    "RAILKEEPER_SMTP_HOST": "deployment-configuration",
+    "RAILKEEPER_SMTP_PASSWORD": "deployment-configuration",
+    "RAILKEEPER_SMTP_PORT": "deployment-configuration",
+    "RAILKEEPER_SMTP_TLS": "deployment-configuration",
+    "RAILKEEPER_SMTP_USER": "deployment-configuration",
+    "RAILKEEPER_STATIC_DIR": "deployment-configuration",
+    "RAILKEEPER_UPDATE_CHECK_URL": "deployment-configuration"
+  }
+}
+```
+
+The implementation must prefer the longest matching translation or API prefix. Every discovered
+frontend route, full translation key, API route, and environment variable must resolve to exactly
+one topic. Assign `layouts-unpublished` the status `not-published` and all other not-yet-authored
+destinations `planned`.
+
+- [ ] **Step 4: Implement coverage validation**
+
+Add and export:
+
+```js
+export function validateCoverage(inventory, manifest, contentRoot)
+```
+
+It must reject unknown status/audience values, duplicate topic IDs, owner references to unknown
+topics, source items with no owner, and `documented` topics whose paired target files do not exist.
+Allowed coverage statuses are `planned`, `documented`, `internal`, and `not-published`. Call this
+validation from the CLI after `validateDocumentTree`.
+
+- [ ] **Step 5: Create paired human-readable coverage pages**
+
+The English and German pages explain:
+
+- what source surfaces are scanned;
+- the difference between `planned`, `documented`, `internal`, and `not-published`;
+- that a topic becomes `documented` only after both target pages pass the page standard;
+- that layout planning remains `not-published` for stable users;
+- how contributors run `npm.cmd run check` and update `docs/coverage.json`.
+
+Both pages link to `docs/coverage.json` on GitHub and show the 20 topic IDs grouped under user,
+admin, developer, and shared headings. Add the page to both reference sidebars.
+
+- [ ] **Step 6: Run the complete documentation check**
+
+```powershell
+cd docs
+npm.cmd run check
+```
+
+Expected: all tests PASS, coverage has no unmapped or multiply mapped source item, and VitePress
+builds without dead links.
+
+- [ ] **Step 7: Commit the coverage contract**
+
+```powershell
+git add docs/coverage.json docs/scripts/validate-docs.mjs docs/scripts/validate-docs.test.mjs
+git add docs/site/reference docs/site/de/reference docs/.vitepress/config.mts
+git commit -m "docs: add repository coverage matrix"
+```
+
+### Task 5: Add CI and GitHub Pages deployment
+
+**Files:**
+
+- Modify: `.github/workflows/ci.yml`
+- Create: `.github/workflows/docs-pages.yml`
+
+**Interfaces:**
+
+- Consumes: `docs/package-lock.json` and `npm run check` from Tasks 1 through 4.
+- Produces: required PR check `Documentation`; deployment environment `github-pages`.
+
+- [ ] **Step 1: Add the documentation job to CI**
+
+Append this job to `.github/workflows/ci.yml`:
+
+```yaml
+  documentation:
+    name: Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: docs/package-lock.json
+      - name: Install documentation dependencies
+        working-directory: docs
+        run: npm ci
+      - name: Check documentation
+        working-directory: docs
+        run: npm run check
+```
+
+- [ ] **Step 2: Create the Pages workflow**
+
+Create `.github/workflows/docs-pages.yml`:
+
+```yaml
+name: Documentation Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "frontend/public/brand/**"
+      - ".github/workflows/docs-pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: documentation-pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: docs/package-lock.json
+      - uses: actions/configure-pages@v4
+      - name: Install documentation dependencies
+        working-directory: docs
+        run: npm ci
+      - name: Build documentation
+        working-directory: docs
+        run: npm run check
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/.vitepress/dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy documentation
+        id: deployment
+        uses: actions/deploy-pages@v4
+```
+
+- [ ] **Step 3: Validate workflow syntax and the local equivalent**
+
+Run:
+
+```powershell
+cd docs
+npm.cmd ci
+npm.cmd run check
+```
+
+Expected: clean install succeeds, all documentation checks pass, and
+`docs/.vitepress/dist/index.html` plus `docs/.vitepress/dist/de/index.html` exist.
+
+- [ ] **Step 4: Commit workflows**
+
+```powershell
+git add .github/workflows/ci.yml .github/workflows/docs-pages.yml
+git commit -m "ci: publish RailKeeper documentation pages"
+```
+
+### Task 6: Add repository entry points and contributor rules
+
+**Files:**
+
+- Modify: `README.md`
+- Modify: `README.de.md`
+- Modify: `CONTRIBUTING.md`
+- Modify: `SUPPORT.md`
+
+**Interfaces:**
+
+- Consumes: published routes from Task 1.
+- Produces: discoverable handbook links and a same-PR documentation rule.
+
+- [ ] **Step 1: Add language-correct handbook links**
+
+Add `Documentation` to the top link row in `README.md` and `Dokumentation` to `README.de.md`:
+
+```text
+https://ichwars.github.io/RailKeeper/
+https://ichwars.github.io/RailKeeper/de/
+```
+
+Add one sentence near each feature overview stating that the handbook contains complete user,
+operator, and developer guidance. Do not expand the README into a second handbook.
+
+- [ ] **Step 2: Document the contribution workflow**
+
+Add a `Documentation changes` section to `CONTRIBUTING.md` with these rules:
+
+```markdown
+## Documentation changes
+
+- Update the English and German page in the same pull request when behavior changes.
+- Keep identical relative paths below `docs/site/` and `docs/site/de/`.
+- Run `cd docs` followed by `npm run check` before opening the pull request.
+- Update `docs/coverage.json` when a route, API area, translation namespace, configuration value,
+  or documentation topic is introduced.
+- A one-language-only change is allowed only for a wording correction that does not change meaning.
+```
+
+- [ ] **Step 3: Route support requests without duplicating troubleshooting content**
+
+Add English and German handbook links to `SUPPORT.md`. Keep issue-reporting and security-reporting
+instructions in `SUPPORT.md`; link to handbook troubleshooting instead of copying it.
+
+- [ ] **Step 4: Run link/build checks and commit**
+
+```powershell
+cd docs
+npm.cmd run check
+cd ..
+git add README.md README.de.md CONTRIBUTING.md SUPPORT.md
+git commit -m "docs: link the RailKeeper handbook"
+```
+
+Expected: documentation checks pass and the only duplicated URLs are the intended language-specific
+entry points.
+
+### Task 7: Correct the stable GitHub release marker and perform end-to-end acceptance
+
+**Files:**
+
+- Modify only if evidence requires correction: `docs/versions.json`
+- Modify only if evidence requires correction: paired home pages
+- No release artifact is created locally or committed.
+
+**Interfaces:**
+
+- Consumes: tag `v0.1.17.5`, `.github/workflows/windows-portable.yml`, public GitHub Releases, and
+  the deployed Pages site.
+- Produces: verified public latest release `v0.1.17.5` and an accepted Etappe 1 deployment.
+
+- [ ] **Step 1: Verify the local and remote tag before changing GitHub state**
+
+Run:
+
+```powershell
+git show -s --format="%H %D %cs %s" v0.1.17.5
+git ls-remote --tags origin refs/tags/v0.1.17.5
+gh release view v0.1.17.5 --repo ichwars/RailKeeper --json tagName,isDraft,isPrerelease,assets,url
+```
+
+Expected: the local tag resolves to commit `9e81856313c759f733d97405bb9fa606d47e74b5`; the remote tag
+exists; the release is non-draft and non-prerelease with the portable ZIP asset. If the remote tag
+is absent, confirm the local tag still points to that exact reviewed commit, then run:
+
+```powershell
+git push origin refs/tags/v0.1.17.5
+```
+
+Stop instead of pushing if the commit differs.
+
+- [ ] **Step 2: Recover a missing release only through the existing release workflow**
+
+If the release or portable ZIP is missing, run:
+
+```powershell
+gh workflow run windows-portable.yml --repo ichwars/RailKeeper --ref v0.1.17.5
+$releaseRunId = gh run list --repo ichwars/RailKeeper `
+  --workflow windows-portable.yml --limit 1 --json databaseId --jq '.[0].databaseId'
+gh run watch --repo ichwars/RailKeeper $releaseRunId --exit-status
+```
+
+Expected: the workflow succeeds and publishes the ZIP to a non-prerelease v0.1.17.5 release. Do
+not upload an unverified local ZIP manually.
+
+- [ ] **Step 3: Mark the verified release as latest and confirm the public API**
+
+```powershell
+gh release edit v0.1.17.5 --repo ichwars/RailKeeper --latest
+gh api repos/ichwars/RailKeeper/releases/latest --jq .tag_name
+```
+
+Expected: `v0.1.17.5`.
+
+- [ ] **Step 4: Enable GitHub Pages from Actions if not already enabled**
+
+In repository settings, set Pages source to GitHub Actions. Then run the workflow manually once:
+
+```powershell
+gh workflow run docs-pages.yml --repo ichwars/RailKeeper --ref main
+$pagesRunId = gh run list --repo ichwars/RailKeeper `
+  --workflow docs-pages.yml --limit 1 --json databaseId --jq '.[0].databaseId'
+gh run watch --repo ichwars/RailKeeper $pagesRunId --exit-status
+```
+
+Expected: the deployment succeeds and reports the Pages URL.
+
+- [ ] **Step 5: Perform visual and functional acceptance**
+
+Check the deployed site at 390 px, 768 px, and 1440 px widths in both light and dark modes:
+
+- English opens at `/RailKeeper/`; German opens at `/RailKeeper/de/`.
+- Switching language from every landing and coverage page preserves the corresponding path.
+- Search finds `backup`, `vehicle`, `Wartung`, and `Sicherung` only in the appropriate locale.
+- Navigation exposes the three audience areas and reference without clipped German labels.
+- The logo loads from the repository asset and no external request is made for fonts, search, or
+  analytics.
+- Missing pages return the VitePress 404 page, not the RailKeeper application shell.
+- All page edit links target the correct file below `docs/site/`.
+
+- [ ] **Step 6: Run the complete repository baseline**
+
+```powershell
+cd backend
+go test ./...
+cd ..\frontend
+npm.cmd run build
+cd ..\docs
+npm.cmd run check
+```
+
+Expected: all Go tests pass, the frontend production build succeeds, and every documentation test
+and build succeeds.
+
+- [ ] **Step 7: Record Etappe 1 acceptance**
+
+Update the implementation pull request description with:
+
+```text
+- Documentation check: passed
+- Backend tests: passed
+- Frontend build: passed
+- GitHub Pages deployment: passed
+- English/German path parity: passed
+- Light/dark and 390/768/1440 px visual checks: passed
+- Latest stable GitHub Release: v0.1.17.5
+- Remaining content work: Etappen 2 through 5 from the approved design specification
+```
+
+No additional source commit is required unless verification finds and fixes a defect.

--- a/docs/superpowers/specs/2026-08-15-railkeeper-bilingual-documentation-design.md
+++ b/docs/superpowers/specs/2026-08-15-railkeeper-bilingual-documentation-design.md
@@ -1,0 +1,265 @@
+# Zweisprachiges RailKeeper-Handbuch auf GitHub Pages
+
+Datum: 15. August 2026
+
+Status: fachlich freigegeben
+
+Geltungsbereich: Dokumentationsplattform, Informationsarchitektur und Pflegeprozess
+
+## Ziel
+
+RailKeeper erhält ein öffentliches, zweisprachiges Handbuch auf GitHub Pages. Es soll den
+vollständigen stabilen Funktionsumfang für Anwender und Administratoren sowie den aktuellen
+Entwicklungsstand für Mitwirkende dokumentieren. Die Dokumentation muss auch bei wachsendem
+Projektumfang auffindbar, überprüfbar und dauerhaft pflegbar bleiben.
+
+Das Handbuch verwendet Englisch als öffentlichen Einstieg. Deutsch wird vollständig und fachlich
+gleichwertig gepflegt. Eine Dokumentationsänderung gilt erst als abgeschlossen, wenn beide
+Sprachfassungen vorliegen.
+
+## Zielgruppen und Versionsbezug
+
+Das Handbuch trennt drei Zielgruppen in der Hauptnavigation:
+
+1. **Benutzerhandbuch:** Bedienung aller veröffentlichten Arbeitsbereiche und Funktionen.
+2. **Installation und Administration:** Installation, Konfiguration, Betrieb, Sicherheit,
+   Datensicherung und Fehlerbehebung.
+3. **Entwicklung und Architektur:** Entwicklungsumgebung, Systemgrenzen, Verträge, Datenhaltung,
+   Tests, Releases und Beiträge.
+
+Benutzer- und Administrationsinhalte beschreiben den jeweils neuesten stabilen Release. Beim
+ersten Handbuch-Release ist dies RailKeeper v0.1.17.5. Entwicklungs- und Architekturinhalt
+beschreibt ausdrücklich den Stand von `main`.
+
+Die öffentliche GitHub-Kennzeichnung „Latest Release“ verweist derzeit abweichend auf v0.1.14.
+Vor Veröffentlichung des Handbuchs wird geprüft, ob Releases oder Release-Artefakte fehlen, und
+v0.1.17.5 wird korrekt als neuester stabiler GitHub Release veröffentlicht beziehungsweise
+gekennzeichnet. Diese Korrektur darf keine unvollständigen oder ungeprüften Release-Artefakte
+veröffentlichen.
+
+Historische Handbuchversionen sind in der ersten Ausbaustufe nicht vorgesehen. Release-Notizen
+bleiben erhalten. Eine Versionsauswahl wird erst eingeführt, wenn mehrere RailKeeper-Versionen
+parallel unterstützt werden oder relevante Unterschiede im Betrieb dies erforderlich machen.
+
+## Technische Architektur
+
+Das Handbuch wird mit VitePress als statische Website erzeugt und über GitHub Pages bereitgestellt.
+Diese Wahl passt zum vorhandenen Node-, Vite- und TypeScript-Umfeld des Projekts und benötigt keinen
+zusätzlichen externen Such- oder Hostingdienst.
+
+VitePress stellt bereit:
+
+- sprachabhängige Navigation und direkte Sprachumschaltung,
+- lokale Volltextsuche im Browser,
+- responsive Seiten mit heller und dunkler Darstellung,
+- Markdown-basierte Inhalte mit Git-Historie und Pull-Request-Review,
+- automatisierte statische Builds für GitHub Pages.
+
+Die Dokumentationsquellen liegen unter `docs/` im Hauptrepository. Englisch verwendet den
+Wurzelpfad der veröffentlichten Seite, Deutsch den Präfix `/de/`. Fachlich zusammengehörige Seiten
+haben nach dem Sprachpräfix denselben Pfad, zum Beispiel:
+
+```text
+/guide/vehicles/maintenance
+/de/guide/vehicles/maintenance
+```
+
+Die vorhandenen stabilen Dokumente in `docs/`, die README-Dateien, Release-Notizen und Screenshots
+werden nicht blind dupliziert. Sie werden der neuen Informationsarchitektur zugeordnet, in beiden
+Sprachen überarbeitet oder als weiterhin eigenständige Projektdateien verlinkt. Bestehende Links
+sollen nach Möglichkeit erhalten oder gezielt weitergeleitet werden.
+
+## Informationsarchitektur
+
+### Benutzerhandbuch
+
+Das Benutzerhandbuch umfasst mindestens:
+
+- Schnellstart, Ersteinrichtung, Anmeldung und grundlegende Navigation,
+- Übersicht, Kennzahlen, Suche, Filter und Datenqualitätsanzeigen,
+- Fahrzeuge, Modelldaten, technische Daten, Eigentum und Leseansichten,
+- Zubehör, Bestandsführung, Lagerorte, Reservierungen, Einbauten und Historie,
+- Bilder, Anhänge, Webdokumente und Dokumentdownloads,
+- Decoder, CV-Werte, Profile, Import, Export und Funktionstasten,
+- Wartungen und Zustandshistorie,
+- Artikel-, Produkt- und Ersatzteilsuche mit Quellenprüfung,
+- PDF-Berichte, QR-Codes, Druck und Druckerauswahl,
+- Ausstellung, Sperrstatus, Messe-Rolle und Listenansichten,
+- CSV-, TSV-, XML- und JSON-Importe sowie kontrollierte Aktualisierungen,
+- ECoS-Auslesung und die Grenzen der Z21- und CS3-Verbindungsadapter,
+- Anlagenplanung, sobald der Arbeitsbereich als stabile Funktion veröffentlicht ist.
+
+### Installation und Administration
+
+Der Administrationsbereich umfasst mindestens:
+
+- Windows-Portable- und Docker-Installation,
+- Ersteinrichtung, Datenverzeichnis und Laufzeitmodell,
+- Umgebungsvariablen und gespeicherte Systemeinstellungen,
+- Benutzer, Rollen, Berechtigungsgrenzen und Sitzungen,
+- SMTP und Passwort-Wiederherstellung,
+- Backup, Validierung, Wiederherstellung und Kompatibilitätsprüfung,
+- Updates, Release-Kanäle und Prüfungen nach Updates,
+- TLS, Reverse Proxy, sichere Cookies und Schutz des Datenverzeichnisses,
+- Upload-Grenzen, erlaubte Dateitypen, OCR und Druckerkonfiguration,
+- Betrieb, Zustandsprüfung, Logs und Smoke-Tests,
+- systematische Fehlerdiagnose und konservative Datenrettung,
+- Sicherheits-, Datenschutz- und Local-first-Modell.
+
+### Entwicklung und Architektur
+
+Der Entwicklerbereich umfasst mindestens:
+
+- lokale Entwicklungsumgebung und benötigte Werkzeuge,
+- modularen Monolithen und Verantwortungsgrenzen,
+- Backend-, Frontend- und Infrastrukturstruktur,
+- OpenAPI-Vertrag, API-Konventionen und Fehlerformate,
+- SQLite-Schema, Migrationen und Stammdaten-Seeds,
+- Upload- und Dateispeicher sowie Pfadbegrenzung,
+- Authentifizierung, Autorisierung, CSRF und Audit-Logging,
+- Import-, Export- und Backupformate einschließlich Kompatibilität,
+- Tests, Builds, statische Prüfungen und visuelle Qualitätssicherung,
+- Release-Prozess, Versionsnummern, Artefakte und Release-Kanäle,
+- Beitragsprozess und Pull-Request-Anforderungen,
+- stabile Architekturentscheidungen und bewusst zurückgestellte Vorhaben.
+
+### Bereichsübergreifende Inhalte
+
+Volltextsuche, FAQ, Fehlerbehebung, Glossar und Release-Notizen sind aus allen drei Bereichen
+erreichbar. Querverweise verbinden verwandte Abläufe. Fachliche Aussagen werden an einer
+kanonischen Stelle gepflegt und von anderen Seiten verlinkt, um widersprüchliche Duplikate zu
+vermeiden.
+
+## Seitenstandard
+
+Jede Funktionsseite folgt einem gemeinsamen Aufbau, soweit die einzelnen Abschnitte für das Thema
+zutreffen:
+
+1. Zweck und typische Einsatzfälle,
+2. Voraussetzungen und benötigte Rolle,
+3. Ablauf Schritt für Schritt,
+4. sämtliche Felder, Aktionen, Statuswerte und Auswirkungen,
+5. Validierungen, Grenzen und Sicherheitsabfragen,
+6. häufige Fehler und deren Behebung,
+7. verwandte Funktionen und weiterführende Seiten,
+8. dokumentierter RailKeeper-Stand und letzte fachliche Prüfung.
+
+Screenshots unterstützen Orientierung und komplexe Abläufe, ersetzen aber keine textliche
+Erklärung. Wenn sichtbarer UI-Text für das Verständnis relevant ist, erhält jede Sprachfassung ein
+Bild in der entsprechenden Sprache. Sprachneutrale Abbildungen dürfen gemeinsam verwendet werden.
+Alle Bilder müssen im hellen oder dunklen Modus gut verständlich sein, relevante Zustände zeigen
+und ohne personenbezogene oder produktive Daten auskommen.
+
+## Vollständigkeitsnachweis
+
+Eine Coverage-Matrix macht den Anspruch „alles“ überprüfbar. Sie wird aus folgenden Quellen
+erstellt und bei funktionalen Änderungen fortgeführt:
+
+- sichtbare Routen, Navigationseinträge, Ansichten, Tabs und Dialoge,
+- deutsche und englische UI-Übersetzungsschlüssel,
+- öffentliche API-Endpunkte und OpenAPI-Operationen,
+- Rollen- und Berechtigungsprüfungen,
+- Konfigurationswerte und Umgebungsvariablen,
+- Migrationen, persistierte Hauptkonzepte und Dateispeicher,
+- Import-, Export-, Backup- und Wiederherstellungsformate,
+- bestehende README-, Betriebs-, Sicherheits-, Architektur- und Release-Dokumente.
+
+Jeder Eintrag verweist auf seine englische und deutsche Zielseite oder trägt einen begründeten
+Status, beispielsweise intern, noch nicht veröffentlicht oder bewusst ohne Benutzeroberfläche.
+Ein Abschnitt gilt nicht allein deshalb als dokumentiert, weil sein Name in einer Übersicht
+erscheint.
+
+## Pflege- und Veröffentlichungsprozess
+
+Funktionsänderungen aktualisieren die zugehörigen englischen und deutschen Seiten im selben Pull
+Request. Die Pull-Request-Vorlage erhält dafür eine Dokumentationsprüfung. Automatische Prüfungen
+ersetzen nicht die fachliche Übersetzungsprüfung.
+
+Die Continuous-Integration-Prüfung umfasst mindestens:
+
+- reproduzierbare Installation der festgelegten VitePress-Abhängigkeiten,
+- erfolgreichen Produktions-Build,
+- Prüfung interner Links und referenzierter Bilder,
+- Prüfung, dass jede veröffentlichte Seite eine DE/EN-Gegenseite besitzt,
+- Prüfung erforderlicher Seitenmetadaten,
+- Erkennung versehentlich eingecheckter Build-Ausgaben.
+
+Fehlende Sprachseiten, defekte Links, fehlende Medien oder ungültige Metadaten brechen den
+Dokumentations-Build ab. Semantische Übersetzungsabweichungen werden im Review anhand einer kurzen
+Checkliste geprüft. Kleine rein sprachliche Korrekturen dürfen nur eine Sprachfassung ändern, wenn
+die fachliche Aussage nachweislich unverändert bleibt.
+
+Nach erfolgreicher Prüfung veröffentlicht ein GitHub-Actions-Workflow die statische Seite aus
+`main` auf GitHub Pages. Benutzer- und Administrationsseiten werden im Rahmen eines Releases auf
+den neuen stabilen Stand gebracht. Entwicklerseiten können unabhängig davon mit `main`
+fortgeschrieben werden. Die Startseite nennt klar den dokumentierten stabilen Release und verweist
+separat auf die Entwicklerdokumentation.
+
+## Umsetzungsetappen
+
+### Etappe 1: Plattform und Bestandsaufnahme
+
+VitePress, Sprachrouting, Suche, zurückhaltendes RailKeeper-Branding, GitHub-Pages-Workflow,
+Qualitätsprüfungen und Coverage-Matrix werden eingerichtet. Die Navigation ist vollständig, auch
+wenn einzelne Zielseiten zunächst eindeutig als noch nicht erstellt gekennzeichnet sind.
+
+Abnahme: Beide Sprachen bauen lokal und in CI, Suche und Sprachwechsel funktionieren, die
+Coverage-Matrix erfasst alle bekannten Quellen.
+
+### Etappe 2: Benutzerhandbuch
+
+Alle stabil veröffentlichten Bedienabläufe werden nach dem Seitenstandard dokumentiert. Komplexe
+Abläufe erhalten geprüfte Screenshots und konkrete Beispiele.
+
+Abnahme: Jeder stabile UI- und Benutzerablauf besitzt vollständige englische und deutsche Seiten;
+offene Coverage-Einträge betreffen keine veröffentlichte Benutzerfunktion.
+
+### Etappe 3: Installation und Administration
+
+Installation, Konfiguration, Rollen, Backup und Restore, Updates, Sicherheit, Betrieb und
+Fehlerbehebung werden zusammengeführt und vervollständigt.
+
+Abnahme: Ein neuer Betreiber kann RailKeeper installieren, sicher konfigurieren, aktualisieren,
+sichern, wiederherstellen und typische Fehler untersuchen, ohne auf interne Projektnotizen
+angewiesen zu sein.
+
+### Etappe 4: Entwicklung und Architektur
+
+Die stabilen technischen Konzepte, Verträge und Entwicklungsabläufe werden auf Basis von `main`
+dokumentiert. Flüchtige Implementierungsdetails werden nur aufgenommen, wenn sie für Verträge,
+Sicherheit, Kompatibilität oder Beiträge relevant sind.
+
+Abnahme: Ein neuer Mitwirkender kann das Projekt aufsetzen, die Modulgrenzen verstehen, Änderungen
+testen und einen regelkonformen Pull Request vorbereiten.
+
+### Etappe 5: Gesamtabnahme und Veröffentlichung
+
+Coverage, Sprachgleichheit, Links, Medien, mobile und Desktop-Darstellung sowie helle und dunkle
+Darstellung werden geprüft. Die GitHub-Release-Kennzeichnung wird korrigiert, bevor das Handbuch
+öffentlich als Dokumentation für v0.1.17.5 bezeichnet wird.
+
+Abnahme: Alle Coverage-Einträge sind dokumentiert oder begründet klassifiziert, beide Sprachen
+sind vollständig, alle automatischen Prüfungen bestehen und GitHub Pages ist öffentlich
+erreichbar.
+
+## Qualitäts- und Sicherheitsgrenzen
+
+- Das Handbuch darf keine Zugangsdaten, privaten Backups, produktiven Daten oder internen Pfade aus
+  realen Installationen enthalten.
+- Sicherheitskritische Anleitungen müssen mit den serverseitigen Rollen- und Schutzmechanismen
+  übereinstimmen.
+- Backup- und Restore-Anleitungen müssen Datenverlust-Risiken, Vorprüfung und Bestätigung klar
+  benennen.
+- Externe Artikel- und Suchdaten werden als Vorschläge dargestellt, nicht als vertrauenswürdige
+  Stammdaten.
+- Verborgene oder unfertige Funktionen werden nicht als stabiler Benutzerumfang dokumentiert.
+- Die erzeugte Website und lokale Begleitartefakte werden nicht in Git eingecheckt.
+
+## Nicht-Ziele der ersten Ausbaustufe
+
+- keine separate native GitHub-Wiki-Instanz,
+- kein externer Suchdienst und keine Dokumentations-Telemetrie,
+- keine parallelen historischen Handbuchversionen,
+- keine automatische maschinelle Übersetzung als veröffentlichte Endfassung,
+- keine vollständige Referenz jedes internen Typs oder jeder privaten Funktion,
+- keine Änderung des Local-first-, Sicherheits- oder Bereitstellungsmodells von RailKeeper.

--- a/docs/superpowers/specs/2026-08-15-railkeeper-bilingual-documentation-design.md
+++ b/docs/superpowers/specs/2026-08-15-railkeeper-bilingual-documentation-design.md
@@ -28,12 +28,12 @@ Das Handbuch trennt drei Zielgruppen in der Hauptnavigation:
    Tests, Releases und Beiträge.
 
 Benutzer- und Administrationsinhalte beschreiben den jeweils neuesten stabilen Release. Beim
-ersten Handbuch-Release ist dies RailKeeper v0.1.17.5. Entwicklungs- und Architekturinhalt
+ersten Handbuch-Release ist dies RailKeeper v0.1.17.6. Entwicklungs- und Architekturinhalt
 beschreibt ausdrücklich den Stand von `main`.
 
 Die öffentliche GitHub-Kennzeichnung „Latest Release“ verweist derzeit abweichend auf v0.1.14.
 Vor Veröffentlichung des Handbuchs wird geprüft, ob Releases oder Release-Artefakte fehlen, und
-v0.1.17.5 wird korrekt als neuester stabiler GitHub Release veröffentlicht beziehungsweise
+v0.1.17.6 wird korrekt als neuester stabiler GitHub Release veröffentlicht beziehungsweise
 gekennzeichnet. Diese Korrektur darf keine unvollständigen oder ungeprüften Release-Artefakte
 veröffentlichen.
 
@@ -236,7 +236,7 @@ testen und einen regelkonformen Pull Request vorbereiten.
 
 Coverage, Sprachgleichheit, Links, Medien, mobile und Desktop-Darstellung sowie helle und dunkle
 Darstellung werden geprüft. Die GitHub-Release-Kennzeichnung wird korrigiert, bevor das Handbuch
-öffentlich als Dokumentation für v0.1.17.5 bezeichnet wird.
+öffentlich als Dokumentation für v0.1.17.6 bezeichnet wird.
 
 Abnahme: Alle Coverage-Einträge sind dokumentiert oder begründet klassifiziert, beide Sprachen
 sind vollständig, alle automatischen Prüfungen bestehen und GitHub Pages ist öffentlich

--- a/docs/versions.json
+++ b/docs/versions.json
@@ -1,4 +1,4 @@
 {
-  "stable": "0.1.17.5",
+  "stable": "0.1.17.6",
   "development": "main"
 }

--- a/docs/versions.json
+++ b/docs/versions.json
@@ -1,0 +1,4 @@
+{
+  "stable": "0.1.17.5",
+  "development": "main"
+}


### PR DESCRIPTION
## Summary

- add a bilingual VitePress documentation foundation with English as the default and complete German path parity
- add metadata, version, source-inventory, and coverage validation for repository documentation surfaces
- add documentation CI, GitHub Pages deployment, repository entry points, and contributor rules
- align stable documentation with verified release v0.1.17.6
- complete responsive light/dark browser QA including local search, language switching, edit links, and 404 handling

## Impact

RailKeeper gains a maintainable handbook foundation for users, administrators, and developers. GitHub Pages will deploy from `main` after this pull request is merged and Pages is configured to use GitHub Actions.

## Validation

- `go test ./...`
- `npm.cmd run build`
- `npm.cmd run test:run` (91 files, 482 tests)
- `npm.cmd run check` (19 documentation tests and VitePress build)
- `actionlint .github/workflows/ci.yml .github/workflows/docs-pages.yml`
- responsive browser QA at 390 px, 768 px, and 1440 px in light and dark mode