### PR TITLE
ci: update GitHub Pages actions

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -30,14 +30,14 @@ jobs:
           node-version: 24
           cache: npm
           cache-dependency-path: docs/package-lock.json
-      - uses: actions/configure-pages@v4
+      - uses: actions/configure-pages@v6
       - name: Install documentation dependencies
         working-directory: docs
         run: npm ci
       - name: Build documentation
         working-directory: docs
         run: npm run check
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: docs/.vitepress/dist
 
@@ -50,4 +50,4 @@ jobs:
     steps:
       - name: Deploy documentation
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary

- update `actions/configure-pages` from v4 to v6
- update `actions/upload-pages-artifact` from v3 to v5
- update `actions/deploy-pages` from v4 to v5

## Root cause

The failed run shown in the report started before GitHub Pages was enabled for Actions deployments. Pages is now enabled and the subsequent deployment succeeded. This update removes the remaining Node.js 20 deprecation warning by moving all Pages actions to their current official major versions.

## Validation

- `actionlint .github/workflows/docs-pages.yml`
- `npm.cmd run check` (19 documentation tests and VitePress build)
- `git diff --check`