### PR TITLE
docs: use official RailKeeper logos

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -13,8 +13,8 @@ export default defineConfig({
       "link",
       {
         rel: "icon",
-        type: "image/svg+xml",
-        href: "/RailKeeper/brand/railkeeper-mark.svg",
+        type: "image/png",
+        href: "/RailKeeper/brand/railkeeper-mark.png",
       },
     ],
   ],
@@ -88,7 +88,7 @@ export default defineConfig({
     },
   },
   themeConfig: {
-    logo: "/brand/railkeeper-mark.svg",
+    logo: "/brand/railkeeper-mark.png",
     siteTitle: "RailKeeper Docs",
     socialLinks: [{ icon: "github", link: repositoryUrl }],
     editLink: {

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -25,7 +25,12 @@
 
 .VPNavBarTitle .logo {
   height: 28px;
+  object-fit: contain;
   width: 28px;
+}
+
+.VPHero .VPImage {
+  object-fit: contain;
 }
 
 .VPHero .name {

--- a/docs/site/de/index.md
+++ b/docs/site/de/index.md
@@ -11,7 +11,7 @@ hero:
   text: Werkstattwissen direkt beim Projekt
   tagline: Das Handbuch folgt v0.1.17.6, die Entwicklungsdokumentation dem Stand von main.
   image:
-    src: /brand/railkeeper-mark.svg
+    src: /brand/railkeeper-logo.png
     alt: RailKeeper
   actions:
     - theme: brand

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -11,7 +11,7 @@ hero:
   text: Workshop knowledge, kept with the project
   tagline: User guidance follows stable v0.1.17.6. Development documentation follows main.
   image:
-    src: /brand/railkeeper-mark.svg
+    src: /brand/railkeeper-logo.png
     alt: RailKeeper
   actions:
     - theme: brand

--- a/docs/superpowers/plans/2026-08-16-railkeeper-documentation-logo.md
+++ b/docs/superpowers/plans/2026-08-16-railkeeper-documentation-logo.md
@@ -1,0 +1,114 @@
+# RailKeeper Documentation Logo Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the documentation placeholder artwork with the existing official RailKeeper logo
+assets in navigation, favicon, and both landing-page heroes.
+
+**Architecture:** VitePress continues to serve brand assets from `frontend/public/brand` through its
+configured public directory. Configuration owns navigation and favicon branding, while the paired
+English and German frontmatter owns hero artwork.
+
+**Tech Stack:** VitePress 2.0.0-alpha.19, Markdown frontmatter, TypeScript configuration, npm.
+
+## Global Constraints
+
+- Navigation and favicon use `/brand/railkeeper-mark.png`.
+- English and German hero sections use `/brand/railkeeper-logo.png`.
+- Do not change copy, navigation, colors, spacing, or page structure.
+- Keep English and German metadata and relative paths paired.
+- Load no external image resource.
+
+---
+
+### Task 1: Replace and verify documentation branding
+
+**Files:**
+
+- Modify: `docs/.vitepress/config.mts`
+- Modify: `docs/site/index.md`
+- Modify: `docs/site/de/index.md`
+
+**Interfaces:**
+
+- Consumes: `frontend/public/brand/railkeeper-mark.png` and
+  `frontend/public/brand/railkeeper-logo.png`.
+- Produces: official RailKeeper branding at the English and German documentation entry points.
+
+- [ ] **Step 1: Confirm the documentation baseline**
+
+Run:
+
+```powershell
+cd docs
+npm.cmd ci --cache ..\.cache\npm-docs
+npm.cmd run check
+```
+
+Expected: dependency installation reports zero vulnerabilities, all documentation tests pass, and
+VitePress builds successfully.
+
+- [ ] **Step 2: Replace the configured navigation and favicon asset**
+
+In `docs/.vitepress/config.mts`, use this favicon entry:
+
+```ts
+{
+  rel: "icon",
+  type: "image/png",
+  href: "/RailKeeper/brand/railkeeper-mark.png",
+}
+```
+
+Use this theme logo value:
+
+```ts
+logo: "/brand/railkeeper-mark.png",
+```
+
+- [ ] **Step 3: Replace both hero assets**
+
+In both `docs/site/index.md` and `docs/site/de/index.md`, use:
+
+```yaml
+image:
+  src: /brand/railkeeper-logo.png
+  alt: RailKeeper
+```
+
+- [ ] **Step 4: Run the documentation contract and build**
+
+Run:
+
+```powershell
+cd docs
+npm.cmd run check
+```
+
+Expected: 19 tests pass, the document validator exits successfully, and the VitePress build
+completes without a dead-link or missing-asset error.
+
+- [ ] **Step 5: Perform browser acceptance**
+
+Run:
+
+```powershell
+cd docs
+npm.cmd run preview -- --host 127.0.0.1
+```
+
+Check `/RailKeeper/` and `/RailKeeper/de/` in light and dark mode at desktop and mobile widths.
+Expected: the navigation shows the official train signet; both heroes show the full official logo;
+images retain their proportions without clipping or horizontal overflow; all image requests stay on
+the local preview origin.
+
+- [ ] **Step 6: Commit the implementation**
+
+Run:
+
+```powershell
+git add docs/.vitepress/config.mts docs/site/index.md docs/site/de/index.md
+git commit -m "docs: use official RailKeeper logos"
+```

--- a/docs/superpowers/specs/2026-08-16-railkeeper-documentation-logo-design.md
+++ b/docs/superpowers/specs/2026-08-16-railkeeper-documentation-logo-design.md
@@ -1,0 +1,34 @@
+# RailKeeper Documentation Logo Design
+
+## Goal
+
+Replace the stylized placeholder logos on both documentation landing pages with the existing
+official RailKeeper assets. The change must preserve the current bilingual structure and responsive
+VitePress layout.
+
+## Considered approaches
+
+1. Use the full logo everywhere. This is visually consistent, but the wordmark becomes unreadable
+   in the compact navigation slot and duplicates the adjacent site title.
+2. Use only the train mark everywhere. This fits the navigation, but the prominent hero area would
+   still omit the official RailKeeper wordmark.
+3. Use each official asset according to its role. This keeps the navigation compact and gives the
+   hero the complete brand presentation.
+
+The third approach is selected.
+
+## Design
+
+- Navigation uses `/brand/railkeeper-mark.png`, the official train signet without the wordmark.
+- English and German hero sections use `/brand/railkeeper-logo.png`, the complete official logo.
+- The favicon follows the navigation mark for consistent browser branding.
+- Existing headings, buttons, navigation, translations, colors, and layout remain unchanged.
+- Existing responsive image constraints remain in place unless visual verification shows clipping
+  or distortion. Any sizing adjustment must stay limited to the documentation theme.
+
+## Verification
+
+- Run the complete documentation check and production build.
+- Inspect English and German landing pages in light and dark mode.
+- Check desktop and mobile widths for correct proportions, no clipping, and no horizontal overflow.
+- Confirm both assets load from the repository and no external image request is introduced.


### PR DESCRIPTION
## Summary

- replace the documentation navigation icon and favicon with the official RailKeeper train signet
- replace both English and German landing-page hero graphics with the complete official RailKeeper logo
- preserve the original PNG proportions with documentation-scoped `object-fit: contain` rules

## Impact

The public documentation now uses the existing official RailKeeper branding instead of the temporary SVG artwork. No copy, navigation, layout structure, or external asset source changes.

## Validation

- `npm.cmd ci --cache ..\.cache\npm-docs` (0 vulnerabilities)
- `npm.cmd run check` (19 tests and VitePress build)
- desktop and mobile browser QA in light and dark mode
- English and German landing pages verified
- no horizontal overflow; favicon and images load from the local brand directory