### PR TITLE
docs: add overview and data quality guide

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -45,6 +45,7 @@ export default defineConfig({
               items: [
                 { text: "Überblick", link: "/de/guide/" },
                 { text: "Erste Schritte", link: "/de/guide/getting-started/" },
+                { text: "Dashboard und Datenqualität", link: "/de/guide/overview/" },
               ],
             },
           ],
@@ -111,6 +112,7 @@ export default defineConfig({
           items: [
             { text: "Overview", link: "/guide/" },
             { text: "Getting started", link: "/guide/getting-started/" },
+            { text: "Dashboard and data quality", link: "/guide/overview/" },
           ],
         },
       ],

--- a/docs/coverage.json
+++ b/docs/coverage.json
@@ -11,7 +11,7 @@
     {
       "id": "overview",
       "audience": "user",
-      "status": "planned",
+      "status": "documented",
       "englishPath": "guide/overview/index.md",
       "germanPath": "de/guide/overview/index.md"
     },

--- a/docs/site/de/guide/index.md
+++ b/docs/site/de/guide/index.md
@@ -21,3 +21,6 @@ sich noch in Entwicklung und wird deshalb nicht als stabile Benutzerfunktion dar
 [Ersteinrichtung und Anmeldung](/de/guide/getting-started/) erklärt, wie der erste Administrator
 angelegt wird, die An- und Abmeldung funktioniert, eine Anmeldung mit Zwei-Faktor-Code abgeschlossen
 und ein vergessenes Passwort wiederhergestellt wird.
+
+Fahre mit [Übersicht, Kennzahlen und Datenqualität](/de/guide/overview/) fort, um das Dashboard zu
+verstehen, Bestandslücken als gefilterte Fahrzeuglisten zu öffnen und die Kacheln anzuordnen.

--- a/docs/site/de/guide/overview/index.md
+++ b/docs/site/de/guide/overview/index.md
@@ -18,6 +18,10 @@ Benutzer mit den Rollen Admin, Editor, Viewer oder Planner können die Übersich
 das ausschließlich die Rolle Messe besitzt, startet unter **Ausstellung** und kann dieses Dashboard
 nicht aufrufen.
 
+Nur Benutzer mit der Rolle Admin oder Editor können Fahrzeugdaten ändern. Viewer und Planner
+können das Dashboard und gefilterte Ergebnisse prüfen, müssen fehlende Daten aber durch einen Admin
+oder Editor korrigieren lassen.
+
 ## Übersicht öffnen und aktualisieren
 
 Wähle **Übersicht** in der Seitenleiste. RailKeeper lädt die für die aktuelle Sitzung verfügbaren
@@ -35,7 +39,7 @@ Das Import/Export-Symbol im selben Seitenkopf öffnet **Import/Export**.
 
 | Kennzahl | Bedeutung |
 | --- | --- |
-| **Gesamtbestand** | Anzahl der Fahrzeuge. Die Zeile darunter meldet, wie viele Kategorie- und Spurweitengruppen in den jeweils fünf häufigsten Werten vorkommen. Bei mehr als fünf Werten ist dies nicht die Anzahl aller unterschiedlichen Werte. |
+| **Gesamtbestand** | Anzahl der Fahrzeuge. Die Zeile darunter meldet, wie viele Kategorie- und Spurweitengruppen in den jeweils fünf häufigsten Werten vorkommen. Fehlende Angaben bilden die Gruppen **Ohne Kategorie** und **Ohne Spur**. Bei mehr als fünf Werten ist dies nicht die Anzahl aller unterschiedlichen Werte. |
 | **Digitalisierung** | Digitale Fahrzeuge geteilt durch alle Fahrzeuge, auf ganze Prozent gerundet. Die Detailzeile zeigt die Anzahl digitaler und analoger Fahrzeuge. |
 | **Erfasster Listenwert** | Summe der auswertbaren, gepflegten Fahrzeug-Listenpreise. RailKeeper verarbeitet übliche Zahlenformate mit Komma oder Punkt und zeigt die Euro-Summe auf ganze Euro gerundet. Fehlende oder nicht auswertbare Preise zählen als null. Die Kennzahl ist keine Marktwertschätzung. |
 | **Wartung** | Anzahl nicht erledigter Wartungseinträge, deren Fälligkeitsdatum heute oder früher liegt. Die Detailzeile zeigt getrennt die in den nächsten 30 Tagen fälligen und alle offenen Einträge, einschließlich Einträgen ohne Fälligkeitsdatum. |
@@ -51,7 +55,8 @@ geändert und jede Kachel kann ausgeblendet werden.
 
 **Bestandsmix** zeigt bis zu fünf Kategorien mit den meisten Fahrzeugen. Fehlende Kategorien werden
 als **Ohne Kategorie** zusammengefasst. Der Balken zeigt den Anteil am Gesamtbestand, die Zahl die
-exakte Fahrzeuganzahl.
+exakte Fahrzeuganzahl. Ein Balken mit einem Wert größer null besitzt eine sichtbare Mindestbreite
+von 8 %. Kleine Kategorien können deshalb breiter als ihr exakter Prozentanteil erscheinen.
 
 ### Datenqualität
 
@@ -72,8 +77,9 @@ vollständig ist. Ohne Fahrzeuge stehen alle fünf Werte bei 0 %.
 
 ### Handlungsbedarf
 
-**Handlungsbedarf** zeigt Datenlücken mit einem Wert größer null. Wähle eine Zeile, um
-**Fahrzeuge** mit dem passenden aktiven Filter zu öffnen.
+**Handlungsbedarf** zeigt Datenlücken mit einem Wert größer null. Wähle eine Zeile, um den
+**Fahrzeugbestand**, dessen Seitenüberschrift **Bestand** lautet, mit dem passenden aktiven Filter
+zu öffnen.
 
 | Datenlücke | Ausgewählte Fahrzeuge |
 | --- | --- |
@@ -87,8 +93,8 @@ unterscheidet kein ausdrücklich ausgewähltes Hauptbild. Sind alle vier Werte n
 dass keine größeren Datenlücken erkannt wurden.
 
 Die Übersicht selbst besitzt keine allgemeine Suche und keine Filterleiste. Suche, kombinierte
-Filter und Änderungen erfolgen unter **Fahrzeuge**, nachdem eine Datenlücke gewählt oder der Bestand
-direkt geöffnet wurde.
+Filter und Änderungen erfolgen im **Fahrzeugbestand**, nachdem eine Datenlücke gewählt oder der
+Bestand direkt geöffnet wurde.
 
 ### Hersteller
 
@@ -99,7 +105,7 @@ unter **Ohne Hersteller** zusammengefasst.
 
 **Schnellaktionen** öffnet den nächsten Arbeitsbereich, ohne Daten zu ändern:
 
-- **Bestand pflegen** öffnet **Fahrzeuge**.
+- **Bestand pflegen** öffnet den **Fahrzeugbestand**.
 - **Import/Export** öffnet den Bereich zum Importieren, Exportieren und Drucken.
 - **Stammdaten prüfen** öffnet **Einstellungen**. Dort können berechtigte Benutzer Auswahlwerte und
   Einstellungen für Bestandsnummern verwalten.
@@ -110,9 +116,10 @@ zusätzliche Rolle.
 ### Wartungsradar
 
 **Wartungsradar** zeigt bis zu vier nicht erledigte Wartungseinträge mit Fälligkeitsdatum, sortiert
-nach dem nächsten Termin. Jede Zeile enthält Bestandsnummer, Fahrzeugname oder Wartungsart,
-Wartungsart, Fälligkeitshinweis und Datum. Heute fällige und überfällige Einträge werden
-hervorgehoben.
+nach dem frühesten Fälligkeitsdatum. Der am längsten überfällige Eintrag steht daher zuerst, danach
+folgen später überfällige, heute fällige und zukünftige Einträge. Jede Zeile enthält Bestandsnummer,
+Fahrzeugname oder Wartungsart, Wartungsart, Fälligkeitshinweis und Datum. Heute fällige und
+überfällige Einträge werden hervorgehoben.
 
 Die untere Zeile fasst zusammen:
 
@@ -136,26 +143,30 @@ Daten:
 4. Ersatzteile und strukturierte Preis-/Wertpflege erwägen, wenn keine frühere Bedingung zutrifft.
 
 Dies ist ein regelbasierter Hinweis und keine automatische Datenbewertung oder externe Empfehlung.
+Das Anlegen, Importieren und Ändern von Fahrzeugen erfordert die Rolle Admin oder Editor.
 
 ## Datenlücken bearbeiten
 
 1. Öffne **Handlungsbedarf** in der Übersicht.
 2. Wähle die passende Datenlücke.
-3. RailKeeper öffnet **Fahrzeuge** und aktiviert den zugehörigen Bestands- oder Qualitätsfilter.
-4. Öffne die betroffenen Datensätze und ergänze oder korrigiere die fehlenden Angaben.
+3. RailKeeper öffnet den **Fahrzeugbestand** und aktiviert den zugehörigen Bestands- oder
+   Qualitätsfilter.
+4. Öffne die betroffenen Datensätze. Ergänze oder korrigiere als Admin oder Editor die fehlenden
+   Angaben. Verwende als Viewer oder Planner das Ergebnis, um die Datensätze zu identifizieren, und
+   bitte einen Admin oder Editor um die Änderung.
 5. Kehre zur **Übersicht** zurück und aktualisiere das Dashboard.
 
-Das Zurücksetzen aller Filter unter **Fahrzeuge** entfernt den Datenlücken-Parameter aus der
-Browseradresse. Auch die Wahl eines anderen Qualitätsfilters entfernt ihn. Andere manuelle
-Filteränderungen können den ursprünglichen Parameter in der Adresse belassen, obwohl sich die
-sichtbare Auswahl bereits geändert hat.
+Bei einer Lücke für Artikelnummer, EAN oder Decoder entfernt das Schließen des aktiven
+Qualitätsfilter-Eintrags den Datenlücken-Parameter aus der Browseradresse. **Filter entfernen**
+entfernt ihn bei jeder Lücke. Andere manuelle Filteränderungen lassen die ursprüngliche Datenlücke
+aktiv und behalten den Parameter bei.
 
 ## Dashboard anordnen
 
 Jeder Kachelkopf enthält drei Bedienelemente:
 
-- Nach oben verschiebt die Kachel um eine Position nach vorn.
-- Nach unten verschiebt sie um eine Position nach hinten.
+- **Nach vorn** verschiebt die Kachel um eine Position nach vorn.
+- **Nach hinten** verschiebt sie um eine Position nach hinten.
 - Ausblenden entfernt die Kachel aus dem Dashboard.
 
 Sobald mindestens eine Kachel ausgeblendet wurde, erscheint das Zurücksetzen-Symbol im Seitenkopf.
@@ -170,7 +181,7 @@ gespeichert.
 
 | Situation | Anzeige in RailKeeper | Nächster Schritt |
 | --- | --- | --- |
-| Keine Fahrzeuge | Hauptkennzahlen mit null, leere Listen und Empfehlung zum Anlegen oder Importieren | Fahrzeuge anlegen oder eine Bestandsliste importieren |
+| Keine Fahrzeuge | Hauptkennzahlen mit null, leere Listen und Empfehlung zum Anlegen oder Importieren | Als Admin oder Editor Fahrzeuge anlegen oder eine Liste importieren. Als Viewer oder Planner eine dieser Rollen um das Befüllen des Bestands bitten. |
 | Keine offene Wartung mit Fälligkeitsdatum | Leerhinweis im Wartungsradar | Ein Fälligkeitsdatum ergänzen, wenn die Arbeit im Radar erscheinen soll |
 | Keine größeren Datenlücken | Bestätigung unter **Handlungsbedarf** | Mit Wartung oder weiteren Bestandsangaben fortfahren |
 | Alle Kacheln ausgeblendet | **Dashboard leer** mit **Layout zurücksetzen** | Layout zurücksetzen, um alle Kacheln wiederherzustellen |

--- a/docs/site/de/guide/overview/index.md
+++ b/docs/site/de/guide/overview/index.md
@@ -158,8 +158,10 @@ Das Anlegen, Importieren und Ändern von Fahrzeugen erfordert die Rolle Admin od
 
 Bei einer Lücke für Artikelnummer, EAN oder Decoder entfernt das Schließen des aktiven
 Qualitätsfilter-Eintrags den Datenlücken-Parameter aus der Browseradresse. **Filter entfernen**
-entfernt ihn bei jeder Lücke. Andere manuelle Filteränderungen lassen die ursprüngliche Datenlücke
-aktiv und behalten den Parameter bei.
+Andere Filtergruppen lassen diese Qualitätslücke aktiv und behalten den Parameter bei. Bei **Ohne
+Hauptbild** ersetzt die Wahl eines anderen Bestandsfilters die aktive Bildlücke, lässt aber den nun
+veralteten Parameter `gap=no-main-image` in der Adresse stehen. **Filter entfernen** entfernt den
+Parameter bei jeder Datenlücke.
 
 ## Dashboard anordnen
 

--- a/docs/site/de/guide/overview/index.md
+++ b/docs/site/de/guide/overview/index.md
@@ -1,0 +1,188 @@
+---
+title: Übersicht, Kennzahlen und Datenqualität
+description: RailKeeper-Dashboard auswerten, Datenlücken bearbeiten und Kacheln anordnen.
+audience: user
+status: stable
+reviewedVersion: 0.1.17.6
+lastReviewed: 2026-08-16
+---
+
+# Übersicht, Kennzahlen und Datenqualität
+
+Die **Übersicht** ist das Arbeits-Dashboard von RailKeeper für Bestandsgröße, erfassten Wert,
+Digitalisierung, Wartung und Datenqualität. Dieses Kapitel erklärt die Bedeutung jeder Kennzahl und
+den Weg von einem Hinweis zu den betroffenen Fahrzeugen. Es beschreibt den stabilen
+RailKeeper-Stand v0.1.17.6.
+
+Benutzer mit den Rollen Admin, Editor, Viewer oder Planner können die Übersicht öffnen. Ein Konto,
+das ausschließlich die Rolle Messe besitzt, startet unter **Ausstellung** und kann dieses Dashboard
+nicht aufrufen.
+
+## Übersicht öffnen und aktualisieren
+
+Wähle **Übersicht** in der Seitenleiste. RailKeeper lädt die für die aktuelle Sitzung verfügbaren
+Fahrzeuge und berechnet die Dashboard-Werte im Browser. Die Übersicht ist damit eine aktuelle
+Zusammenfassung der Fahrzeugdaten und kein separat gespeicherter Serverbericht.
+
+Verwende das Aktualisieren-Symbol im Seitenkopf, nachdem Fahrzeug- oder Wartungsdaten in einem
+anderen Bereich geändert wurden. Während des Ladens ist die Schaltfläche deaktiviert. Schlägt das
+Laden fehl, zeigt RailKeeper den Fehler oberhalb des Dashboards. Zuvor geladene Werte bleiben, wenn
+vorhanden, sichtbar. Prüfe deshalb den Fehler, bevor du dich auf diese Werte verlässt.
+
+Das Import/Export-Symbol im selben Seitenkopf öffnet **Import/Export**.
+
+## Die vier Hauptkennzahlen lesen
+
+| Kennzahl | Bedeutung |
+| --- | --- |
+| **Gesamtbestand** | Anzahl der Fahrzeuge. Die Zeile darunter meldet, wie viele Kategorie- und Spurweitengruppen in den jeweils fünf häufigsten Werten vorkommen. Bei mehr als fünf Werten ist dies nicht die Anzahl aller unterschiedlichen Werte. |
+| **Digitalisierung** | Digitale Fahrzeuge geteilt durch alle Fahrzeuge, auf ganze Prozent gerundet. Die Detailzeile zeigt die Anzahl digitaler und analoger Fahrzeuge. |
+| **Erfasster Listenwert** | Summe der auswertbaren, gepflegten Fahrzeug-Listenpreise. RailKeeper verarbeitet übliche Zahlenformate mit Komma oder Punkt und zeigt die Euro-Summe auf ganze Euro gerundet. Fehlende oder nicht auswertbare Preise zählen als null. Die Kennzahl ist keine Marktwertschätzung. |
+| **Wartung** | Anzahl nicht erledigter Wartungseinträge, deren Fälligkeitsdatum heute oder früher liegt. Die Detailzeile zeigt getrennt die in den nächsten 30 Tagen fälligen und alle offenen Einträge, einschließlich Einträgen ohne Fälligkeitsdatum. |
+
+Ohne Fahrzeuge sind Bestand und Wert null, Prozentkennzahlen werden mit 0 % angezeigt.
+
+## Dashboard-Kacheln verwenden
+
+Die folgenden sieben Kacheln verbinden Bestandshinweise und Schnellzugriffe. Ihre Reihenfolge kann
+geändert und jede Kachel kann ausgeblendet werden.
+
+### Bestandsmix
+
+**Bestandsmix** zeigt bis zu fünf Kategorien mit den meisten Fahrzeugen. Fehlende Kategorien werden
+als **Ohne Kategorie** zusammengefasst. Der Balken zeigt den Anteil am Gesamtbestand, die Zahl die
+exakte Fahrzeuganzahl.
+
+### Datenqualität
+
+**Datenqualität** zeigt den Anteil aller Fahrzeuge, die fünf einzelne Prüfungen erfüllen:
+
+| Kennzahl | Gilt als erfüllt, wenn |
+| --- | --- |
+| **Bilder** | Mindestens ein Bild für das Fahrzeug gespeichert ist |
+| **Decoder-Nummern** | Eines der beiden Decoder-Nummernfelder einen Wert enthält |
+| **Artikelnummern** | Das Artikelnummernfeld einen Wert enthält |
+| **EAN** | Das EAN-Feld einen Wert enthält |
+| **Voll dokumentiert** | Artikelnummer, EAN und mindestens ein Bild gemeinsam vorhanden sind |
+
+Jede Prozentangabe verwendet den Gesamtbestand als Bezugsgröße. **Decoder-Nummern** berücksichtigt
+daher auch analoge Fahrzeuge, wenn eines der beiden Decoder-Nummernfelder gefüllt ist. Umgekehrt
+erfordert **Voll dokumentiert** keine Decoder-Nummer und bestätigt nicht, dass jedes Fahrzeugfeld
+vollständig ist. Ohne Fahrzeuge stehen alle fünf Werte bei 0 %.
+
+### Handlungsbedarf
+
+**Handlungsbedarf** zeigt Datenlücken mit einem Wert größer null. Wähle eine Zeile, um
+**Fahrzeuge** mit dem passenden aktiven Filter zu öffnen.
+
+| Datenlücke | Ausgewählte Fahrzeuge |
+| --- | --- |
+| **Ohne Hauptbild** | Fahrzeuge ohne ein gespeichertes Bild |
+| **Ohne Artikel-Nr.** | Fahrzeuge ohne Artikelnummer |
+| **Ohne EAN** | Fahrzeuge ohne EAN |
+| **Digital ohne Decoder-Nr.** | Digitale Fahrzeuge ohne Wert in beiden Decoder-Nummernfeldern |
+
+In v0.1.17.6 prüft **Ohne Hauptbild** technisch, ob irgendein Bild vorhanden ist. Die Prüfung
+unterscheidet kein ausdrücklich ausgewähltes Hauptbild. Sind alle vier Werte null, meldet die Kachel,
+dass keine größeren Datenlücken erkannt wurden.
+
+Die Übersicht selbst besitzt keine allgemeine Suche und keine Filterleiste. Suche, kombinierte
+Filter und Änderungen erfolgen unter **Fahrzeuge**, nachdem eine Datenlücke gewählt oder der Bestand
+direkt geöffnet wurde.
+
+### Hersteller
+
+**Hersteller** ordnet bis zu fünf Hersteller nach Fahrzeuganzahl. Leere Herstellerangaben werden
+unter **Ohne Hersteller** zusammengefasst.
+
+### Schnellaktionen
+
+**Schnellaktionen** öffnet den nächsten Arbeitsbereich, ohne Daten zu ändern:
+
+- **Bestand pflegen** öffnet **Fahrzeuge**.
+- **Import/Export** öffnet den Bereich zum Importieren, Exportieren und Drucken.
+- **Stammdaten prüfen** öffnet **Einstellungen**. Dort können berechtigte Benutzer Auswahlwerte und
+  Einstellungen für Bestandsnummern verwalten.
+
+Am Ziel gelten weiterhin die Rechte des angemeldeten Benutzers. Eine Schnellaktion vergibt keine
+zusätzliche Rolle.
+
+### Wartungsradar
+
+**Wartungsradar** zeigt bis zu vier nicht erledigte Wartungseinträge mit Fälligkeitsdatum, sortiert
+nach dem nächsten Termin. Jede Zeile enthält Bestandsnummer, Fahrzeugname oder Wartungsart,
+Wartungsart, Fälligkeitshinweis und Datum. Heute fällige und überfällige Einträge werden
+hervorgehoben.
+
+Die untere Zeile fasst zusammen:
+
+- **Erledigt**: alle erledigten Wartungseinträge.
+- **Kosten**: Summe der auswertbaren Kosten aller Wartungseinträge, einschließlich erledigter
+  Einträge.
+- **Zustände**: Anzahl unterschiedlicher Zustandsbewertungen innerhalb der fünf häufigsten Werte.
+  Der angezeigte Wert ist deshalb auf fünf begrenzt.
+
+Besitzt keine offene Wartung ein Fälligkeitsdatum, zeigt das Radar seinen Leerzustand. Offene
+Wartungen ohne Datum zählen trotzdem zur Hauptkennzahl am oberen Seitenrand.
+
+### Nächster Mehrwert
+
+**Nächster Mehrwert** wählt nach einer festen Reihenfolge genau einen Hinweis aus den aktuellen
+Daten:
+
+1. Fahrzeuge anlegen oder importieren, wenn der Bestand leer ist.
+2. Bilder ergänzen, solange die Bildabdeckung unter 70 % liegt.
+3. Fällige Wartungen bearbeiten, sobald mindestens ein Eintrag heute fällig oder überfällig ist.
+4. Ersatzteile und strukturierte Preis-/Wertpflege erwägen, wenn keine frühere Bedingung zutrifft.
+
+Dies ist ein regelbasierter Hinweis und keine automatische Datenbewertung oder externe Empfehlung.
+
+## Datenlücken bearbeiten
+
+1. Öffne **Handlungsbedarf** in der Übersicht.
+2. Wähle die passende Datenlücke.
+3. RailKeeper öffnet **Fahrzeuge** und aktiviert den zugehörigen Bestands- oder Qualitätsfilter.
+4. Öffne die betroffenen Datensätze und ergänze oder korrigiere die fehlenden Angaben.
+5. Kehre zur **Übersicht** zurück und aktualisiere das Dashboard.
+
+Das Zurücksetzen aller Filter unter **Fahrzeuge** entfernt den Datenlücken-Parameter aus der
+Browseradresse. Auch die Wahl eines anderen Qualitätsfilters entfernt ihn. Andere manuelle
+Filteränderungen können den ursprünglichen Parameter in der Adresse belassen, obwohl sich die
+sichtbare Auswahl bereits geändert hat.
+
+## Dashboard anordnen
+
+Jeder Kachelkopf enthält drei Bedienelemente:
+
+- Nach oben verschiebt die Kachel um eine Position nach vorn.
+- Nach unten verschiebt sie um eine Position nach hinten.
+- Ausblenden entfernt die Kachel aus dem Dashboard.
+
+Sobald mindestens eine Kachel ausgeblendet wurde, erscheint das Zurücksetzen-Symbol im Seitenkopf.
+**Layout zurücksetzen** zeigt wieder alle sieben Kacheln und stellt ihre Standardreihenfolge her.
+Wurden alle Kacheln ausgeblendet, bietet auch der leere Dashboard-Bereich diese Schaltfläche an.
+
+Reihenfolge und ausgeblendete Kacheln werden im lokalen Speicher des aktuellen Browsers abgelegt.
+Sie werden nicht mit anderen Browsern geteilt und nicht als kontoweite Dashboard-Einstellung
+gespeichert.
+
+## Leere und besondere Zustände
+
+| Situation | Anzeige in RailKeeper | Nächster Schritt |
+| --- | --- | --- |
+| Keine Fahrzeuge | Hauptkennzahlen mit null, leere Listen und Empfehlung zum Anlegen oder Importieren | Fahrzeuge anlegen oder eine Bestandsliste importieren |
+| Keine offene Wartung mit Fälligkeitsdatum | Leerhinweis im Wartungsradar | Ein Fälligkeitsdatum ergänzen, wenn die Arbeit im Radar erscheinen soll |
+| Keine größeren Datenlücken | Bestätigung unter **Handlungsbedarf** | Mit Wartung oder weiteren Bestandsangaben fortfahren |
+| Alle Kacheln ausgeblendet | **Dashboard leer** mit **Layout zurücksetzen** | Layout zurücksetzen, um alle Kacheln wiederherzustellen |
+| Laden der Fahrzeuge fehlgeschlagen | Fehlertext oberhalb des Dashboards | Verbindung und Sitzung prüfen, danach erneut aktualisieren |
+
+## Verwandte Seiten
+
+- [Überblick zum Benutzerhandbuch](/de/guide/)
+- [Ersteinrichtung und Anmeldung](/de/guide/getting-started/)
+- [Überblick zur Administration](/de/administration/)
+
+## Dokumentierter RailKeeper-Stand
+
+Diese Seite dokumentiert den stabilen RailKeeper-Stand **v0.1.17.6** und wurde zuletzt am
+2026-08-16 geprüft.

--- a/docs/site/de/guide/overview/index.md
+++ b/docs/site/de/guide/overview/index.md
@@ -157,7 +157,7 @@ Das Anlegen, Importieren und Ändern von Fahrzeugen erfordert die Rolle Admin od
 5. Kehre zur **Übersicht** zurück und aktualisiere das Dashboard.
 
 Bei einer Lücke für Artikelnummer, EAN oder Decoder entfernt das Schließen des aktiven
-Qualitätsfilter-Eintrags den Datenlücken-Parameter aus der Browseradresse. **Filter entfernen**
+Qualitätsfilter-Eintrags den Datenlücken-Parameter aus der Browseradresse.
 Andere Filtergruppen lassen diese Qualitätslücke aktiv und behalten den Parameter bei. Bei **Ohne
 Hauptbild** ersetzt die Wahl eines anderen Bestandsfilters die aktive Bildlücke, lässt aber den nun
 veralteten Parameter `gap=no-main-image` in der Adresse stehen. **Filter entfernen** entfernt den

--- a/docs/site/guide/index.md
+++ b/docs/site/guide/index.md
@@ -20,3 +20,6 @@ development and is therefore not presented as a stable user feature.
 
 [First setup and sign-in](/guide/getting-started/) explains how to create the first administrator,
 sign in and out, complete a two-factor sign-in, and recover a forgotten password.
+
+Continue with [Overview, metrics, and data quality](/guide/overview/) to understand the dashboard,
+follow inventory gaps into filtered vehicle lists, and arrange its widgets.

--- a/docs/site/guide/overview/index.md
+++ b/docs/site/guide/overview/index.md
@@ -16,6 +16,9 @@ to continue from an indicator to the affected vehicles. It describes stable Rail
 Admin, Editor, Viewer, and Planner users can open the overview. An account with only the Messe role
 starts in **Exhibition** and cannot open this dashboard.
 
+Only Admin and Editor users can change vehicle data. Viewer and Planner users can inspect the
+dashboard and filtered results, but must ask an Admin or Editor to correct missing data.
+
 ## Open and refresh the overview
 
 Select **Overview** in the sidebar. RailKeeper loads the vehicles available to the current session
@@ -33,7 +36,7 @@ The Import/Export icon in the same header opens **Import/Export**.
 
 | Metric | Meaning |
 | --- | --- |
-| **Total inventory** | Number of vehicles. The line below reports how many category and gauge groups occur among the five most frequent values in each list. It is not a count of every distinct value when more than five exist. |
+| **Total inventory** | Number of vehicles. The line below reports how many category and gauge groups occur among the five most frequent values in each list. Missing values form the **No category** and **No gauge** groups. It is not a count of every distinct value when more than five exist. |
 | **Digitalization** | Digital vehicles divided by all vehicles, rounded to a whole percentage. The detail line shows the digital and analog counts. |
 | **Recorded list value** | Sum of parseable, maintained vehicle list prices. RailKeeper accepts common comma and point number formats and displays the euro total rounded to whole euros. Missing or unparseable prices contribute zero. This is not a market-value estimate. |
 | **Maintenance** | Number of incomplete maintenance entries whose due date is today or earlier. The detail line separately shows incomplete entries due in the next 30 days and all incomplete entries, including entries without a due date. |
@@ -49,7 +52,8 @@ each widget can be hidden.
 
 **Inventory mix** lists up to five categories with the most vehicles. Missing category values are
 grouped as **No category**. The bar shows the category's share of all vehicles, while the number is
-the exact vehicle count.
+the exact vehicle count. A non-zero bar has a minimum visible width of 8%, so small categories can
+look wider than their exact percentage.
 
 ### Data quality
 
@@ -70,8 +74,8 @@ field is complete. With no vehicles, all five percentages are 0%.
 
 ### Action needed
 
-**Action needed** lists non-zero data gaps. Select a row to open **Vehicles** with the matching
-filter active.
+**Action needed** lists non-zero data gaps. Select a row to open **Vehicle inventory**, whose page
+heading is **Inventory**, with the matching filter active.
 
 | Gap | Vehicles selected |
 | --- | --- |
@@ -85,7 +89,7 @@ distinguish a specifically selected main image. When all four counts are zero, t
 that no major data gaps were detected.
 
 The overview itself has no general search or filter bar. Searching, combining filters, and editing
-records happens in **Vehicles** after following a gap or opening the inventory directly.
+records happens in **Vehicle inventory** after following a gap or opening the inventory directly.
 
 ### Manufacturers
 
@@ -96,7 +100,7 @@ grouped as **No manufacturer**.
 
 **Quick actions** opens the next work area without changing data:
 
-- **Maintain inventory** opens **Vehicles**.
+- **Maintain inventory** opens **Vehicle inventory**.
 - **Import/Export** opens the import, export, and print area.
 - **Check master data** opens **Settings**, where authorized users can manage selection values and
   inventory-number settings.
@@ -107,8 +111,10 @@ additional role.
 ### Maintenance radar
 
 **Maintenance radar** shows up to four incomplete maintenance entries with a due date, ordered by
-the closest due date. Each row contains the vehicle inventory number, vehicle name or maintenance
-kind, maintenance kind, due-distance label, and date. Entries due today or overdue are highlighted.
+the earliest due date. The oldest overdue entry therefore appears first, followed by later overdue,
+today's, and upcoming entries. Each row contains the vehicle inventory number, vehicle name or
+maintenance kind, maintenance kind, due-distance label, and date. Entries due today or overdue are
+highlighted.
 
 The lower row summarizes:
 
@@ -131,25 +137,28 @@ maintenance without a due date still contributes to the summary metric at the to
    applies.
 
 This is a fixed rule-based hint, not an automated data assessment or external recommendation.
+Creating, importing, or changing vehicles requires the Admin or Editor role.
 
 ## Work from data gaps
 
 1. Open **Action needed** on the overview.
 2. Select the relevant gap.
-3. RailKeeper opens **Vehicles** and activates the corresponding inventory or quality filter.
-4. Open the affected records and add or correct the missing data.
+3. RailKeeper opens **Vehicle inventory** and activates the corresponding inventory or quality
+   filter.
+4. Open the affected records. As an Admin or Editor, add or correct the missing data. As a Viewer
+   or Planner, use the result to identify the records and ask an Admin or Editor to update them.
 5. Return to **Overview** and use refresh to recalculate the dashboard.
 
-Resetting all filters in **Vehicles** removes the gap parameter from the browser address. Selecting
-another quality filter also removes it. Other manual filter changes can leave the original
-parameter in the address even though the visible selection has changed.
+For an article-number, EAN, or decoder gap, clearing the active quality-filter pill removes the gap
+parameter from the browser address. **Clear filters** also removes it for every gap. Other manual
+filter changes leave the original gap active and retain the parameter.
 
 ## Arrange the dashboard
 
 Every widget header contains three controls:
 
-- Move up places the widget one position earlier.
-- Move down places it one position later.
+- **Move forward** places the widget one position earlier.
+- **Move backward** places it one position later.
 - Hide removes the widget from the dashboard.
 
 After at least one widget is hidden, the reset icon appears in the page header. **Reset layout**
@@ -163,7 +172,7 @@ shared with other browsers or saved as account-wide dashboard settings.
 
 | Situation | What RailKeeper shows | What to do |
 | --- | --- | --- |
-| No vehicles | Zero summary values, empty lists, and the create/import recommendation | Create vehicles or import an inventory list |
+| No vehicles | Zero summary values, empty lists, and the create/import recommendation | As an Admin or Editor, create vehicles or import a list. As a Viewer or Planner, ask one of those roles to populate the inventory. |
 | No due-dated open maintenance | An empty maintenance-radar message | Add a due date if the work should appear in the radar |
 | No major data gaps | A confirmation in **Action needed** | Continue with maintenance or other inventory details |
 | All widgets hidden | **Dashboard empty** with **Reset layout** | Reset the layout to restore all widgets |

--- a/docs/site/guide/overview/index.md
+++ b/docs/site/guide/overview/index.md
@@ -1,0 +1,180 @@
+---
+title: Overview, metrics, and data quality
+description: Read the RailKeeper dashboard, follow data gaps, and arrange its widgets.
+audience: user
+status: stable
+reviewedVersion: 0.1.17.6
+lastReviewed: 2026-08-16
+---
+
+# Overview, metrics, and data quality
+
+The **Overview** is RailKeeper's working dashboard for inventory size, recorded value,
+digitalization, maintenance, and data quality. This chapter explains what each number means and how
+to continue from an indicator to the affected vehicles. It describes stable RailKeeper v0.1.17.6.
+
+Admin, Editor, Viewer, and Planner users can open the overview. An account with only the Messe role
+starts in **Exhibition** and cannot open this dashboard.
+
+## Open and refresh the overview
+
+Select **Overview** in the sidebar. RailKeeper loads the vehicles available to the current session
+and calculates the dashboard values in the browser. The overview is therefore a current summary of
+vehicle data, not a separately stored server report.
+
+Use the refresh icon in the page header after changing vehicle or maintenance data in another
+view. The control is disabled while data is loading. If loading fails, RailKeeper shows the error
+above the dashboard. Previously loaded values remain visible when available, so check the error
+before relying on them.
+
+The Import/Export icon in the same header opens **Import/Export**.
+
+## Read the four summary metrics
+
+| Metric | Meaning |
+| --- | --- |
+| **Total inventory** | Number of vehicles. The line below reports how many category and gauge groups occur among the five most frequent values in each list. It is not a count of every distinct value when more than five exist. |
+| **Digitalization** | Digital vehicles divided by all vehicles, rounded to a whole percentage. The detail line shows the digital and analog counts. |
+| **Recorded list value** | Sum of parseable, maintained vehicle list prices. RailKeeper accepts common comma and point number formats and displays the euro total rounded to whole euros. Missing or unparseable prices contribute zero. This is not a market-value estimate. |
+| **Maintenance** | Number of incomplete maintenance entries whose due date is today or earlier. The detail line separately shows incomplete entries due in the next 30 days and all incomplete entries, including entries without a due date. |
+
+With no vehicles, inventory and value are zero and percentage metrics show 0%.
+
+## Use the dashboard widgets
+
+The seven widgets below combine inventory signals and shortcuts. Their order can be changed and
+each widget can be hidden.
+
+### Inventory mix
+
+**Inventory mix** lists up to five categories with the most vehicles. Missing category values are
+grouped as **No category**. The bar shows the category's share of all vehicles, while the number is
+the exact vehicle count.
+
+### Data quality
+
+**Data quality** reports the share of all vehicles that meet five individual checks:
+
+| Indicator | Counts as covered when |
+| --- | --- |
+| **Images** | At least one image is stored for the vehicle |
+| **Decoder numbers** | Either decoder-number field contains a value |
+| **Article numbers** | The article-number field contains a value |
+| **EAN** | The EAN field contains a value |
+| **Fully documented** | Article number, EAN, and at least one image are all present |
+
+Every percentage uses the total vehicle count as its denominator. **Decoder numbers** therefore
+also includes analog vehicles when they have a value in either decoder-number field. Conversely,
+**Fully documented** does not require a decoder number and does not certify that every vehicle
+field is complete. With no vehicles, all five percentages are 0%.
+
+### Action needed
+
+**Action needed** lists non-zero data gaps. Select a row to open **Vehicles** with the matching
+filter active.
+
+| Gap | Vehicles selected |
+| --- | --- |
+| **Without main image** | Vehicles without any stored image |
+| **Without article no.** | Vehicles without an article number |
+| **Without EAN** | Vehicles without an EAN |
+| **Digital without decoder no.** | Digital vehicles without a value in either decoder-number field |
+
+In v0.1.17.6, **Without main image** technically checks whether any image exists. It does not
+distinguish a specifically selected main image. When all four counts are zero, the widget reports
+that no major data gaps were detected.
+
+The overview itself has no general search or filter bar. Searching, combining filters, and editing
+records happens in **Vehicles** after following a gap or opening the inventory directly.
+
+### Manufacturers
+
+**Manufacturers** ranks up to five manufacturers by vehicle count. Empty manufacturer values are
+grouped as **No manufacturer**.
+
+### Quick actions
+
+**Quick actions** opens the next work area without changing data:
+
+- **Maintain inventory** opens **Vehicles**.
+- **Import/Export** opens the import, export, and print area.
+- **Check master data** opens **Settings**, where authorized users can manage selection values and
+  inventory-number settings.
+
+The destination still applies the signed-in user's permissions. A shortcut does not grant an
+additional role.
+
+### Maintenance radar
+
+**Maintenance radar** shows up to four incomplete maintenance entries with a due date, ordered by
+the closest due date. Each row contains the vehicle inventory number, vehicle name or maintenance
+kind, maintenance kind, due-distance label, and date. Entries due today or overdue are highlighted.
+
+The lower row summarizes:
+
+- **Done**: every completed maintenance entry.
+- **Cost**: the sum of parseable costs from all maintenance entries, including completed entries.
+- **Conditions**: how many distinct condition ratings are represented among the five most frequent
+  ratings, so the displayed value is capped at five.
+
+If no incomplete maintenance entry has a due date, the radar shows its empty-state message. Open
+maintenance without a due date still contributes to the summary metric at the top of the page.
+
+### Next value
+
+**Next value** chooses one recommendation from the current data in this order:
+
+1. Create or import vehicles when the inventory is empty.
+2. Add images while image coverage is below 70%.
+3. Work through due maintenance when at least one item is due today or overdue.
+4. Consider spare-parts and structured price/value maintenance when none of the earlier conditions
+   applies.
+
+This is a fixed rule-based hint, not an automated data assessment or external recommendation.
+
+## Work from data gaps
+
+1. Open **Action needed** on the overview.
+2. Select the relevant gap.
+3. RailKeeper opens **Vehicles** and activates the corresponding inventory or quality filter.
+4. Open the affected records and add or correct the missing data.
+5. Return to **Overview** and use refresh to recalculate the dashboard.
+
+Resetting all filters in **Vehicles** removes the gap parameter from the browser address. Selecting
+another quality filter also removes it. Other manual filter changes can leave the original
+parameter in the address even though the visible selection has changed.
+
+## Arrange the dashboard
+
+Every widget header contains three controls:
+
+- Move up places the widget one position earlier.
+- Move down places it one position later.
+- Hide removes the widget from the dashboard.
+
+After at least one widget is hidden, the reset icon appears in the page header. **Reset layout**
+shows all seven widgets again and restores their default order. If all widgets are hidden, an empty
+dashboard panel also provides the reset button.
+
+Widget order and hidden state are stored in the current browser's local storage. They are not
+shared with other browsers or saved as account-wide dashboard settings.
+
+## Empty and exceptional states
+
+| Situation | What RailKeeper shows | What to do |
+| --- | --- | --- |
+| No vehicles | Zero summary values, empty lists, and the create/import recommendation | Create vehicles or import an inventory list |
+| No due-dated open maintenance | An empty maintenance-radar message | Add a due date if the work should appear in the radar |
+| No major data gaps | A confirmation in **Action needed** | Continue with maintenance or other inventory details |
+| All widgets hidden | **Dashboard empty** with **Reset layout** | Reset the layout to restore all widgets |
+| Vehicle loading fails | Error text above the dashboard | Check the connection and session, then refresh again |
+
+## Related pages
+
+- [User Guide overview](/guide/)
+- [First setup and sign-in](/guide/getting-started/)
+- [Administration overview](/administration/)
+
+## Documented RailKeeper version
+
+This page documents stable RailKeeper **v0.1.17.6** and was last reviewed on 2026-08-16.

--- a/docs/site/guide/overview/index.md
+++ b/docs/site/guide/overview/index.md
@@ -150,8 +150,10 @@ Creating, importing, or changing vehicles requires the Admin or Editor role.
 5. Return to **Overview** and use refresh to recalculate the dashboard.
 
 For an article-number, EAN, or decoder gap, clearing the active quality-filter pill removes the gap
-parameter from the browser address. **Clear filters** also removes it for every gap. Other manual
-filter changes leave the original gap active and retain the parameter.
+parameter from the browser address. Changes in other filter groups leave that quality gap active and
+retain the parameter. For **Without main image**, selecting another inventory filter replaces the
+active image gap but leaves the now-stale `gap=no-main-image` parameter in the address. **Clear
+filters** removes the parameter for every gap.
 
 ## Arrange the dashboard
 

--- a/docs/superpowers/plans/2026-08-16-railkeeper-user-guide-overview.md
+++ b/docs/superpowers/plans/2026-08-16-railkeeper-user-guide-overview.md
@@ -1,0 +1,186 @@
+# RailKeeper User Guide Overview Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish a complete English and German guide for the dashboard overview, its metrics,
+data-quality indicators, maintenance signals, shortcuts, and local layout controls in stable
+RailKeeper v0.1.17.6.
+
+**Architecture:** Add one paired user-guide page at the paths already reserved by the coverage
+matrix. Link the pair from both user-guide sidebars and landing pages, then change only the
+`overview` coverage topic from `planned` to `documented`. The pages explain how the browser derives
+dashboard values from vehicle data and distinguish dashboard indicators from the filtered vehicle
+lists opened by the data-gap links.
+
+**Tech Stack:** VitePress 2, Markdown with validated frontmatter, Node.js documentation checks,
+React/TypeScript sources as the stable behavior contract.
+
+## Global Constraints
+
+- English remains the public root locale; German uses the `/de/` prefix.
+- English and German pages use identical relative paths below `docs/site/` and `docs/site/de/`.
+- User content documents stable RailKeeper `0.1.17.6`, not unpublished `main` behavior.
+- Both pages use `audience: user`, `status: stable`, `reviewedVersion: 0.1.17.6`, and
+  `lastReviewed: 2026-08-16`.
+- The two language versions must be semantically equivalent, not literal machine translations.
+- State that Admin, Editor, Viewer, and Planner users can open the overview. Messe-only users start
+  in Exhibition and cannot open it.
+- Do not describe the overview as a server-side report. Its values are calculated in the browser
+  from the vehicles returned for the current session.
+- Do not claim that the overview has a general search or filter bar. Only the four data-gap links
+  open the vehicle inventory with the matching filter active.
+- Explain percentage denominators precisely. Decoder coverage uses all vehicles, while the
+  `Digital without decoder no.` gap counts only digital vehicles without either decoder-number
+  field.
+- Explain that `Fully documented` requires an article number, EAN, and at least one image. It does
+  not certify every vehicle field as complete.
+- Explain that widget order and hidden state are local to the current browser storage. The reset
+  control appears after at least one widget is hidden and restores the default order and all
+  widgets.
+- Do not include private inventory data, screenshots with real records, or generated build output.
+- Keep `docs/.vitepress/dist` and `docs/node_modules` out of Git.
+
+---
+
+### Task 1: Publish the paired overview and data-quality guide
+
+**Files:**
+
+- Create: `docs/site/guide/overview/index.md`
+- Create: `docs/site/de/guide/overview/index.md`
+- Modify: `docs/site/guide/index.md`
+- Modify: `docs/site/de/guide/index.md`
+- Modify: `docs/.vitepress/config.mts`
+- Modify: `docs/coverage.json`
+
+**Interfaces:**
+
+- Consumes: the `overview` coverage topic, `OverviewView`, application role routing, vehicle gap
+  filters, and stable version metadata.
+- Produces: `/guide/overview/`, `/de/guide/overview/`, paired sidebar and landing-page entries, and
+  a `documented` coverage status for `overview`.
+
+- [ ] **Step 1: Make the coverage contract fail for the missing pages**
+
+Change only the `overview` topic in `docs/coverage.json` from `planned` to `documented`.
+
+- [ ] **Step 2: Verify the contract rejects the missing destinations**
+
+Run:
+
+```powershell
+cd docs
+npm.cmd run check
+```
+
+Expected: failure naming the missing English and German `overview` pages.
+
+- [ ] **Step 3: Write the English page**
+
+Create `docs/site/guide/overview/index.md` with required frontmatter and these content requirements:
+
+1. Title `Overview, metrics, and data quality`, scope, supported roles, and stable version.
+2. `Open and refresh the overview`:
+   - use **Overview** in the sidebar;
+   - the refresh icon reloads the vehicle data and disables itself while loading;
+   - a load failure appears above the dashboard and does not silently replace the data.
+3. `Read the four summary metrics` with a table defining:
+   - total inventory and its distinct top-five category/gauge count;
+   - digitalization as digital vehicles divided by all vehicles;
+   - recorded list value as the sum of parseable maintained list-price strings in euros, rounded
+     to whole euros for display;
+   - maintenance as overdue or due-today entries, with separate next-30-days and all-open counts.
+4. `Use the dashboard widgets` with exact coverage of:
+   - Inventory mix: five most common categories;
+   - Data quality: image, decoder-number, article-number, EAN, and fully-documented percentages;
+   - Action needed: the four data gaps and their filtered `/vehicles?gap=...` destinations;
+   - Manufacturers: five most common manufacturers;
+   - Quick actions: Vehicles, Import/Export, and Settings/master-data destinations;
+   - Maintenance radar: four closest incomplete due-dated entries, overdue/today/upcoming labels,
+     completed total, all maintenance costs, and distinct condition ratings;
+   - Next value: deterministic recommendation priority for empty inventory, image coverage below
+     70 percent, due maintenance, then the stable-inventory suggestion.
+5. `Understand the data-quality percentages`:
+   - denominator is the total vehicle count for every percentage;
+   - an image means at least one vehicle image;
+   - decoder number accepts either decoder-number field and is not limited to digital vehicles;
+   - fully documented means article number + EAN + at least one image;
+   - zero vehicles produce zero percent rather than an undefined value.
+6. `Work from data gaps`:
+   - select a gap to open Vehicles with exactly that gap filter;
+   - list the four gap meanings;
+   - clarify that editing happens in Vehicles, not on the dashboard;
+   - clarify that the overview itself has no general search/filter bar.
+7. `Arrange the dashboard`:
+   - up/down controls move each widget in the order;
+   - hide removes a widget;
+   - reset restores all seven widgets and default order;
+   - preferences are stored in current browser local storage, not as shared account settings.
+8. `Empty and exceptional states` covering no vehicles, no maintenance with due date, no major
+   data gaps, all widgets hidden, and vehicle-loading errors.
+9. `Related pages` linking only to `/guide/`, `/guide/getting-started/`, and `/administration/` so
+   no link points to an unpublished guide page.
+10. `Documented RailKeeper version` stating stable `v0.1.17.6` and review date 2026-08-16.
+
+Use English UI labels exactly as shown by the stable interface.
+
+- [ ] **Step 4: Write the semantically equivalent German page**
+
+Create `docs/site/de/guide/overview/index.md` with matching frontmatter, facts, formulas, caveats,
+states, and destinations. Use the title `Übersicht, Kennzahlen und Datenqualität` and German UI
+labels exactly as shown by the stable interface.
+
+- [ ] **Step 5: Add both pages to the guide sidebars**
+
+In `docs/.vitepress/config.mts`, preserve the landing-page and getting-started items, then add:
+
+```ts
+{ text: "Dashboard and data quality", link: "/guide/overview/" }
+```
+
+```ts
+{ text: "Dashboard und Datenqualität", link: "/de/guide/overview/" }
+```
+
+- [ ] **Step 6: Add the chapter to both guide landing pages**
+
+Add a short next-step paragraph to `docs/site/guide/index.md` linking to `/guide/overview/` and the
+equivalent German paragraph linking to `/de/guide/overview/`. Keep both landing pages semantically
+equivalent and set `lastReviewed` to `2026-08-16`.
+
+- [ ] **Step 7: Run the complete documentation check**
+
+Run:
+
+```powershell
+cd docs
+npm.cmd run check
+```
+
+Expected: 19 tests pass, coverage validation produces no errors, and VitePress builds both routes
+without dead links.
+
+- [ ] **Step 8: Review the language pair and source fidelity**
+
+Check the pair against:
+
+```text
+frontend/src/features/overview/OverviewView.tsx
+frontend/src/features/vehicles/useVehicleInventoryController.ts
+frontend/src/app/App.tsx
+frontend/src/app/Shell.tsx
+frontend/src/shared/i18n/en.ts
+frontend/src/shared/i18n/de.ts
+```
+
+Expected: both pages describe the same stable behavior, every formula and threshold matches the
+source, and no general dashboard search or filter is claimed.
+
+- [ ] **Step 9: Commit the content package**
+
+```powershell
+git add docs/site/guide docs/site/de/guide docs/.vitepress/config.mts docs/coverage.json
+git commit -m "docs: add overview user guide"
+```


### PR DESCRIPTION
## What changed

- adds complete English and German user-guide chapters for the Overview dashboard
- documents metrics, data-quality formulas, maintenance ordering, gap filters, permissions, recommendations, and local widget layout
- adds both chapters to the guide sidebars and landing pages
- marks the `overview` documentation coverage topic as documented
- includes the focused implementation plan

## Why

The growing RailKeeper feature set needs stable, source-verified user documentation in both supported documentation languages. This chapter explains the dashboard without promising unavailable search or filter behavior and explicitly targets stable v0.1.17.6.

## User impact

Users can now understand every Overview metric, follow data gaps into the correct filtered vehicle inventory, distinguish read-only and editing roles, and customize or reset the local dashboard layout.

## Validation

- `cd docs && npm.cmd run check`
- 19/19 documentation tests passed
- coverage validation passed
- VitePress production build passed
- independent source-fidelity review completed against v0.1.17.6
