### PR TITLE
docs: add getting started user guide

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -42,7 +42,10 @@ export default defineConfig({
           "/de/guide/": [
             {
               text: "Benutzerhandbuch",
-              items: [{ text: "Überblick", link: "/de/guide/" }],
+              items: [
+                { text: "Überblick", link: "/de/guide/" },
+                { text: "Erste Schritte", link: "/de/guide/getting-started/" },
+              ],
             },
           ],
           "/de/administration/": [
@@ -105,7 +108,10 @@ export default defineConfig({
       "/guide/": [
         {
           text: "User Guide",
-          items: [{ text: "Overview", link: "/guide/" }],
+          items: [
+            { text: "Overview", link: "/guide/" },
+            { text: "Getting started", link: "/guide/getting-started/" },
+          ],
         },
       ],
       "/administration/": [

--- a/docs/coverage.json
+++ b/docs/coverage.json
@@ -4,7 +4,7 @@
     {
       "id": "setup-auth",
       "audience": "user",
-      "status": "planned",
+      "status": "documented",
       "englishPath": "guide/getting-started/index.md",
       "germanPath": "de/guide/getting-started/index.md"
     },

--- a/docs/site/de/guide/getting-started/index.md
+++ b/docs/site/de/guide/getting-started/index.md
@@ -76,11 +76,15 @@ Die Passwort-Wiederherstellung verwendet die für das Konto gespeicherte E-Mail-
 5. Gib ein neues Passwort mit mindestens 12 Zeichen ein und wiederhole es.
 6. Setze das Passwort, kehre zur Anmeldung zurück und verwende die neuen Zugangsdaten.
 
-Die Antwort auf eine Reset-Anfrage ist für bekannte und unbekannte Adressen absichtlich identisch.
-Sie bestätigt nicht, ob ein Konto existiert. Bei eingerichtetem SMTP-Versand sendet RailKeeper den
-Link per E-Mail. Ohne SMTP kann der Betreiber die lokale Wiederherstellungs-URL dem RailKeeper-
-Serverprotokoll entnehmen. Wende dich an einen Administrator oder Betreiber, wenn keine Nachricht
-ankommt.
+Die im Anmeldeformular angezeigte Bestätigung ist für bekannte und unbekannte Adressen absichtlich
+identisch. Die HTTP-Antwort von v0.1.17.6 enthält jedoch nur bei einem bekannten Konto den Wert
+`expiresAt`. API-Clients oder Personen, die Netzwerkantworten untersuchen, können daraus ableiten,
+ob ein Konto existiert. Betreiber müssen dies als bekannte Einschränkung beim Schutz vor
+Kontenermittlung in dieser Version behandeln.
+
+Bei eingerichtetem SMTP-Versand sendet RailKeeper den Link per E-Mail. Ohne SMTP kann der Betreiber
+die lokale Wiederherstellungs-URL dem RailKeeper-Serverprotokoll entnehmen. Wende dich an einen
+Administrator oder Betreiber, wenn keine Nachricht ankommt.
 
 Nur die neueste offene Reset-Anfrage bleibt gültig. Ein Wiederherstellungslink läuft nach 30
 Minuten ab und kann einmal verwendet werden. Der erfolgreiche Reset widerruft alle bestehenden
@@ -97,17 +101,20 @@ Reset-Bestätigungen auf zehn innerhalb von zehn Minuten.
 | Die Ersteinrichtung wird abgelehnt | Prüfe die Mindestlänge von 3 Zeichen für den Benutzernamen, das E-Mail-Format, die Mindestlänge von 12 Zeichen für das Passwort und beide Passworteingaben. Warte nach wiederholten Versuchen das zehnminütige Begrenzungsfenster ab. |
 | Die Anmeldung meldet ungültige Zugangsdaten | Prüfe Benutzername und Passwort. RailKeeper verwendet für ein unbekanntes Konto und ein falsches Passwort absichtlich dieselbe Meldung. |
 | RailKeeper verlangt einen Zwei-Faktor-Code | Für das Konto ist Zwei-Faktor-Authentifizierung aktiviert. Gib den aktuellen Code aus der Authenticator-App ein. Ein falscher oder abgelaufener Code wird als ungültige Zugangsdaten gemeldet. |
-| Es kommt keine E-Mail zur Passwort-Wiederherstellung an | Prüfe Adresse und Spam-Ordner und wende dich danach an einen Administrator. SMTP ist möglicherweise nicht eingerichtet, und die allgemeine Antwort bestätigt nicht, dass das Konto existiert. |
+| Es kommt keine E-Mail zur Passwort-Wiederherstellung an | Prüfe Adresse und Spam-Ordner und wende dich danach an einen Administrator. SMTP ist möglicherweise nicht eingerichtet, und die im Formular angezeigte Bestätigung bestätigt nicht, dass das Konto existiert. |
 | Ein Reset-Link ist ungültig oder abgelaufen | Fordere einen neuen Link an. Frühere Links werden durch eine neuere Anfrage, nach 30 Minuten oder nach der ersten Verwendung ungültig. |
 | RailKeeper meldet zu viele Versuche | Sende das Formular nicht weiter ab und warte das zutreffende fünf- oder zehnminütige Begrenzungsfenster ab. |
 
 ## Sicherheitshinweise
 
-- Verwende ein einmaliges Passwort und teile keine Administrator-Zugangsdaten.
+- Verwende ein nur für RailKeeper genutztes, nicht wiederverwendetes Passwort und teile keine
+  Administrator-Zugangsdaten.
 - Verwende HTTPS und sichere Cookies, wenn die Instanz über ein Netzwerk erreichbar ist. Die
   Betriebsanforderungen stehen unter [Installation und Administration](/de/administration/).
-- Die allgemeine Reset-Antwort schützt Kontoinformationen. Sie darf nicht dazu verwendet werden,
-  registrierte E-Mail-Adressen zu ermitteln.
+- Die allgemeine Formularmeldung bietet in v0.1.17.6 keinen vollständigen Schutz vor
+  Kontenermittlung, weil sich die HTTP-Antwort für bekannte Konten unterscheidet. Begrenze den
+  Netzwerkzugriff, überwache wiederholte Reset-Anfragen und installiere eine Version mit korrigiertem
+  Verhalten, sobald sie verfügbar ist.
 - Bitte einen Administrator, unerwartete Anmelde- oder Wiederherstellungsaktivität zu prüfen, statt
   weiterhin Zugangsdaten zu erraten.
 

--- a/docs/site/de/guide/getting-started/index.md
+++ b/docs/site/de/guide/getting-started/index.md
@@ -1,0 +1,122 @@
+---
+title: Ersteinrichtung und Anmeldung
+description: Ersten Administrator anlegen, sicher anmelden und den Zugang zu RailKeeper wiederherstellen.
+audience: user
+status: stable
+reviewedVersion: 0.1.17.6
+lastReviewed: 2026-08-16
+---
+
+# Ersteinrichtung und Anmeldung
+
+Dieses Kapitel erklärt das erste Administratorkonto, die normale Anmeldung und Anmeldung mit
+Zwei-Faktor-Code, die Abmeldung sowie die Passwort-Wiederherstellung. Es beschreibt den stabilen
+RailKeeper-Stand v0.1.17.6.
+
+## Voraussetzungen
+
+RailKeeper muss bereits installiert und im Browser erreichbar sein. Das Formular zur
+Ersteinrichtung erscheint nur, solange die RailKeeper-Datenbank kein Benutzerkonto enthält.
+RailKeeper besitzt keinen vorgegebenen Benutzernamen und kein Standardpasswort.
+
+Erscheint stattdessen die Anmeldung, wurde die Ersteinrichtung bereits abgeschlossen. Melde dich
+mit einem bestehenden Konto an oder wende dich an die Person, die diese Instanz betreibt.
+
+## Ersten Administrator anlegen
+
+Für die einmalige Ersteinrichtung ist kein vorhandenes Konto und keine Rolle erforderlich.
+
+1. Öffne RailKeeper im Browser.
+2. Fülle alle Felder unter **Ersteinrichtung** aus.
+
+   | Feld | Anforderung | Zweck |
+   | --- | --- | --- |
+   | Benutzername | Erforderlich, nach Entfernen äußerer Leerzeichen mindestens 3 Zeichen | Identifiziert das Konto bei der Anmeldung |
+   | E-Mail-Adresse | Erforderlich, gültige E-Mail-Adresse | Empfängt Wiederherstellungslinks, wenn der E-Mail-Versand eingerichtet ist |
+   | Passwort | Erforderlich, mindestens 12 Zeichen | Schützt das erste Konto |
+   | Passwort wiederholen | Erforderlich und identisch mit **Passwort** | Verhindert einen unbemerkten Tippfehler |
+
+3. Wähle **Admin erstellen**.
+4. Verwende nach erfolgreicher Ersteinrichtung das normale Anmeldeformular mit den neuen
+   Zugangsdaten.
+
+Das erste Konto erhält die Rollen Admin, Editor und Viewer. Die Ersteinrichtung kann keinen zweiten
+ersten Administrator anlegen. Zum Schutz vor wiederholten Versuchen akzeptiert RailKeeper höchstens
+fünf Einrichtungsversuche pro Client-Adresse innerhalb von zehn Minuten.
+
+## Anmelden
+
+1. Gib **Benutzername** und **Passwort** ein.
+2. Wähle **Anmelden**.
+3. Ist für das Konto die Zwei-Faktor-Authentifizierung aktiviert, zeigt RailKeeper jetzt das Feld
+   **Zwei-Faktor-Code** an. Gib den aktuellen Code aus der eingerichteten Authenticator-App ein und
+   wähle erneut **Anmelden**.
+
+Eine erfolgreiche Anmeldung erzeugt eine serverseitige Sitzung mit einer Laufzeit von bis zu zwölf
+Stunden. Benutzer mit den Rollen Admin, Editor, Viewer oder Planner starten in der **Übersicht**.
+Ein Konto, das ausschließlich die Rolle Messe besitzt, startet unter **Ausstellung**.
+
+RailKeeper akzeptiert höchstens zehn Anmeldeanfragen von einer Client-Adresse innerhalb von fünf
+Minuten. Warte vor dem nächsten Versuch, statt das Formular wiederholt abzusenden.
+
+## Abmelden
+
+Verwende das Abmeldesymbol in der Fußzeile der Seitenleiste. RailKeeper widerruft die aktuelle
+serverseitige Sitzung und kehrt zum Anmeldeformular zurück. Das bloße Schließen des Browser-Tabs
+meldet die Sitzung nicht ausdrücklich ab.
+
+## Vergessenes Passwort wiederherstellen
+
+Die Passwort-Wiederherstellung verwendet die für das Konto gespeicherte E-Mail-Adresse.
+
+1. Wähle im Anmeldeformular **Passwort vergessen?**.
+2. Gib die E-Mail-Adresse des Kontos ein.
+3. Wähle **Reset anfordern**.
+4. Öffne den neuesten empfangenen Wiederherstellungslink.
+5. Gib ein neues Passwort mit mindestens 12 Zeichen ein und wiederhole es.
+6. Setze das Passwort, kehre zur Anmeldung zurück und verwende die neuen Zugangsdaten.
+
+Die Antwort auf eine Reset-Anfrage ist für bekannte und unbekannte Adressen absichtlich identisch.
+Sie bestätigt nicht, ob ein Konto existiert. Bei eingerichtetem SMTP-Versand sendet RailKeeper den
+Link per E-Mail. Ohne SMTP kann der Betreiber die lokale Wiederherstellungs-URL dem RailKeeper-
+Serverprotokoll entnehmen. Wende dich an einen Administrator oder Betreiber, wenn keine Nachricht
+ankommt.
+
+Nur die neueste offene Reset-Anfrage bleibt gültig. Ein Wiederherstellungslink läuft nach 30
+Minuten ab und kann einmal verwendet werden. Der erfolgreiche Reset widerruft alle bestehenden
+Sitzungen dieses Benutzers, auch in anderen Browsern.
+
+RailKeeper begrenzt Reset-Anfragen auf fünf pro Client-Adresse innerhalb von zehn Minuten und
+Reset-Bestätigungen auf zehn innerhalb von zehn Minuten.
+
+## Fehlerbehebung
+
+| Problem | Ursache und Maßnahme |
+| --- | --- |
+| Das Formular zur Ersteinrichtung erscheint nicht | Es existiert bereits mindestens ein Benutzer. Verwende die Anmeldung oder wende dich an den Betreiber. |
+| Die Ersteinrichtung wird abgelehnt | Prüfe die Mindestlänge von 3 Zeichen für den Benutzernamen, das E-Mail-Format, die Mindestlänge von 12 Zeichen für das Passwort und beide Passworteingaben. Warte nach wiederholten Versuchen das zehnminütige Begrenzungsfenster ab. |
+| Die Anmeldung meldet ungültige Zugangsdaten | Prüfe Benutzername und Passwort. RailKeeper verwendet für ein unbekanntes Konto und ein falsches Passwort absichtlich dieselbe Meldung. |
+| RailKeeper verlangt einen Zwei-Faktor-Code | Für das Konto ist Zwei-Faktor-Authentifizierung aktiviert. Gib den aktuellen Code aus der Authenticator-App ein. Ein falscher oder abgelaufener Code wird als ungültige Zugangsdaten gemeldet. |
+| Es kommt keine E-Mail zur Passwort-Wiederherstellung an | Prüfe Adresse und Spam-Ordner und wende dich danach an einen Administrator. SMTP ist möglicherweise nicht eingerichtet, und die allgemeine Antwort bestätigt nicht, dass das Konto existiert. |
+| Ein Reset-Link ist ungültig oder abgelaufen | Fordere einen neuen Link an. Frühere Links werden durch eine neuere Anfrage, nach 30 Minuten oder nach der ersten Verwendung ungültig. |
+| RailKeeper meldet zu viele Versuche | Sende das Formular nicht weiter ab und warte das zutreffende fünf- oder zehnminütige Begrenzungsfenster ab. |
+
+## Sicherheitshinweise
+
+- Verwende ein einmaliges Passwort und teile keine Administrator-Zugangsdaten.
+- Verwende HTTPS und sichere Cookies, wenn die Instanz über ein Netzwerk erreichbar ist. Die
+  Betriebsanforderungen stehen unter [Installation und Administration](/de/administration/).
+- Die allgemeine Reset-Antwort schützt Kontoinformationen. Sie darf nicht dazu verwendet werden,
+  registrierte E-Mail-Adressen zu ermitteln.
+- Bitte einen Administrator, unerwartete Anmelde- oder Wiederherstellungsaktivität zu prüfen, statt
+  weiterhin Zugangsdaten zu erraten.
+
+## Verwandte Seiten
+
+- [Überblick des Benutzerhandbuchs](/de/guide/)
+- [Installation und Administration](/de/administration/)
+
+## Dokumentierter RailKeeper-Stand
+
+Diese Seite dokumentiert den stabilen RailKeeper-Stand **v0.1.17.6** und wurde zuletzt am
+2026-08-16 mit der Anwendung abgeglichen.

--- a/docs/site/de/guide/index.md
+++ b/docs/site/de/guide/index.md
@@ -4,7 +4,7 @@ description: Alle stabilen Arbeitsabläufe in RailKeeper kennenlernen.
 audience: user
 status: stable
 reviewedVersion: 0.1.17.6
-lastReviewed: 2026-08-15
+lastReviewed: 2026-08-16
 ---
 
 # Benutzerhandbuch
@@ -15,3 +15,9 @@ Decoderdaten, Wartung, Dokumente, Berichte, Ausstellungen sowie kontrollierten I
 
 Die Inhalte dieses Bereichs beschreiben RailKeeper v0.1.17.6. Der Anlagen-Arbeitsbereich befindet
 sich noch in Entwicklung und wird deshalb nicht als stabile Benutzerfunktion dargestellt.
+
+## Hier beginnen
+
+[Ersteinrichtung und Anmeldung](/de/guide/getting-started/) erklärt, wie der erste Administrator
+angelegt wird, die An- und Abmeldung funktioniert, eine Anmeldung mit Zwei-Faktor-Code abgeschlossen
+und ein vergessenes Passwort wiederhergestellt wird.

--- a/docs/site/guide/getting-started/index.md
+++ b/docs/site/guide/getting-started/index.md
@@ -1,0 +1,118 @@
+---
+title: First setup and sign-in
+description: Create the first administrator, sign in securely, and recover access to RailKeeper.
+audience: user
+status: stable
+reviewedVersion: 0.1.17.6
+lastReviewed: 2026-08-16
+---
+
+# First setup and sign-in
+
+This chapter covers the first administrator account, normal and two-factor sign-in, sign-out, and
+password recovery. It describes stable RailKeeper v0.1.17.6.
+
+## Before you start
+
+RailKeeper must already be installed and reachable in your browser. The first-setup form appears
+only while the RailKeeper database contains no user account. RailKeeper has no default username or
+password.
+
+If a sign-in form appears instead, setup has already been completed. Sign in with an existing
+account or contact the person who operates the instance.
+
+## Create the first administrator
+
+No existing account or role is required for the one-time setup.
+
+1. Open RailKeeper in your browser.
+2. Complete every field on the **First Setup** form.
+
+   | Field | Requirement | Purpose |
+   | --- | --- | --- |
+   | Username | Required, at least 3 characters after surrounding spaces are removed | Identifies the account at sign-in |
+   | Email address | Required, valid email address | Receives password-recovery links when email delivery is configured |
+   | Password | Required, at least 12 characters | Protects the first account |
+   | Repeat password | Required and identical to **Password** | Prevents an unnoticed typing error |
+
+3. Select **Create admin**.
+4. After RailKeeper confirms the setup, use the normal sign-in form with the new credentials.
+
+The first account receives the Admin, Editor, and Viewer roles. Setup cannot create a second first
+administrator. For protection against repeated attempts, RailKeeper accepts at most five setup
+attempts per client address within ten minutes.
+
+## Sign in
+
+1. Enter your **Username** and **Password**.
+2. Select **Sign in**.
+3. If two-factor authentication is enabled for the account, RailKeeper now shows the
+   **Two-factor code** field. Enter the current code from the configured authenticator and select
+   **Sign in** again.
+
+A successful sign-in creates a server-side session that lasts for up to 12 hours. Admin, Editor,
+Viewer, and Planner users start on **Overview**. An account that has only the Messe role starts on
+**Exhibition**.
+
+RailKeeper accepts at most ten sign-in requests from one client address within five minutes. Wait
+before trying again instead of repeatedly submitting the form.
+
+## Sign out
+
+Use the log-out icon in the sidebar footer. RailKeeper revokes the current server-side session and
+returns to the sign-in form. Closing only the browser tab does not explicitly sign out the session.
+
+## Recover a forgotten password
+
+Password recovery depends on the email address stored for the account.
+
+1. On the sign-in form, select **Forgot password?**.
+2. Enter the account email address.
+3. Select **Request reset**.
+4. Open the newest reset link you receive.
+5. Enter and repeat a new password with at least 12 characters.
+6. Set the password, return to sign-in, and use the new credentials.
+
+The response to a reset request is deliberately identical for known and unknown addresses. It does
+not confirm whether an account exists. When SMTP is configured, RailKeeper sends the link by email.
+Without SMTP, the operator can obtain the local recovery URL from the RailKeeper server log. Contact
+an administrator or operator if no message arrives.
+
+Only the newest open reset request remains valid. A reset link expires after 30 minutes and can be
+used once. Completing the reset revokes every existing session for that user, including sessions in
+other browsers.
+
+RailKeeper limits reset requests to five per client address within ten minutes and reset
+confirmations to ten within ten minutes.
+
+## Troubleshooting
+
+| Problem | Cause and action |
+| --- | --- |
+| The first-setup form does not appear | At least one user already exists. Use the sign-in form or contact the operator. |
+| Setup is rejected | Check the 3-character username minimum, the email format, the 12-character password minimum, and both password entries. If attempts were repeated, wait for the ten-minute rate-limit window. |
+| Sign-in reports invalid credentials | Check the username and password. RailKeeper deliberately uses the same error for an unknown account and a wrong password. |
+| RailKeeper asks for a two-factor code | The account has two-factor authentication enabled. Enter the current code from its authenticator. A wrong or expired code is reported as invalid credentials. |
+| No password-reset email arrives | Check the address and spam folder, then contact an administrator. SMTP may not be configured, and the generic response does not confirm that the account exists. |
+| A reset link is invalid or expired | Request a new link. Earlier links become invalid when a newer request is created, after 30 minutes, or after first use. |
+| RailKeeper reports too many attempts | Stop submitting the form and wait for the applicable five-minute or ten-minute rate-limit window. |
+
+## Security notes
+
+- Use a unique password and do not share administrator credentials.
+- Use HTTPS and secure cookies when the instance is reachable over a network. See
+  [Installation and Administration](/administration/) for the operating requirements.
+- The generic reset response protects account information. It must not be used to determine which
+  email addresses are registered.
+- Ask an administrator to review unexpected sign-in or recovery activity rather than continuing to
+  guess credentials.
+
+## Related pages
+
+- [User Guide overview](/guide/)
+- [Installation and Administration](/administration/)
+
+## Documented RailKeeper version
+
+This page documents stable RailKeeper **v0.1.17.6** and was last checked against the application on
+2026-08-16.

--- a/docs/site/guide/getting-started/index.md
+++ b/docs/site/guide/getting-started/index.md
@@ -73,10 +73,14 @@ Password recovery depends on the email address stored for the account.
 5. Enter and repeat a new password with at least 12 characters.
 6. Set the password, return to sign-in, and use the new credentials.
 
-The response to a reset request is deliberately identical for known and unknown addresses. It does
-not confirm whether an account exists. When SMTP is configured, RailKeeper sends the link by email.
-Without SMTP, the operator can obtain the local recovery URL from the RailKeeper server log. Contact
-an administrator or operator if no message arrives.
+The confirmation shown in the sign-in form is deliberately identical for known and unknown
+addresses. However, the v0.1.17.6 HTTP response includes an `expiresAt` value only for a known
+account. API clients or people inspecting network responses can therefore infer whether an account
+exists. Operators must treat this as a known account-enumeration limitation of this release.
+
+When SMTP is configured, RailKeeper sends the link by email. Without SMTP, the operator can obtain
+the local recovery URL from the RailKeeper server log. Contact an administrator or operator if no
+message arrives.
 
 Only the newest open reset request remains valid. A reset link expires after 30 minutes and can be
 used once. Completing the reset revokes every existing session for that user, including sessions in
@@ -93,7 +97,7 @@ confirmations to ten within ten minutes.
 | Setup is rejected | Check the 3-character username minimum, the email format, the 12-character password minimum, and both password entries. If attempts were repeated, wait for the ten-minute rate-limit window. |
 | Sign-in reports invalid credentials | Check the username and password. RailKeeper deliberately uses the same error for an unknown account and a wrong password. |
 | RailKeeper asks for a two-factor code | The account has two-factor authentication enabled. Enter the current code from its authenticator. A wrong or expired code is reported as invalid credentials. |
-| No password-reset email arrives | Check the address and spam folder, then contact an administrator. SMTP may not be configured, and the generic response does not confirm that the account exists. |
+| No password-reset email arrives | Check the address and spam folder, then contact an administrator. SMTP may not be configured, and the confirmation displayed by the form does not confirm that the account exists. |
 | A reset link is invalid or expired | Request a new link. Earlier links become invalid when a newer request is created, after 30 minutes, or after first use. |
 | RailKeeper reports too many attempts | Stop submitting the form and wait for the applicable five-minute or ten-minute rate-limit window. |
 
@@ -102,8 +106,9 @@ confirmations to ten within ten minutes.
 - Use a unique password and do not share administrator credentials.
 - Use HTTPS and secure cookies when the instance is reachable over a network. See
   [Installation and Administration](/administration/) for the operating requirements.
-- The generic reset response protects account information. It must not be used to determine which
-  email addresses are registered.
+- The generic message shown by the form is not complete account-enumeration protection in
+  v0.1.17.6 because the HTTP response schema differs for known accounts. Restrict network access,
+  monitor repeated reset attempts, and apply a release that corrects this behavior when available.
 - Ask an administrator to review unexpected sign-in or recovery activity rather than continuing to
   guess credentials.
 

--- a/docs/site/guide/index.md
+++ b/docs/site/guide/index.md
@@ -4,7 +4,7 @@ description: Learn every stable RailKeeper workflow.
 audience: user
 status: stable
 reviewedVersion: 0.1.17.6
-lastReviewed: 2026-08-15
+lastReviewed: 2026-08-16
 ---
 
 # User Guide
@@ -15,3 +15,8 @@ documents, reports, exhibitions, and controlled import and export.
 
 Content in this section describes stable RailKeeper v0.1.17.6. The layout workspace is still under
 development and is therefore not presented as a stable user feature.
+
+## Start here
+
+[First setup and sign-in](/guide/getting-started/) explains how to create the first administrator,
+sign in and out, complete a two-factor sign-in, and recover a forgotten password.

--- a/docs/superpowers/plans/2026-08-16-railkeeper-user-guide-getting-started.md
+++ b/docs/superpowers/plans/2026-08-16-railkeeper-user-guide-getting-started.md
@@ -1,0 +1,189 @@
+# RailKeeper User Guide Getting Started Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish a complete English and German guide for first setup, sign-in, sign-out, optional
+two-factor sign-in, and password recovery in stable RailKeeper v0.1.17.6.
+
+**Architecture:** Add one paired user-guide page at the paths already reserved by the coverage
+matrix. Link the pair from both user-guide sidebars and landing pages, then change only the
+`setup-auth` coverage topic from `planned` to `documented`. The pages describe verified user-facing
+behavior and link to existing overview pages for administrative prerequisites that belong to later
+documentation stages.
+
+**Tech Stack:** VitePress 2, Markdown with validated frontmatter, Node.js documentation checks,
+React/TypeScript and Go sources as the behavior contract.
+
+## Global Constraints
+
+- English remains the public root locale; German uses the `/de/` prefix.
+- English and German pages use identical relative paths below `docs/site/` and `docs/site/de/`.
+- User content documents stable RailKeeper `0.1.17.6`, not unpublished `main` behavior.
+- Both pages use `audience: user`, `status: stable`, `reviewedVersion: 0.1.17.6`, and
+  `lastReviewed: 2026-08-16`.
+- The two language versions must be semantically equivalent, not literal machine translations.
+- Do not document user management, two-factor setup, session administration, or SMTP setup as part
+  of this chapter. Mention these only as prerequisites or related administrative work.
+- Do not claim that a password-reset email is always sent. The public response intentionally does
+  not reveal whether the entered address belongs to an account.
+- Do not include credentials, reset tokens, real email addresses, private paths, or productive
+  data.
+- Keep generated output, `docs/.vitepress/dist`, and `docs/node_modules` out of Git.
+
+---
+
+### Task 1: Publish the paired first-setup and sign-in guide
+
+**Files:**
+
+- Create: `docs/site/guide/getting-started/index.md`
+- Create: `docs/site/de/guide/getting-started/index.md`
+- Modify: `docs/site/guide/index.md`
+- Modify: `docs/site/de/guide/index.md`
+- Modify: `docs/.vitepress/config.mts`
+- Modify: `docs/coverage.json`
+
+**Interfaces:**
+
+- Consumes: the `setup-auth` coverage topic, `SetupView`, `LoginView`, application startup routing,
+  setup/auth API handlers, and stable version metadata.
+- Produces: `/guide/getting-started/`, `/de/guide/getting-started/`, paired sidebar entries, and a
+  `documented` coverage status for `setup-auth`.
+
+- [ ] **Step 1: Make the coverage contract fail for the missing pages**
+
+Change only the `setup-auth` topic in `docs/coverage.json`:
+
+```json
+{
+  "id": "setup-auth",
+  "audience": "user",
+  "status": "documented",
+  "englishPath": "guide/getting-started/index.md",
+  "germanPath": "de/guide/getting-started/index.md"
+}
+```
+
+- [ ] **Step 2: Verify the contract rejects the missing destinations**
+
+Run:
+
+```powershell
+cd docs
+npm.cmd run check
+```
+
+Expected: failure naming the missing English and German `setup-auth` pages.
+
+- [ ] **Step 3: Write the English page**
+
+Create `docs/site/guide/getting-started/index.md` with the required frontmatter and these exact
+content requirements:
+
+1. Title `First setup and sign-in` and a short scope paragraph.
+2. `Before you start`:
+   - RailKeeper must already be installed and reachable in a browser.
+   - The setup form appears only while the database has no user.
+   - There are no default credentials.
+3. `Create the first administrator`:
+   - no existing role is required;
+   - username is required and at least 3 characters after surrounding whitespace is removed;
+   - email is required and valid because password recovery uses it;
+   - password and repetition are required, identical, and at least 12 characters;
+   - submit with `Create admin`, then use the normal sign-in page;
+   - the first account receives Admin, Editor, and Viewer roles;
+   - setup is one-time and limited to five attempts per client address in ten minutes.
+4. `Sign in`:
+   - enter username and password;
+   - when two-factor authentication is enabled, the code field appears after the first submission;
+   - enter the current authenticator code and submit again;
+   - a successful session lasts up to 12 hours;
+   - Admin, Editor, Viewer, and Planner users start on Overview, Messe-only users on Exhibition.
+5. `Sign out`:
+   - use the log-out icon in the sidebar footer;
+   - signing out revokes the current server-side session and returns to sign-in.
+6. `Recover a forgotten password`:
+   - open `Forgot password?`, enter the account email, and request the reset;
+   - the response stays identical for known and unknown addresses;
+   - configured SMTP sends a time-limited link; without SMTP, an operator can obtain the local
+     recovery URL from the server log;
+   - contact an administrator if no email arrives;
+   - the newest link invalidates earlier open reset requests, expires after 30 minutes, and is
+     single-use;
+   - set and repeat a password of at least 12 characters;
+   - completion revokes every existing session for that user.
+7. `Troubleshooting` table covering absent setup form, rejected setup, invalid sign-in, missing
+   two-factor code, missing reset email, invalid/expired reset link, and rate limiting.
+8. `Security notes` covering HTTPS for network-exposed instances, unique credentials, and the
+   deliberate account-enumeration protection of the generic reset response.
+9. `Related pages` linking to `/guide/` and `/administration/` only, so no link points to an
+   unpublished page.
+10. `Documented RailKeeper version` stating stable `v0.1.17.6` and review date 2026-08-16.
+
+Use interface labels exactly as shown by the English UI: `Create admin`, `Sign in`,
+`Forgot password?`, and `Request reset`.
+
+- [ ] **Step 4: Write the semantically equivalent German page**
+
+Create `docs/site/de/guide/getting-started/index.md` with matching frontmatter and the same facts,
+order, limits, security effects, troubleshooting cases, and related destinations. Use these German
+UI labels verbatim: `Admin erstellen`, `Anmelden`, `Passwort vergessen?`, and `Reset anfordern`.
+Use the heading `Ersteinrichtung und Anmeldung`.
+
+- [ ] **Step 5: Add both pages to the guide sidebars**
+
+In `docs/.vitepress/config.mts`, preserve the existing overview item and add the paired second item:
+
+```ts
+{ text: "Getting started", link: "/guide/getting-started/" }
+```
+
+```ts
+{ text: "Erste Schritte", link: "/de/guide/getting-started/" }
+```
+
+- [ ] **Step 6: Add a clear entry point to both guide landing pages**
+
+Append a `Start here` section to `docs/site/guide/index.md` that links to
+`/guide/getting-started/` and states that the chapter covers first administrator creation, sign-in,
+sign-out, two-factor sign-in, and password recovery. Add the equivalent `Hier beginnen` section to
+`docs/site/de/guide/index.md` linking to `/de/guide/getting-started/`. Update both landing-page
+`lastReviewed` values to `2026-08-16`.
+
+- [ ] **Step 7: Run the complete documentation check**
+
+Run:
+
+```powershell
+cd docs
+npm.cmd run check
+```
+
+Expected: 19 tests pass, coverage validation produces no errors, and VitePress builds both new
+routes without dead links.
+
+- [ ] **Step 8: Review the language pair and source fidelity**
+
+Check the pair against this source checklist:
+
+```text
+frontend/src/features/setup/SetupView.tsx
+frontend/src/features/auth/LoginView.tsx
+frontend/src/app/App.tsx
+backend/internal/application/setup.go
+backend/internal/application/auth.go
+backend/internal/api/auth_handlers.go
+```
+
+Expected: the two pages contain the same behavior; every numeric limit and security effect matches
+the sources; later administrative features are not expanded here.
+
+- [ ] **Step 9: Commit the content package**
+
+```powershell
+git add docs/site/guide docs/site/de/guide docs/.vitepress/config.mts docs/coverage.json
+git commit -m "docs: add getting started user guide"
+```
+

--- a/docs/superpowers/plans/2026-08-16-railkeeper-user-guide-getting-started.md
+++ b/docs/superpowers/plans/2026-08-16-railkeeper-user-guide-getting-started.md
@@ -26,8 +26,9 @@ React/TypeScript and Go sources as the behavior contract.
 - The two language versions must be semantically equivalent, not literal machine translations.
 - Do not document user management, two-factor setup, session administration, or SMTP setup as part
   of this chapter. Mention these only as prerequisites or related administrative work.
-- Do not claim that a password-reset email is always sent. The public response intentionally does
-  not reveal whether the entered address belongs to an account.
+- Do not claim that a password-reset email is always sent. The visible confirmation is identical
+  for known and unknown addresses, but stable v0.1.17.6 includes `expiresAt` only for known accounts
+  in the HTTP response. Document this account-enumeration limitation explicitly.
 - Do not include credentials, reset tokens, real email addresses, private paths, or productive
   data.
 - Keep generated output, `docs/.vitepress/dist`, and `docs/node_modules` out of Git.
@@ -106,7 +107,9 @@ content requirements:
    - signing out revokes the current server-side session and returns to sign-in.
 6. `Recover a forgotten password`:
    - open `Forgot password?`, enter the account email, and request the reset;
-   - the response stays identical for known and unknown addresses;
+   - the visible confirmation stays identical for known and unknown addresses;
+   - the v0.1.17.6 HTTP response can still reveal a known account through its optional `expiresAt`
+     field, which must be identified as a security limitation;
    - configured SMTP sends a time-limited link; without SMTP, an operator can obtain the local
      recovery URL from the server log;
    - contact an administrator if no email arrives;
@@ -117,7 +120,7 @@ content requirements:
 7. `Troubleshooting` table covering absent setup form, rejected setup, invalid sign-in, missing
    two-factor code, missing reset email, invalid/expired reset link, and rate limiting.
 8. `Security notes` covering HTTPS for network-exposed instances, unique credentials, and the
-   deliberate account-enumeration protection of the generic reset response.
+   incomplete account-enumeration protection of the v0.1.17.6 reset response.
 9. `Related pages` linking to `/guide/` and `/administration/` only, so no link points to an
    unpublished page.
 10. `Documented RailKeeper version` stating stable `v0.1.17.6` and review date 2026-08-16.
@@ -186,4 +189,3 @@ the sources; later administrative features are not expanded here.
 git add docs/site/guide docs/site/de/guide docs/.vitepress/config.mts docs/coverage.json
 git commit -m "docs: add getting started user guide"
 ```
-


### PR DESCRIPTION
## Summary

- add complete English and German guides for first setup, sign-in, sign-out, two-factor sign-in, and password recovery
- add paired user-guide sidebar and landing-page entry points
- mark the setup/auth coverage topic as documented
- document the v0.1.17.6 password-reset response limitation accurately

## Impact

This is the first complete Etappe 2 user-guide chapter. It changes documentation only and does not modify RailKeeper runtime behavior.

The security guidance distinguishes the generic message shown in the UI from the differing `expiresAt` HTTP response field in v0.1.17.6, so the handbook does not overstate account-enumeration protection.

## Validation

- `cd docs && npm.cmd run check`
- 19/19 documentation tests passed
- VitePress production build passed
- English and German routes rendered locally with paired sidebars and no horizontal overflow
- relevant setup/auth sources are unchanged from tag `v0.1.17.6`
- independent review: no Critical, Important, or Minor findings after correction
