### PR TITLE
docs: add bilingual vehicle search and spare parts guide

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -50,6 +50,10 @@ export default defineConfig({
                 { text: "Fahrzeugbilder und Beilagen", link: "/de/guide/vehicles/media" },
                 { text: "Fahrzeugwartung und Zustand", link: "/de/guide/vehicles/maintenance" },
                 { text: "Decoder, Funktionen und CV-Daten", link: "/de/guide/vehicles/decoder-cv" },
+                {
+                  text: "Artikelsuche, Web-Dokumente und Ersatzteile",
+                  link: "/de/guide/vehicles/search-and-spares",
+                },
               ],
             },
           ],
@@ -121,6 +125,10 @@ export default defineConfig({
             { text: "Vehicle images and attachments", link: "/guide/vehicles/media" },
             { text: "Vehicle maintenance and condition", link: "/guide/vehicles/maintenance" },
             { text: "Decoder, functions, and CV data", link: "/guide/vehicles/decoder-cv" },
+            {
+              text: "Article search, web documents, and spare parts",
+              link: "/guide/vehicles/search-and-spares",
+            },
           ],
         },
       ],

--- a/docs/aegis/work/2026-08-16-vehicle-search-spares-guide/10-intent.md
+++ b/docs/aegis/work/2026-08-16-vehicle-search-spares-guide/10-intent.md
@@ -1,0 +1,69 @@
+# Task Intent Draft: Vehicle Search and Spare Parts Guide
+
+## Requested outcome
+
+Continue the bilingual RailKeeper wiki by publishing the next planned coverage topic,
+`vehicle-search-spares`, for stable `v0.1.17.6` and integrate it through a reviewed, green pull
+request.
+
+## Scope
+
+- English and German user-guide pages for article search, barcode/EAN, web documents, attachment
+  extraction, and vehicle spare parts.
+- Coverage status, sidebars, landing pages, and related-page transitions.
+- Stable-source audit, documentation checks, independent review, PR, green checks, and merge.
+
+## Non-goals
+
+- No application behavior changes.
+- No accessory, master-data, settings, deployment, or administration chapter implementation.
+- No changes to the dirty local `main` checkout.
+- No documentation of behavior newer than `v0.1.17.6`.
+
+## Risk hints
+
+- External suggestions can be mistaken for authoritative model data.
+- Search-result application and remote-image persistence occur at different times.
+- Document, extraction, and manufacturer-import batches can partially persist.
+- OCR is optional and environment-dependent.
+- Some visible and translated search functions are not reachable in the stable vehicle UI.
+
+## Baseline read set hint
+
+Required and acknowledged:
+
+- repository `AGENTS.md`;
+- `origin/main` documentation structure and `docs/coverage.json`;
+- existing core vehicle, media, maintenance, and decoder/CV chapters;
+- stable `v0.1.17.6` frontend article-search, document, media, and spare-parts controllers;
+- stable shared dialogs, preferences, view models, routes, API adapter, and translations;
+- stable backend article-search, remote import, extraction/OCR, spare-parts, migration, and backup
+  sources.
+
+Missing baseline refs: none.
+
+## Baseline usage draft
+
+- Acknowledged before design: all refs above.
+- Cited by design: exact primary source owners and compatibility boundary.
+- Stable source remains authoritative even though the worktree follows newer `main` documentation.
+
+## Impact statement draft
+
+Documentation-only change. It adds one paired user chapter, marks one existing coverage topic as
+documented, and extends documentation navigation. Runtime, API, schema, permissions, and release
+behavior remain unchanged.
+
+## Execution readiness view
+
+- Intent lock: finish the next complete bilingual user topic.
+- Scope fence: vehicle article search, web documents, and spare parts only.
+- Baseline lock: behavior claims must match tag `v0.1.17.6`.
+- Owner constraints: preserve existing coverage and published-page ownership.
+- Compatibility boundary: no claims from later `main` application work.
+- Task batches: spec, plan, coverage gate, paired pages, navigation, audit/review, PR/merge.
+- Test obligations: documentation test suite, coverage validation, VitePress build, focused scans.
+- Review gates: user spec approval, independent review, exact-head green GitHub checks.
+- Drift rule: pause if a required workflow belongs to another coverage owner or differs in stable
+  source.
+- Evidence before completion: commits, green local checks, clean reviews, merged PR, green Pages.

--- a/docs/aegis/work/2026-08-16-vehicle-search-spares-guide/20-checkpoint.md
+++ b/docs/aegis/work/2026-08-16-vehicle-search-spares-guide/20-checkpoint.md
@@ -1,0 +1,51 @@
+# Todo Checkpoint Draft
+
+## Current state
+
+- Topic selected: `vehicle-search-spares`.
+- Recommended workflow-first structure selected by the user.
+- Three design sections approved by the user.
+- Isolated worktree created from current `origin/main` on branch
+  `dev/docs-user-guide-search-spares`.
+- Baseline documentation check is green.
+
+## Active slice
+
+Write, self-review, and commit the complete design specification and continuity records.
+
+## Todo map
+
+- [x] Determine the next coverage topic.
+- [x] Audit stable frontend, backend, routes, translations, storage, and backup boundaries.
+- [x] Present alternatives and obtain design approval.
+- [ ] Commit and obtain user review of the written specification.
+- [ ] Write and commit the detailed implementation plan.
+- [ ] Implement coverage, paired pages, navigation, and cross-links.
+- [ ] Verify, independently review, correct, and re-review.
+- [ ] Push, open PR, await exact-head checks, merge, and verify publication.
+
+## Evidence refs
+
+- Stable tag: `v0.1.17.6`.
+- Worktree base: `2e243c66971ef2979892b592852bacd18693c6d9`.
+- Baseline: `cd docs; npm.cmd run check`, 19 tests passed, coverage validation passed, VitePress
+  build passed.
+- Approved design discussion: workflow-first approach plus data-safety and review sections.
+
+## Blocked on
+
+Nothing for the active slice. User review is the next required gate after the spec commit.
+
+## Resume state hint
+
+Read `10-intent.md`, this checkpoint, the committed design specification, and current worktree
+status. Do not resume from the dirty local `main` checkout.
+
+## Drift check draft
+
+- Original intent served: yes.
+- Scope fence respected: yes.
+- Stable compatibility boundary respected: yes.
+- New runtime owner or adapter introduced: no.
+- Evidence sufficient for next step: yes.
+- Decision: continue.

--- a/docs/aegis/work/2026-08-16-vehicle-search-spares-guide/20-checkpoint.md
+++ b/docs/aegis/work/2026-08-16-vehicle-search-spares-guide/20-checkpoint.md
@@ -8,10 +8,14 @@
 - Isolated worktree created from current `origin/main` on branch
   `dev/docs-user-guide-search-spares`.
 - Baseline documentation check is green.
+- Bilingual chapter, coverage, sidebars, landing transitions, and published cross-links are
+  implemented and committed.
+- Stable-source audit and independent read-only review are complete with no remaining finding.
 
 ## Active slice
 
-Obtain the execution-method selection for the committed implementation plan.
+Commit the review corrections, run fresh exact-head verification, then publish through a guarded
+pull request.
 
 ## Todo map
 
@@ -20,8 +24,8 @@ Obtain the execution-method selection for the committed implementation plan.
 - [x] Present alternatives and obtain design approval.
 - [x] Commit and obtain user review of the written specification.
 - [x] Write and commit the detailed implementation plan.
-- [ ] Implement coverage, paired pages, navigation, and cross-links.
-- [ ] Verify, independently review, correct, and re-review.
+- [x] Implement coverage, paired pages, navigation, and cross-links.
+- [x] Verify, independently review, correct, and re-review.
 - [ ] Push, open PR, await exact-head checks, merge, and verify publication.
 
 ## Evidence refs
@@ -34,7 +38,7 @@ Obtain the execution-method selection for the committed implementation plan.
 
 ## Blocked on
 
-User selection between subagent-driven and inline execution.
+Nothing. Publication can continue after the correction commit and fresh local check.
 
 ## Resume state hint
 
@@ -49,5 +53,8 @@ and current worktree status. Do not resume from the dirty local `main` checkout.
 - New runtime owner or adapter introduced: no.
 - Plan covers every approved workflow, persistence boundary, recovery case, role, coverage change,
   navigation change, source audit, review gate, and exact-head publication gate: yes.
-- Evidence sufficient for execution selection: yes.
-- Decision: await execution selection.
+- Independent review disposition: three Minor findings corrected, focused re-review found no
+  remaining issue.
+- Evidence sufficient for publication: yes, after committing corrections and fresh exact-head
+  verification.
+- Decision: continue to publication gate.

--- a/docs/aegis/work/2026-08-16-vehicle-search-spares-guide/20-checkpoint.md
+++ b/docs/aegis/work/2026-08-16-vehicle-search-spares-guide/20-checkpoint.md
@@ -11,15 +11,15 @@
 
 ## Active slice
 
-Write, self-review, and commit the complete design specification and continuity records.
+Obtain the execution-method selection for the committed implementation plan.
 
 ## Todo map
 
 - [x] Determine the next coverage topic.
 - [x] Audit stable frontend, backend, routes, translations, storage, and backup boundaries.
 - [x] Present alternatives and obtain design approval.
-- [ ] Commit and obtain user review of the written specification.
-- [ ] Write and commit the detailed implementation plan.
+- [x] Commit and obtain user review of the written specification.
+- [x] Write and commit the detailed implementation plan.
 - [ ] Implement coverage, paired pages, navigation, and cross-links.
 - [ ] Verify, independently review, correct, and re-review.
 - [ ] Push, open PR, await exact-head checks, merge, and verify publication.
@@ -34,12 +34,12 @@ Write, self-review, and commit the complete design specification and continuity 
 
 ## Blocked on
 
-Nothing for the active slice. User review is the next required gate after the spec commit.
+User selection between subagent-driven and inline execution.
 
 ## Resume state hint
 
-Read `10-intent.md`, this checkpoint, the committed design specification, and current worktree
-status. Do not resume from the dirty local `main` checkout.
+Read `10-intent.md`, this checkpoint, the committed design specification, the implementation plan,
+and current worktree status. Do not resume from the dirty local `main` checkout.
 
 ## Drift check draft
 
@@ -47,5 +47,7 @@ status. Do not resume from the dirty local `main` checkout.
 - Scope fence respected: yes.
 - Stable compatibility boundary respected: yes.
 - New runtime owner or adapter introduced: no.
-- Evidence sufficient for next step: yes.
-- Decision: continue.
+- Plan covers every approved workflow, persistence boundary, recovery case, role, coverage change,
+  navigation change, source audit, review gate, and exact-head publication gate: yes.
+- Evidence sufficient for execution selection: yes.
+- Decision: await execution selection.

--- a/docs/aegis/work/2026-08-16-vehicle-search-spares-guide/90-evidence.md
+++ b/docs/aegis/work/2026-08-16-vehicle-search-spares-guide/90-evidence.md
@@ -1,0 +1,29 @@
+# Evidence Bundle Draft
+
+## Baseline
+
+- `origin/main` refreshed before topic selection.
+- Isolated branch and worktree created without changing local `main`.
+- Documentation dependencies installed only in the isolated worktree.
+- Baseline `npm.cmd run check`: 19 tests passed, coverage validation passed, VitePress production
+  build completed.
+
+## Stable-source evidence
+
+- Normal search criteria, EAN-only exception, local field/image application, and selection defaults
+  confirmed in the stable vehicle article-search controller and dialog.
+- Camera security, permission, digit normalization, and minimum detected length confirmed in the
+  stable barcode dialog.
+- Ten-second search timeout and ten-result cap confirmed in the stable article-search service.
+- Document discovery, URL-based import detection, category inference, sequential imports, and
+  refresh behavior confirmed in the stable document controller and remote attachment handler.
+- Attachment extraction order, 12 MiB read bound, 80-suggestion cap, optional OCR, automatic
+  sequential import, and deduplication confirmed in stable API and application sources.
+- Manual spare-part validation, identity, conservative create merge, immediate actions, lookup cap,
+  availability checking, and Piko/Roco import order confirmed in stable frontend and service code.
+- Viewer read/search routes and Editor write routes confirmed in stable route specifications.
+- Stored spare parts and media confirmed in application backup scope.
+
+## Review state
+
+Design discussion approved. Written spec self-review and user review remain pending.

--- a/docs/aegis/work/2026-08-16-vehicle-search-spares-guide/90-evidence.md
+++ b/docs/aegis/work/2026-08-16-vehicle-search-spares-guide/90-evidence.md
@@ -26,4 +26,6 @@
 
 ## Review state
 
-Design discussion approved. Written spec self-review and user review remain pending.
+Design discussion, written-spec self-review, and written-spec user review completed. The detailed
+implementation plan passed a spec-coverage, placeholder, type/name, line-hygiene, and scope review.
+`npm.cmd run check` passed again with 19 tests, coverage validation, and the VitePress build.

--- a/docs/aegis/work/2026-08-16-vehicle-search-spares-guide/90-evidence.md
+++ b/docs/aegis/work/2026-08-16-vehicle-search-spares-guide/90-evidence.md
@@ -29,3 +29,12 @@
 Design discussion, written-spec self-review, and written-spec user review completed. The detailed
 implementation plan passed a spec-coverage, placeholder, type/name, line-hygiene, and scope review.
 `npm.cmd run check` passed again with 19 tests, coverage validation, and the VitePress build.
+
+Implementation commits added the paired chapter and coverage, then navigation and cross-links.
+Stable-source audit confirmed search, camera, remote import, extraction, spare-part, role, and
+backup behavior against `v0.1.17.6`.
+
+Independent read-only review found no Critical or Important issue. Three Minor findings were
+corrected: legacy source-default migration, extraction success/failure refresh and tab timing, and
+clear German wording for trimmed whitespace. Focused re-review reported no remaining finding and
+declared the branch ready after commit and fresh verification.

--- a/docs/coverage.json
+++ b/docs/coverage.json
@@ -46,7 +46,7 @@
     {
       "id": "vehicle-search-spares",
       "audience": "user",
-      "status": "planned",
+      "status": "documented",
       "englishPath": "guide/vehicles/search-and-spares.md",
       "germanPath": "de/guide/vehicles/search-and-spares.md"
     },

--- a/docs/site/de/guide/index.md
+++ b/docs/site/de/guide/index.md
@@ -37,3 +37,7 @@ Fälligkeiten, Abschluss, Kosten, verknüpfte Medien und sicheres Löschen.
 [Decoder, Funktionen und CV-Daten](/de/guide/vehicles/decoder-cv) behandelt Zuordnungen F0-F31,
 die schreibgeschützte Fahrkurve, CV-Werte und Austausch, Decoder-Dateivorschauen und sicheres
 Speichern.
+
+[Artikelsuche, Web-Dokumente und Ersatzteile](/de/guide/vehicles/search-and-spares) erklärt, wie du
+externe Vorschläge prüfst, ausgewählte Artikeldaten und Bilder speicherst, Dokumente importierst und
+Ersatzteile pflegst, ohne teilweise Schreibvorgänge zu übersehen.

--- a/docs/site/de/guide/vehicles/decoder-cv.md
+++ b/docs/site/de/guide/vehicles/decoder-cv.md
@@ -318,6 +318,7 @@ nacheinander ausgeführten Aktion rückgängig.
 - [Fahrzeugbestand und Grunddaten](/de/guide/vehicles/)
 - [Fahrzeugbilder und Beilagen](/de/guide/vehicles/media)
 - [Fahrzeugwartung und Zustand](/de/guide/vehicles/maintenance)
+- [Artikelsuche, Web-Dokumente und Ersatzteile](/de/guide/vehicles/search-and-spares)
 
 ## Dokumentierte RailKeeper-Version
 

--- a/docs/site/de/guide/vehicles/index.md
+++ b/docs/site/de/guide/vehicles/index.md
@@ -311,6 +311,7 @@ Datei physisch zu entfernen.
 - [Fahrzeugbilder und Beilagen](/de/guide/vehicles/media)
 - [Fahrzeugwartung und Zustand](/de/guide/vehicles/maintenance)
 - [Decoder, Funktionen und CV-Daten](/de/guide/vehicles/decoder-cv)
+- [Artikelsuche, Web-Dokumente und Ersatzteile](/de/guide/vehicles/search-and-spares)
 - [Ersteinrichtung und Anmeldung](/de/guide/getting-started/)
 - [Übersicht, Kennzahlen und Datenqualität](/de/guide/overview/)
 - [Übersicht der Administration](/de/administration/)

--- a/docs/site/de/guide/vehicles/maintenance.md
+++ b/docs/site/de/guide/vehicles/maintenance.md
@@ -172,6 +172,7 @@ Medienaktion nicht rückgängig.
 - [Fahrzeugbestand und Grunddaten](/de/guide/vehicles/)
 - [Fahrzeugbilder und Beilagen](/de/guide/vehicles/media)
 - [Decoder, Funktionen und CV-Daten](/de/guide/vehicles/decoder-cv)
+- [Artikelsuche, Web-Dokumente und Ersatzteile](/de/guide/vehicles/search-and-spares)
 
 ## Dokumentierte RailKeeper-Version
 

--- a/docs/site/de/guide/vehicles/media.md
+++ b/docs/site/de/guide/vehicles/media.md
@@ -126,10 +126,10 @@ akzeptiert. Diese Seite verspricht nichts über Kopien, die du zuvor heruntergel
 von RailKeeper angelegt hast.
 
 Admin, Editor, Viewer und Planner können vorhandene Medien ansehen. Serverseitige Schreibzugriffe
-erfordern Admin oder Editor. **Quelle öffnen** ist der Übergang für importierte Bildquellen.
-**Gefundene Dokumente**, **Ersatzteile extrahieren**, Web-Dokument-Import, externe Artikelbilder,
-CV-Dateien und das Bearbeiten von Wartungen sind Fachgrenzen. Ihre Arbeitsabläufe werden auf dieser
-Seite nicht erklärt.
+erfordern Admin oder Editor. **Quelle öffnen** ist der Übergang für importierte Bildquellen. Externe
+Artikelbilder, **Gefundene Dokumente**, Web-Dokument-Import und **Ersatzteile extrahieren** erklärt
+[Artikelsuche, Web-Dokumente und Ersatzteile](/de/guide/vehicles/search-and-spares). CV-Dateien und
+das Bearbeiten von Wartungen bleiben Fachgrenzen, die auf dieser Seite nicht erklärt werden.
 
 ## Leere, teilweise und fehlerhafte Zustände
 
@@ -154,6 +154,7 @@ Seite nicht erklärt.
 - [Fahrzeugbestand und Grunddaten](/de/guide/vehicles/)
 - [Fahrzeugwartung und Zustand](/de/guide/vehicles/maintenance)
 - [Decoder, Funktionen und CV-Daten](/de/guide/vehicles/decoder-cv)
+- [Artikelsuche, Web-Dokumente und Ersatzteile](/de/guide/vehicles/search-and-spares)
 
 ## Dokumentierte RailKeeper-Version
 

--- a/docs/site/de/guide/vehicles/search-and-spares.md
+++ b/docs/site/de/guide/vehicles/search-and-spares.md
@@ -32,7 +32,8 @@ verwenden.
 
 Die Standardquellen sind Herstellerseiten, Modellbahn-Fokus-Kataloge, Händlerseiten und die
 allgemeine Websuche. Modellbau Wiki ist eine optionale fünfte Quelle. Normale Artikel- und
-Dokumentsuchen benötigen:
+Dokumentsuchen benötigen die folgenden Werte. RailKeeper migriert erkannte ältere
+Standardkombinationen beim Lesen der Browsereinstellung auf die aktuellen Vorgaben.
 
 - Hersteller;
 - Spurweite;
@@ -159,7 +160,8 @@ nur fehlende URLs.
 
 Jede gespeicherte Beilage bietet **Ersatzteile extrahieren**. Die Aktion speichert zuerst die
 aktuelle Beschreibung, Kategorie und Wartungsverknüpfung dieser ausgewählten Beilage. Danach wird
-nur diese Beilage analysiert, zu **Ersatzteile** gewechselt und das Fahrzeug neu geladen.
+nur diese Beilage analysiert und die akzeptierten Vorschläge werden erstellt. Erst nach Erfolg der
+gesamten Folge lädt RailKeeper das Fahrzeug neu und wechselt zu **Ersatzteile**.
 
 Die Extraktion benötigt eine gespeicherte Fahrzeug-Artikelnummer. Der Server liest höchstens
 12 MiB aus der Beilage und liefert höchstens 80 eindeutige Vorschläge. Wahrscheinliche
@@ -174,8 +176,8 @@ und erstellt alle verbleibenden Kandidaten nacheinander. Eine Quell-URL zur inte
 RailKeeper-Beilagenadresse wird nicht als externer Ersatzteillink gespeichert.
 
 Beilagenmetadaten und früher erstellte Ersatzteile bleiben gespeichert, wenn eine spätere Anfrage
-fehlschlägt. Lade das Fahrzeug neu und vergleiche Beilage und Ersatzteile vor einem erneuten
-Versuch.
+fehlschlägt. Das normale Neuladen und der Tabwechsel bleiben dann aus. Lade das Fahrzeug manuell
+neu und vergleiche Beilage und Ersatzteile vor einem erneuten Versuch.
 
 ## Ersatzteile manuell pflegen
 
@@ -183,9 +185,9 @@ Der Tab **Ersatzteile** kann beschrieben werden, sobald das Fahrzeug existiert. 
 Artikelnummer, Beschreibung, Preis als freien Text und externen Link. Mindestens Artikelnummer,
 Beschreibung oder Link ist erforderlich. Ein Preis allein ist ungültig.
 
-Neue und geänderte Werte werden außen bereinigt. Anfangs ist die Tabelle aufsteigend nach
-Artikelnummer sortiert. Wähle eine Spaltenüberschrift, um Artikelnummer, Beschreibung, Preis oder
-Link auf- oder absteigend zu sortieren.
+Bei neuen und geänderten Werten werden führende und nachgestellte Leerzeichen entfernt. Anfangs ist
+die Tabelle aufsteigend nach Artikelnummer sortiert. Wähle eine Spaltenüberschrift, um
+Artikelnummer, Beschreibung, Preis oder Link auf- oder absteigend zu sortieren.
 
 Das Erstellen eines Ersatzteils mit vorhandener Identität aktualisiert die passende Zeile, statt
 eine weitere anzulegen. Die Identität verwendet zuerst die normalisierte Artikelnummer, sonst die

--- a/docs/site/de/guide/vehicles/search-and-spares.md
+++ b/docs/site/de/guide/vehicles/search-and-spares.md
@@ -1,0 +1,313 @@
+---
+title: Artikelsuche, Web-Dokumente und Ersatzteile
+description: Externe Artikeldaten prüfen, Web-Dokumente importieren und Fahrzeugersatzteile pflegen.
+audience: user
+status: stable
+reviewedVersion: 0.1.17.6
+lastReviewed: 2026-08-16
+---
+
+# Artikelsuche, Web-Dokumente und Ersatzteile
+
+RailKeeper kann externe Vorschläge verwenden, um ein Fahrzeug zu vervollständigen,
+Referenzdokumente zu importieren und Ersatzteile zu pflegen. Diese Ergebnisse sind Ausgangspunkte,
+keine verbindlichen Modelldaten. Öffne die Quelle und prüfe Hersteller und Artikelidentität, bevor
+du etwas speicherst.
+
+Der Ablauf unterscheidet vier Zustände:
+
+| Zustand | Bedeutung |
+| --- | --- |
+| Suchergebnis | Externer Vorschlag, nicht gespeichert |
+| Übernommenes Feld oder ausgewähltes Bild | Lokaler Zustand im Fahrzeugeditor, noch nicht gespeichert |
+| Importiertes Dokument oder Ersatzteilaktion | Sofortiger Schreibvorgang auf dem Server |
+| Gespeichertes Fahrzeug | Grunddaten und vorgemerkte Bilder wurden durch den Fahrzeugspeicherablauf geschrieben |
+
+## Voraussetzungen, Einstellungen und Zugriffsrechte
+
+**Artikeldaten-Websuche** ist standardmäßig aktiviert, sofern sie nicht in den Einstellungen
+deaktiviert wurde. Der Aktivierungszustand und die ausgewählten Quellen sind Einstellungen des
+aktuellen Browsers. Ein anderer Browser oder ein anderes Gerät kann daher andere Einstellungen
+verwenden.
+
+Die Standardquellen sind Herstellerseiten, Modellbahn-Fokus-Kataloge, Händlerseiten und die
+allgemeine Websuche. Modellbau Wiki ist eine optionale fünfte Quelle. Normale Artikel- und
+Dokumentsuchen benötigen:
+
+- Hersteller;
+- Spurweite;
+- Artikelnummer oder Bezeichnung.
+
+Eine reine EAN-Barcodesuche ist die Ausnahme und kann ohne diese Identitätswerte ausgeführt werden.
+
+Admin und Editor können den bearbeitbaren Fahrzeugdialog nutzen, Dateien importieren und
+Ersatzteile ändern. Viewer und Planner können gespeicherte Fahrzeuge, Beilagen und Ersatzteile
+ansehen. Die Artikelsuche-API erlaubt Lesezugriff ab Viewer, der schreibgeschützte Fahrzeugdialog
+deaktiviert Such- und Übernahmeaktionen dennoch. Schreibzugriffe auf Bilder, Beilagen und
+Ersatzteile benötigen serverseitig mindestens Editor. Messe erhält keinen allgemeinen
+Fahrzeugzugriff.
+
+## Nach Artikeldaten suchen
+
+Öffne einen Fahrzeugeditor und nutze **Artikeldaten suchen** unter **Modell**. Die Aktion bleibt
+deaktiviert, bis Hersteller, Spurweite und entweder Artikelnummer oder Bezeichnung vorhanden sind.
+RailKeeper sendet diese Angaben zusammen mit weiteren nicht leeren suchbaren Fahrzeugfeldern und
+den in diesem Browser ausgewählten Quellen.
+
+Der Server bereinigt die Eingabe und kann bekannte Hersteller um Aliase und bevorzugte Domains
+ergänzen. Er erstellt mehrere gezielte Suchanfragen, verwendet ein Dienstzeitlimit von zehn
+Sekunden, bewertet und sortiert die Ergebnisse, entfernt doppelte URLs und liefert höchstens zehn
+Ergebnisse. Suchen für Piko und Roco können außerdem direkte herstellerspezifische
+Ersatzteilergebnisse enthalten.
+
+Der Ergebnisdialog zeigt die Belege hinter den Vorschlägen:
+
+- endgültige Suchanfrage, aktive Quellklassen, bevorzugte Domains und geplante Suchanfragen;
+- Ergebnistitel, Quelle, Bewertung, Textauszug und Anzahl gefundener Felder;
+- ob die Detailseite geladen wurde, fehlgeschlagen ist oder übersprungen wurde;
+- **Quelle öffnen** zur unabhängigen Prüfung;
+- gefundene Bilder und ihre Vorschauen;
+- aktuelle und gefundene Werte, ihren Status und Konflikte.
+
+Die stabilen Ergebnisgruppen enthalten diese Felder:
+
+| Gruppe | Sichtbare Felder |
+| --- | --- |
+| Modell | Bezeichnung, Artikelnummer, Hersteller, Spurweite, EAN, Bahngesellschaft, Epoche, Baureihe, Fahrzeugnummer, Untertyp, Kategorie |
+| Maße / Aufbau | Länge, Gewicht, Farbe, Beschriftung, Ladung, Inneneinrichtung, Achsen, Achsanzahl, Haftreifen |
+| Technik | Schnittstelle, Stromabnehmer, Digital-/Decoderdaten, Sound, Beleuchtung und technische Beschreibungen |
+| Weitere Daten | Beschreibung, weitere Informationen, Produktionszeitraum, Listenpreis und Quell-URL |
+
+RailKeeper entfernt offensichtlich leere, werbliche, Cookie-, Navigations- und unplausible
+Feldwerte vor der Anzeige. Filterung und eine hohe Bewertung erleichtern die Prüfung, beweisen aber
+nicht, dass ein verbleibender Wert zum physischen Modell gehört.
+
+## Mit Barcode oder Kamera suchen
+
+Nutze **Barcode suchen** unter **Modell**, um ein EAN-Feld mit dem aktuellen Wert aus dem
+Fahrzeugformular zu öffnen. Tippe den Wert ein, füge ihn ein, nutze einen Tastaturscanner oder
+starte die Kamera.
+
+Das Absenden eines nicht leeren Codes kopiert ihn in das lokale EAN-Feld, lässt die Artikelnummer
+unverändert, schließt den Barcodedialog und startet eine reine EAN-Suche. Die EAN wird erst beim
+Speichern des Fahrzeugs dauerhaft geschrieben.
+
+Die Kamerasuche benötigt:
+
+- einen sicheren Browserkontext wie HTTPS oder localhost;
+- Kameraunterstützung und Berechtigung im Browser;
+- einen lesbaren Code mit mindestens acht Ziffern, nachdem Nichtziffern entfernt wurden.
+
+RailKeeper fordert nach Möglichkeit die rückseitige Kamera an. Eine Erkennung füllt das Feld,
+sendet die Suche aber nicht automatisch ab. Schlägt Berechtigung, Browserunterstützung oder
+Erkennung fehl, gib die EAN manuell ein oder nutze einen Tastaturscanner.
+
+## Ein Suchergebnis prüfen und übernehmen
+
+Auswahlen gehören jeweils zu einem Ergebnis. Ein gefundenes Feld ist anfangs nur ausgewählt, wenn
+das aktuelle Fahrzeugfeld leer ist. Gleiche Werte und Konflikte werden nicht automatisch
+ausgewählt. Bilder sind nie vorausgewählt. Ein Bild mit fehlgeschlagener Vorschau verschwindet und
+wird aus der Auswahl entfernt.
+
+Öffne die Quelle und vergleiche die Artikelidentität, bevor du etwas auswählst. Prüfe Konflikte und
+Plausibilität über alle Feldgruppen. **Ausgewählte Felder übernehmen** überträgt anschließend nur
+markierte, gültige Felder dieses Ergebnisses. Wahrheitswerte werden in die stabile RailKeeper-
+Darstellung umgewandelt. Ausgewählte Bilder werden als vorgemerkte externe Bilder geführt. Ist
+noch kein Bild vorgemerkt, wird das erste ausgewählte Bild zum Kandidaten für das Hauptbild.
+
+Die Übernahme schließt den Ergebnisdialog, schreibt aber nichts auf den Server. Prüfe das gesamte
+Fahrzeugformular und die vorgemerkten Bilder und nutze danach **Erstellen** oder **Änderungen
+speichern**. Schließen oder Neuladen vor diesem Speichern verwirft übernommene Felder, EAN und
+vorgemerkte Bilder.
+
+Beim Speichern schreibt RailKeeper zuerst das Grundfahrzeug und lädt danach ausgewählte externe
+Bilder nacheinander herunter. Schlägt ein späteres Bild fehl, bleiben Fahrzeug und frühere Bilder
+gespeichert. Die normale abschließende Aktualisierung erfolgt dann nicht. Lade das Fahrzeug neu,
+vergleiche die gespeicherten Bilder und wiederhole nur fehlende Importe. Sortierung, Metadaten,
+Vorschauen, Wartungsverknüpfungen und Löschen nach dem Import erklärt
+[Fahrzeugbilder und Beilagen](/de/guide/vehicles/media).
+
+## Web-Dokumente finden und importieren
+
+Öffne am gespeicherten Fahrzeug **Uploads** und nutze **Gefundene Dokumente**. Die Suche verwendet
+die gespeicherte Fahrzeugidentität und die normale Voraussetzung aus Hersteller, Spurweite und
+Artikelnummer oder Bezeichnung. Ergebnisse werden anhand URL oder Titel zusammengeführt und zeigen
+Titel, Art und Quelle.
+
+RailKeeper erkennt ein bereits importiertes Dokument, wenn seine URL in einer
+Beilagenbeschreibung vorkommt. Eine solche Zeile kann nicht erneut ausgewählt werden und bietet
+lokale Aktionen zum Herunterladen und Öffnen. Importiere ein einzelnes verbleibendes Ergebnis oder
+wähle alle noch nicht gespeicherten Ergebnisse aus.
+
+Ein Import lädt den externen Inhalt herunter und speichert ihn als echte lokale Fahrzeugbeilage.
+Die Beschreibung enthält Quelle und Quell-URL. RailKeeper leitet eine dieser Kategorien ab:
+
+- `Ersatzteilliste` bei Ersatzteilsignalen;
+- `Anleitung` bei Handbuch- oder Anleitungssignalen;
+- `Dokumentation` in allen anderen Fällen.
+
+Der Server akzeptiert nur öffentliche HTTP(S)-URLs, prüft Weiterleitungsziele erneut und blockiert
+private oder interne Ziele. Er erzwingt außerdem die konfigurierte Größen- und Typbegrenzung für
+Beilagen, lehnt leere Dateien ab und verwendet für externe Anfragen ein Zeitlimit von zehn Sekunden.
+
+Der Import mehrerer ausgewählter Dokumente sendet die Anfragen nacheinander. Ein späterer Fehler
+lässt frühere Dokumente gespeichert und verhindert die normale abschließende Aktualisierung und
+das Zurücksetzen der Auswahl. Lade das Fahrzeug neu, vergleiche die Beilagenliste und wiederhole
+nur fehlende URLs.
+
+## Ersatzteile aus einer Beilage extrahieren
+
+Jede gespeicherte Beilage bietet **Ersatzteile extrahieren**. Die Aktion speichert zuerst die
+aktuelle Beschreibung, Kategorie und Wartungsverknüpfung dieser ausgewählten Beilage. Danach wird
+nur diese Beilage analysiert, zu **Ersatzteile** gewechselt und das Fahrzeug neu geladen.
+
+Die Extraktion benötigt eine gespeicherte Fahrzeug-Artikelnummer. Der Server liest höchstens
+12 MiB aus der Beilage und liefert höchstens 80 eindeutige Vorschläge. Wahrscheinliche
+Ersatzteillisten, Anleitungen, Serviceblätter, HTML und unterstützte Textinhalte können analysiert
+werden. PDF-Text wird zuerst direkt extrahiert. Gescannte PDFs können eine optionale, vom Betreiber
+bereitgestellte OCR verwenden. Ohne funktionierende OCR kann ein Scan berechtigterweise keine
+Vorschläge liefern.
+
+Die stabile Aktion besitzt weder Bestätigung noch Zeilenvorschau. Sie bereinigt Beschreibungen,
+verwirft leere und dokumenttitelähnliche Zeilen, entfernt bereits am Fahrzeug vorhandene Duplikate
+und erstellt alle verbleibenden Kandidaten nacheinander. Eine Quell-URL zur internen
+RailKeeper-Beilagenadresse wird nicht als externer Ersatzteillink gespeichert.
+
+Beilagenmetadaten und früher erstellte Ersatzteile bleiben gespeichert, wenn eine spätere Anfrage
+fehlschlägt. Lade das Fahrzeug neu und vergleiche Beilage und Ersatzteile vor einem erneuten
+Versuch.
+
+## Ersatzteile manuell pflegen
+
+Der Tab **Ersatzteile** kann beschrieben werden, sobald das Fahrzeug existiert. Der Editor enthält
+Artikelnummer, Beschreibung, Preis als freien Text und externen Link. Mindestens Artikelnummer,
+Beschreibung oder Link ist erforderlich. Ein Preis allein ist ungültig.
+
+Neue und geänderte Werte werden außen bereinigt. Anfangs ist die Tabelle aufsteigend nach
+Artikelnummer sortiert. Wähle eine Spaltenüberschrift, um Artikelnummer, Beschreibung, Preis oder
+Link auf- oder absteigend zu sortieren.
+
+Das Erstellen eines Ersatzteils mit vorhandener Identität aktualisiert die passende Zeile, statt
+eine weitere anzulegen. Die Identität verwendet zuerst die normalisierte Artikelnummer, sonst die
+normalisierte URL, sonst die Beschreibung. Die Artikelnormalisierung ignoriert ein `ET`-Präfix,
+Satzzeichen, Leerzeichen und Groß-/Kleinschreibung. Beim Erstellen bleiben vorhandene nicht leere
+Werte erhalten. Nur noch leere Felder werden aus der neuen Eingabe ergänzt. Das Bearbeiten einer
+ausgewählten Zeile schreibt genau ihre vier gesendeten Felder.
+
+Speichern, Übernehmen und Löschen wirken sofort und laden das vollständige Fahrzeug nach Erfolg
+neu. Löschen hat keine weitere Bestätigung. Da das vollständige Neuladen andere ungespeicherte
+Änderungen im Fahrzeugeditor ersetzt, speichere oder verwirf sie vorher bewusst.
+
+## Ein gespeichertes Ersatzteil nachschlagen
+
+Ein gespeichertes Ersatzteil mit Artikelnummer bietet **Dieses Ersatzteil suchen**. Die Suche
+verwendet Fahrzeughersteller, Ersatzteil-Artikelnummer, Hersteller- und Katalogquellen und bei
+Bedarf einen Piko- oder Roco-Modus. Die stabile Oberfläche zeigt höchstens fünf Kandidaten und
+bevorzugt nacheinander Ergebnisse mit Preis, Verfügbarkeit und Link.
+
+Ein Ergebnis kann Preis, Verfügbarkeit, Quelle und externen Link zeigen. **Preis und Link
+übernehmen** aktualisiert das gespeicherte Ersatzteil sofort. Artikelnummer und Beschreibung bleiben
+unverändert. Die Verfügbarkeit wird angezeigt, aber nicht gespeichert. Fehlt dem ausgewählten
+Kandidaten ein Preis, kann der stabile Controller Preis und URL eines anderen bepreisten
+Kandidaten derselben Ergebnisliste übernehmen.
+
+Beim Öffnen des Tabs prüft RailKeeper verlinkte Ersatzteile einmal für den aktuellen
+Fahrzeugzustand. Piko und Roco verwenden eine gemeinsame Herstellerübersichtsabfrage. Bei anderen
+Herstellern werden nur die ersten vier extern verlinkten Ersatzteile geprüft, die auch eine
+Artikelnummer besitzen. Der Indikator ordnet erkennbaren Text als verfügbar, begrenzt, nicht
+verfügbar oder unbekannt ein. Er bleibt ein aktueller externer Vorschlag, kein lokaler Bestand und
+keine Lieferzusage.
+
+## Eine Piko- oder Roco-Herstellerübersicht importieren
+
+**Verfügbare Ersatzteile suchen** ist nur aktiv, wenn alle Bedingungen erfüllt sind:
+
+- das Fahrzeug ist gespeichert;
+- sein Herstellername enthält Piko oder Roco;
+- die Fahrzeug-Artikelnummer ist nicht leer;
+- die Artikelsuche ist in diesem Browser aktiviert;
+- der Benutzer hat als Admin oder Editor Zugriff auf den bearbeitbaren Dialog.
+
+RailKeeper durchsucht die Herstellerübersicht und erstellt einen zurückhaltenden Importplan. Die
+Zuordnung bevorzugt normalisierte Ersatzteil-Artikelnummer, dann Beschreibung, dann URL. Wiederholte
+Vorschläge werden zusammengeführt. Vorhandene Treffer werden zuerst aktualisiert, fehlende
+Ersatzteile danach erstellt.
+
+Vorhandene Artikelnummer und Beschreibung bleiben erhalten. Vorhandener Preis und externe URL
+haben ebenfalls Vorrang. Nur fehlender Preis oder fehlende URL werden ergänzt. Aktualisierungen und
+Erstellungen laufen nacheinander ohne gemeinsame Transaktion oder Bestätigungsvorschau. Ein später
+Fehler lässt frühere Zeilen gespeichert und verhindert die normale abschließende Aktualisierung.
+Lade neu und vergleiche vor einem erneuten Versuch. **Keine fehlenden Ersatzteile in der
+Herstellerübersicht gefunden** kann bedeuten, dass alle Herstellervorschläge bereits gespeicherten
+Zeilen entsprechen, nicht dass der Hersteller keine Ersatzteile führt.
+
+## Daten bei mehrstufigen Aktionen schützen
+
+Zeitpunkt von Speicherung und Aktualisierung unterscheidet sich je Aktion:
+
+| Aktion | Speichert Daten | Lädt das vollständige Fahrzeug neu |
+| --- | --- | --- |
+| Artikel- oder Barcodesuche ausführen | Nein | Nein |
+| Ergebnisfelder oder Bilder übernehmen | Nein, nur lokaler Editor | Nein |
+| Fahrzeug nach Ergebnisübernahme speichern | Grundfahrzeug, dann externe Bilder nacheinander | Nur nach Gesamterfolg |
+| Gefundene Dokumente suchen | Nein | Nein |
+| Ein Web-Dokument importieren | Sofort | Nach Erfolg |
+| Ausgewählte Web-Dokumente importieren | Nacheinander | Nur nach Gesamterfolg |
+| Ersatzteile extrahieren | Beilagenmetadaten, dann Ersatzteile nacheinander | Nur nach Gesamterfolg |
+| Ein Ersatzteil hinzufügen, aktualisieren, aus Suche übernehmen oder löschen | Sofort | Nach Erfolg |
+| Preis oder Verfügbarkeit prüfen | Nein | Nein |
+| Piko-/Roco-Übersicht importieren | Aktualisierungen, dann Erstellungen nacheinander | Nur nach Gesamterfolg |
+
+Keine später fehlgeschlagene Anfrage macht eine frühere erfolgreiche Anfrage desselben
+nacheinander ausgeführten Ablaufs rückgängig. Lade nach einem teilweisen Fehler neu, vergleiche die
+gespeicherten Daten und wiederhole nur fehlende Arbeiten.
+
+Suchantworten, Ergebnisauswahlen und ungespeicherte Formularänderungen sind flüchtiger
+Browserzustand und gehören nicht zu einer Sicherung. Gespeicherte, aus der Artikelsuche abgeleitete
+Fahrzeugfelder, importierte Bilder, Beilagenmetadaten und -dateien sowie Fahrzeugersatzteile gehören
+zu den lokalen RailKeeper-Anwendungsdaten und sind in der Anwendungssicherung enthalten.
+
+Erstelle und validiere vor einem großen Dokumentstapel, einer Extraktion, einem Herstellerimport
+oder einer Aufräumaktion eine Anwendungssicherung. Externe Quell-URLs und Ersatzteillinks können
+außerhalb RailKeepers dennoch verschwinden und werden durch eine lokale Sicherung nicht dauerhaft.
+
+## Leere, teilweise und fehlerhafte Zustände beheben
+
+| Situation | Vorgehen |
+| --- | --- |
+| Artikelsuche ist deaktiviert | Aktiviere sie für diesen Browser in den Einstellungen oder arbeite ohne externe Vorschläge weiter. |
+| Normale Suche ist deaktiviert | Trage Hersteller, Spurweite und Artikelnummer oder Bezeichnung ein. |
+| Kamera startet nicht | Nutze HTTPS oder localhost, prüfe Berechtigung und Unterstützung oder gib den Code manuell ein. |
+| Kein Artikelergebnis erscheint | Präzisiere Identität und ausgewählte Quellen, ohne die Quellenprüfung abzuschwächen. |
+| Detailseite ist fehlgeschlagen oder wurde übersprungen | Öffne die Quelle und nutze nur überprüfbare Felder. |
+| Ein gefundenes Bild verschwindet | Seine Vorschau ist fehlgeschlagen. Wähle ein anderes Quellbild. |
+| Übernommene Werte verschwinden | Sie waren lokaler Entwurfszustand. Übernimm sie erneut und speichere das Fahrzeug. |
+| Speichern externer Bilder schlägt teilweise fehl | Lade neu und vergleiche gespeicherte Bilder, bevor du nur fehlende wiederholst. |
+| Keine Web-Dokumente erscheinen | Prüfe gespeicherte Fahrzeugidentität und Quellen. Nicht jede Quelle stellt Dokumente bereit. |
+| Dokumentimport schlägt fehl | Prüfe öffentliche URL, Weiterleitungen, Typ, Größe und externe Verfügbarkeit. |
+| Dokumentstapel schlägt teilweise fehl | Frühere Dokumente bleiben gespeichert. Lade neu und wiederhole nur fehlende URLs. |
+| Extraktion findet nichts | Prüfe Fahrzeug-Artikelnummer, Inhalt, Textextraktion und optionale OCR. |
+| Extraktion schlägt teilweise fehl | Metadaten und frühere Ersatzteile können gespeichert sein. Lade neu und vergleiche. |
+| Ersatzteilformular wird abgelehnt | Trage Artikelnummer, Beschreibung oder Link ein. Ein Preis allein reicht nicht. |
+| Einzelsuche ist deaktiviert | Speichere eine Ersatzteil-Artikelnummer und aktiviere die Artikelsuche. |
+| Verfügbarkeit ist unbekannt | Behandle sie als ungeprüften externen Status und öffne die Quelle. |
+| Herstellerübersicht ist deaktiviert | Sie benötigt Piko oder Roco und die gespeicherte Fahrzeug-Artikelnummer. |
+| Herstellerimport schlägt teilweise fehl | Lade neu, vergleiche und wiederhole erst nach Prüfung der gespeicherten Ergebnisse. |
+| Ersatzteil wurde ohne Nachfrage gelöscht | Löschen wirkt sofort. Wiederherstellung benötigt eine geeignete Sicherung. |
+
+Einige stabile Backend- und Frontendzweige zeigen auch im englischen Sprachmodus deutsche Fehler.
+Behandle dies als Einschränkung der stabilen Oberfläche und leite aus den Speicherregeln oben ab,
+was bereits geschrieben worden sein kann.
+
+## Verwandte Seiten
+
+- [Übersicht des Benutzerhandbuchs](/de/guide/)
+- [Fahrzeugbestand und Grunddaten](/de/guide/vehicles/)
+- [Fahrzeugbilder und Beilagen](/de/guide/vehicles/media)
+- [Fahrzeugwartung und Zustand](/de/guide/vehicles/maintenance)
+- [Decoder, Funktionen und CV-Daten](/de/guide/vehicles/decoder-cv)
+
+## Dokumentierte RailKeeper-Version
+
+Diese Seite dokumentiert die stabile RailKeeper-Version **v0.1.17.6** und wurde zuletzt am
+16.08.2026 geprüft.

--- a/docs/site/de/guide/vehicles/search-and-spares.md
+++ b/docs/site/de/guide/vehicles/search-and-spares.md
@@ -225,8 +225,10 @@ keine Lieferzusage.
 - das Fahrzeug ist gespeichert;
 - sein Herstellername enthält Piko oder Roco;
 - die Fahrzeug-Artikelnummer ist nicht leer;
-- die Artikelsuche ist in diesem Browser aktiviert;
 - der Benutzer hat als Admin oder Editor Zugriff auf den bearbeitbaren Dialog.
+
+Die Schaltfläche kann auch bei deaktivierter Artikelsuche gewählt werden. RailKeeper bricht dann
+vor der externen Anfrage ab, zeigt den Hinweis auf die Einstellungen und speichert nichts.
 
 RailKeeper durchsucht die Herstellerübersicht und erstellt einen zurückhaltenden Importplan. Die
 Zuordnung bevorzugt normalisierte Ersatzteil-Artikelnummer, dann Beschreibung, dann URL. Wiederholte

--- a/docs/site/guide/index.md
+++ b/docs/site/guide/index.md
@@ -35,3 +35,7 @@ due dates, completion, costs, linked media, and safe deletion.
 
 [Decoder, functions, and CV data](/guide/vehicles/decoder-cv) covers F0-F31 mappings, the read-only
 speed curve, CV values and exchange, decoder-file previews, and safe persistence.
+
+[Article search, web documents, and spare parts](/guide/vehicles/search-and-spares) explains how to
+verify external suggestions, save selected article data and images, import documents, and maintain
+spare parts without overlooking partial writes.

--- a/docs/site/guide/vehicles/decoder-cv.md
+++ b/docs/site/guide/vehicles/decoder-cv.md
@@ -298,6 +298,7 @@ No failed later request rolls back an earlier successful request in the same seq
 - [Vehicle inventory and core records](/guide/vehicles/)
 - [Vehicle images and attachments](/guide/vehicles/media)
 - [Vehicle maintenance and condition](/guide/vehicles/maintenance)
+- [Article search, web documents, and spare parts](/guide/vehicles/search-and-spares)
 
 ## Documented RailKeeper version
 

--- a/docs/site/guide/vehicles/index.md
+++ b/docs/site/guide/vehicles/index.md
@@ -302,6 +302,7 @@ important records; the application does not promise physical cleanup of every re
 - [Vehicle images and attachments](/guide/vehicles/media)
 - [Vehicle maintenance and condition](/guide/vehicles/maintenance)
 - [Decoder, functions, and CV data](/guide/vehicles/decoder-cv)
+- [Article search, web documents, and spare parts](/guide/vehicles/search-and-spares)
 - [First setup and sign-in](/guide/getting-started/)
 - [Overview, metrics, and data quality](/guide/overview/)
 - [Administration overview](/administration/)

--- a/docs/site/guide/vehicles/maintenance.md
+++ b/docs/site/guide/vehicles/maintenance.md
@@ -159,6 +159,7 @@ A failed action does not undo an earlier successful independent maintenance or m
 - [Vehicle inventory and core records](/guide/vehicles/)
 - [Vehicle images and attachments](/guide/vehicles/media)
 - [Decoder, functions, and CV data](/guide/vehicles/decoder-cv)
+- [Article search, web documents, and spare parts](/guide/vehicles/search-and-spares)
 
 ## Documented RailKeeper version
 

--- a/docs/site/guide/vehicles/media.md
+++ b/docs/site/guide/vehicles/media.md
@@ -111,9 +111,10 @@ file in the restore panel. Rely on it only after RailKeeper accepts it as compat
 makes no promise about copies downloaded or created outside RailKeeper.
 
 Admin, Editor, Viewer, and Planner may inspect existing media. Server-side writes require Admin or
-Editor. **Open source** is the transition for imported image sources. **Found documents**,
-**Extract spare parts**, web-document import, remote article images, CV files, and editing
-maintenance records are specialist boundaries, not workflows explained on this page.
+Editor. **Open source** is the transition for imported image sources. See
+[Article search, web documents, and spare parts](/guide/vehicles/search-and-spares) for remote
+article images, **Found documents**, web-document import, and **Extract spare parts**. CV files and
+editing maintenance records remain specialist boundaries that are not explained on this page.
 
 ## Empty, partial, and error states
 
@@ -138,6 +139,7 @@ maintenance records are specialist boundaries, not workflows explained on this p
 - [Vehicle inventory and basic data](/guide/vehicles/)
 - [Vehicle maintenance and condition](/guide/vehicles/maintenance)
 - [Decoder, functions, and CV data](/guide/vehicles/decoder-cv)
+- [Article search, web documents, and spare parts](/guide/vehicles/search-and-spares)
 
 ## Documented RailKeeper version
 

--- a/docs/site/guide/vehicles/search-and-spares.md
+++ b/docs/site/guide/vehicles/search-and-spares.md
@@ -209,8 +209,10 @@ a purchase promise.
 - the vehicle is saved;
 - its manufacturer name contains Piko or Roco;
 - the vehicle article number is not empty;
-- article search is enabled in this browser;
 - the user has Admin or Editor access to the editable UI.
+
+The button can still be selected while article search is disabled. In that case RailKeeper stops
+before the external request, displays the Settings message, and stores nothing.
 
 RailKeeper searches the manufacturer overview and builds a conservative import plan. Matching
 prefers normalized spare-part article number, then description, then URL. Repeated suggestions are

--- a/docs/site/guide/vehicles/search-and-spares.md
+++ b/docs/site/guide/vehicles/search-and-spares.md
@@ -30,7 +30,8 @@ therefore use different settings.
 
 The default sources are manufacturer sites, Modellbahn-Fokus catalogs, dealer sites, and general
 web search. Modellbau Wiki is an optional fifth source. Normal article and document searches
-require:
+require the values below. RailKeeper migrates recognized legacy default-source combinations to the
+current defaults when it reads the browser preference.
 
 - manufacturer;
 - gauge;
@@ -148,7 +149,8 @@ compare the attachment list, and retry only missing URLs.
 
 Every stored attachment offers **Extract spare parts**. The action first saves that selected
 attachment's current description, category, and maintenance link. It then analyzes only this
-attachment, switches to **Spare parts**, and reloads the vehicle.
+attachment and creates the accepted suggestions. Only after the complete sequence succeeds does
+RailKeeper reload the vehicle and switch to **Spare parts**.
 
 Extraction requires a saved vehicle article number. The server reads at most 12 MiB from the
 attachment and returns at most 80 unique suggestions. Likely spare-parts PDFs, manuals, service
@@ -161,8 +163,9 @@ document-title-like rows, removes duplicates already stored on the vehicle, and 
 remaining candidate sequentially. A source URL pointing back to RailKeeper's own attachment
 download is not stored as an external spare-part link.
 
-Attachment metadata and earlier spare parts remain stored if a later create request fails. Reload
-the vehicle and compare its attachment and spare-part data before retrying.
+Attachment metadata and earlier spare parts remain stored if a later request fails. The normal
+reload and tab switch then do not occur. Reload the vehicle manually and compare its attachment and
+spare-part data before retrying.
 
 ## Maintain spare parts manually
 

--- a/docs/site/guide/vehicles/search-and-spares.md
+++ b/docs/site/guide/vehicles/search-and-spares.md
@@ -1,0 +1,292 @@
+---
+title: Article search, web documents, and spare parts
+description: Verify external article data, import web documents, and maintain vehicle spare parts.
+audience: user
+status: stable
+reviewedVersion: 0.1.17.6
+lastReviewed: 2026-08-16
+---
+
+# Article search, web documents, and spare parts
+
+RailKeeper can use external suggestions to complete a vehicle, import reference documents, and
+maintain spare parts. Those results are starting points, not authoritative model data. Open the
+source and verify the manufacturer and article identity before storing anything.
+
+This workflow has four distinct states:
+
+| State | Meaning |
+| --- | --- |
+| Search result | External suggestion, not stored |
+| Applied field or selected image | Local vehicle-editor state, not yet stored |
+| Imported document or spare-part action | Immediate server-side write |
+| Saved vehicle | Core fields and pending images persisted through the vehicle-save workflow |
+
+## Prerequisites, settings, and access rights
+
+**Article data web search** is enabled by default unless it was disabled in Settings. Its enabled
+flag and selected sources are preferences in the current browser. Another browser or device can
+therefore use different settings.
+
+The default sources are manufacturer sites, Modellbahn-Fokus catalogs, dealer sites, and general
+web search. Modellbau Wiki is an optional fifth source. Normal article and document searches
+require:
+
+- manufacturer;
+- gauge;
+- article number or designation.
+
+An EAN-only barcode search is the exception and can run without those identity values.
+
+Admin and Editor can use the editable vehicle UI, import files, and change spare parts. Viewer and
+Planner can inspect stored vehicles, attachments, and spare parts. The article-search API permits
+Viewer-level read access, but the read-only vehicle UI still disables search and apply controls.
+Image, attachment, and spare-part writes require Editor-level server access. Messe does not receive
+the general vehicle workflow.
+
+## Search for article data
+
+Open a vehicle editor and use **Search article data** in **Model**. The action remains disabled
+until manufacturer, gauge, and either article number or designation are present. RailKeeper sends
+those values together with other non-empty searchable vehicle fields and the sources selected in
+this browser.
+
+The server trims the input and can enrich a known manufacturer with aliases and preferred domains.
+It builds several targeted queries, applies a ten-second service timeout, scores and sorts the
+results, removes duplicate URLs, and returns at most ten results. Piko and Roco searches can also
+include direct manufacturer-specific spare-part results.
+
+The result dialog exposes the evidence behind the suggestions:
+
+- final query, active source classes, preferred domains, and planned search queries;
+- result title, source, score, snippet, and number of fields;
+- whether the detail page loaded, failed, or was skipped;
+- **Open source** for independent checking;
+- found images and their previews;
+- current and found values, their status, and conflicts.
+
+The stable result groups contain these fields:
+
+| Group | Visible fields |
+| --- | --- |
+| Model | Designation, article no., manufacturer, gauge, EAN, railway, epoch, series, vehicle no., subtype, category |
+| Mass / construction | Length, weight, color, lettering, load, interior, axles, axle count, traction tires |
+| Technology | Adapter, pickups, digital/decoder data, sound, lights, and technical descriptions |
+| More data | Description, additional information, production period, list price, and source URL |
+
+RailKeeper removes obviously empty, advertising, cookie, manual-navigation, and implausible field
+values before display. Filtering and a high score improve review efficiency, but neither proves
+that a remaining value belongs to the physical model.
+
+## Search by barcode or camera
+
+Use **Search barcode** in **Model** to open an EAN field initialized from the current vehicle form.
+Type or paste the value, use a keyboard scanner, or start the camera.
+
+Submitting a non-empty code copies it into the local EAN field, leaves the article number
+unchanged, closes the barcode dialog, and runs an EAN-only search. The EAN is not stored until the
+vehicle itself is saved.
+
+Camera scanning requires:
+
+- a secure browser context such as HTTPS or localhost;
+- browser camera support and permission;
+- a readable code with at least eight digits after non-digits are removed.
+
+RailKeeper requests the environment-facing camera when available. Detection fills the field but
+does not submit the search automatically. If permission, browser support, or detection fails, enter
+the EAN manually or use a keyboard scanner.
+
+## Review and apply one result
+
+Selections belong to one result at a time. A found field starts selected only when the current
+vehicle field is empty. Equal values and conflicts are not selected automatically. Images are
+never preselected. An image whose preview fails disappears and is removed from the selection.
+
+Open the source and compare the article identity before selecting anything. Check conflicts and
+plausibility across all field groups. **Apply selected fields** then applies only the checked valid
+fields from this result. Boolean text is converted into RailKeeper's stable boolean
+representation. Selected images become pending remote images. If no image is already pending, the
+first selected image becomes the main-image candidate.
+
+Applying closes the result dialog but does not write to the server. Inspect the complete vehicle
+form and pending image list, then use **Create** or **Save changes**. Closing the vehicle editor or
+reloading before that save loses the applied fields, EAN, and pending images.
+
+Vehicle save writes the core vehicle first, then downloads selected remote images sequentially. If
+a later image fails, the vehicle and earlier images remain stored, and the normal final refresh is
+not performed. Reload the vehicle, compare its stored images, and retry only the missing ones. See
+[Vehicle images and attachments](/guide/vehicles/media) for ordering, metadata, previews,
+maintenance links, and deletion after import.
+
+## Find and import web documents
+
+Open the saved vehicle's **Uploads** tab and use **Found documents**. The search uses the vehicle's
+stored identity and the normal manufacturer, gauge, and article-number-or-designation requirement.
+Results are deduplicated by URL or title and show title, kind, and source.
+
+RailKeeper recognizes a previously imported document when its URL occurs in an attachment
+description. Such a row cannot be selected again and offers local download and open actions.
+Import one remaining result, or select all results that are not already stored.
+
+An import downloads the external content and stores it as a real local vehicle attachment. Its
+description records the source and source URL. RailKeeper infers one of these categories:
+
+- `Ersatzteilliste` for spare-parts signals;
+- `Anleitung` for manual or instruction signals;
+- `Dokumentation` otherwise.
+
+The server accepts only public HTTP(S) URLs, rechecks redirect destinations, and blocks private or
+internal targets. It also enforces the configured attachment size and type rules, rejects empty
+files, and applies a ten-second remote request timeout.
+
+Importing several selected documents sends requests sequentially. A later failure leaves earlier
+documents stored and prevents the normal final refresh and selection reset. Reload the vehicle,
+compare the attachment list, and retry only missing URLs.
+
+## Extract spare parts from an attachment
+
+Every stored attachment offers **Extract spare parts**. The action first saves that selected
+attachment's current description, category, and maintenance link. It then analyzes only this
+attachment, switches to **Spare parts**, and reloads the vehicle.
+
+Extraction requires a saved vehicle article number. The server reads at most 12 MiB from the
+attachment and returns at most 80 unique suggestions. Likely spare-parts PDFs, manuals, service
+sheets, HTML, and supported text content can be analyzed. PDF text is extracted directly first.
+Scanned PDFs can use optional OCR supplied by the operator. Without working OCR, a scan can
+legitimately produce no suggestions.
+
+The stable action has no confirmation or row preview. It cleans descriptions, drops empty and
+document-title-like rows, removes duplicates already stored on the vehicle, and creates every
+remaining candidate sequentially. A source URL pointing back to RailKeeper's own attachment
+download is not stored as an external spare-part link.
+
+Attachment metadata and earlier spare parts remain stored if a later create request fails. Reload
+the vehicle and compare its attachment and spare-part data before retrying.
+
+## Maintain spare parts manually
+
+The **Spare parts** tab becomes writable after the vehicle exists. The editor contains article
+number, description, price as free text, and external link. At least article number, description,
+or link is required. Price alone is invalid.
+
+New and updated values are trimmed. The initial table order is article number ascending. Select a
+column heading to toggle ascending or descending order for article number, description, price, or
+link.
+
+Creating a part with an existing identity updates the matching entry instead of adding another
+row. Identity uses normalized article number first, otherwise normalized URL, otherwise
+description. Article-number normalization ignores an `ET` prefix, punctuation, spaces, and case.
+The create merge preserves existing non-empty values and fills only fields that are still empty.
+Editing a selected row writes exactly its four submitted fields.
+
+Save, apply, and delete actions persist immediately and reload the complete vehicle after success.
+Delete has no additional confirmation. Because a full reload replaces unrelated unsaved
+vehicle-editor state, save or intentionally discard other edits first.
+
+## Look up one stored spare part
+
+A stored part with an article number offers **Search this spare part**. The lookup uses the vehicle
+manufacturer, the spare-part article number, manufacturer and catalog sources, and a Piko or Roco
+lookup mode when applicable. The stable UI displays at most five candidates, preferring results
+with price, then availability, then link.
+
+Each result can show price, availability, source, and an external link. **Apply price and link**
+updates the stored part immediately. Article number and description remain unchanged.
+Availability is displayed but not stored. If the selected candidate has no price, the stable
+controller can use another priced candidate's price and URL from the same result list.
+
+Opening the tab also checks linked spare parts once for the current vehicle state. Piko and Roco
+use one manufacturer-overview request. Other manufacturers check only the first four externally
+linked parts that also have article numbers. The indicator classifies recognizable text as
+available, limited, unavailable, or unknown. It remains a live suggestion, not local inventory or
+a purchase promise.
+
+## Import a Piko or Roco manufacturer overview
+
+**Find available spare parts** is enabled only when all of these conditions are met:
+
+- the vehicle is saved;
+- its manufacturer name contains Piko or Roco;
+- the vehicle article number is not empty;
+- article search is enabled in this browser;
+- the user has Admin or Editor access to the editable UI.
+
+RailKeeper searches the manufacturer overview and builds a conservative import plan. Matching
+prefers normalized spare-part article number, then description, then URL. Repeated suggestions are
+consolidated. Existing matches are updated first, and missing parts are created second.
+
+Existing article number and description are retained. Existing price and external URL also win;
+only missing price or URL is filled. The updates and creates run sequentially without a transaction
+or confirmation preview. A later failure leaves earlier rows stored and prevents the normal final
+refresh. Reload and compare before retrying. **No missing spare parts found** can mean that every
+manufacturer suggestion already matches a stored row, not that the manufacturer has no parts.
+
+## Protect data during multi-step actions
+
+The timing of persistence and refresh differs by action:
+
+| Action | Persists data | Full vehicle refresh |
+| --- | --- | --- |
+| Run article or barcode search | No | No |
+| Apply result fields or images | No, local editor only | No |
+| Save vehicle after applying a result | Core vehicle, then remote images sequentially | Only after full success |
+| Search found documents | No | No |
+| Import one web document | Immediately | After success |
+| Import selected web documents | Sequentially | Only after full success |
+| Extract spare parts | Attachment metadata, then parts sequentially | Only after full success |
+| Add, update, apply lookup, or delete one spare part | Immediately | After success |
+| Check price or availability | No | No |
+| Import Piko/Roco overview | Updates, then creates sequentially | Only after full success |
+
+No later failed request rolls back an earlier successful request in the same sequential workflow.
+Reload, compare stored data, and retry only missing work after any partial failure.
+
+Search responses, result selections, and unsaved form changes are transient browser state and do
+not belong to a backup. Once saved, article-derived vehicle fields, imported images, attachment
+metadata and blobs, and vehicle spare parts belong to local RailKeeper application data and are
+included in the application backup scope.
+
+Before a large document batch, extraction run, manufacturer import, or cleanup, create an
+application backup and validate it. External source URLs and spare-part links can still disappear
+outside RailKeeper and are not made durable by a local backup.
+
+## Resolve empty, partial, and error states
+
+| Situation | What to do |
+| --- | --- |
+| Article search is disabled | Enable it in Settings for this browser, or continue without external suggestions. |
+| Normal search is disabled | Enter manufacturer, gauge, and article number or designation. |
+| Camera does not start | Use HTTPS or localhost, check permission and support, or enter the code manually. |
+| No article result appears | Refine the identity and selected sources without weakening source verification. |
+| Detail page failed or was skipped | Open the source and use only fields you can verify. |
+| A found image disappears | Its preview failed. Select a different source image. |
+| Applied values vanish | They were local draft state. Apply them again and save the vehicle. |
+| Remote-image save partly fails | Reload and compare stored images before retrying only missing ones. |
+| No web documents appear | Check saved vehicle identity and sources. Not every source exposes documents. |
+| Document import fails | Check public URL, redirects, type, size, and remote availability. |
+| Document batch partly fails | Earlier documents remain stored. Reload and retry only missing URLs. |
+| Extraction finds nothing | Check vehicle article number, content, text extraction, and optional OCR. |
+| Extraction partly fails | Metadata and earlier parts can already be stored. Reload and compare. |
+| Spare-part form is rejected | Enter article number, description, or link. Price alone is insufficient. |
+| Single lookup is disabled | Store a spare-part article number and enable article search. |
+| Availability is unknown | Treat it as unverified external status and open the source. |
+| Manufacturer overview is disabled | It requires Piko or Roco and the saved vehicle article number. |
+| Manufacturer import partly fails | Reload, compare, and rerun only after understanding stored results. |
+| A spare part was deleted without a prompt | Deletion is immediate. Recovery requires a suitable backup. |
+
+Some stable backend and frontend branches still show German errors in English mode. Treat the
+message as a stable UI limitation and use the persistence rules above to determine what may already
+have been stored.
+
+## Related pages
+
+- [User Guide overview](/guide/)
+- [Vehicle inventory and basic data](/guide/vehicles/)
+- [Vehicle images and attachments](/guide/vehicles/media)
+- [Vehicle maintenance and condition](/guide/vehicles/maintenance)
+- [Decoder, functions, and CV data](/guide/vehicles/decoder-cv)
+
+## Documented RailKeeper version
+
+This page documents stable RailKeeper **v0.1.17.6** and was last reviewed on 2026-08-16.

--- a/docs/superpowers/plans/2026-08-16-railkeeper-vehicle-search-spares-guide.md
+++ b/docs/superpowers/plans/2026-08-16-railkeeper-vehicle-search-spares-guide.md
@@ -180,7 +180,8 @@ Web documents
 
 Attachment extraction
 - Extract spare parts first saves the selected attachment metadata, then analyzes only that
-  attachment, switches tabs, and reloads the vehicle.
+  attachment and creates accepted suggestions. Only full success reloads the vehicle and switches
+  tabs. A failure skips both final actions.
 - A saved vehicle article number is required.
 - Analysis reads at most 12 MiB and returns at most 80 unique suggestions.
 - PDFs use direct text first; optional OCR may help scanned PDFs.

--- a/docs/superpowers/plans/2026-08-16-railkeeper-vehicle-search-spares-guide.md
+++ b/docs/superpowers/plans/2026-08-16-railkeeper-vehicle-search-spares-guide.md
@@ -1,0 +1,651 @@
+# RailKeeper Vehicle Search and Spare Parts Guide Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish a complete English and German stable user-guide chapter for vehicle article
+search, barcode/EAN search, web-document import, attachment extraction, and spare-part workflows.
+
+**Architecture:** Add one paired VitePress chapter and promote its existing coverage topic from
+`planned` to `documented`. Keep the chapter workflow-first, connect it only to already published
+user-guide owners, and verify every behavior claim against tag `v0.1.17.6` before publication.
+
+**Tech Stack:** Markdown, JSON, TypeScript VitePress configuration, Node.js documentation tests,
+VitePress 2.0.0-alpha.19, GitHub Actions, GitHub Pages.
+
+## Global Constraints
+
+- Document stable RailKeeper `v0.1.17.6`, never later behavior from `main`.
+- Use review date `2026-08-16` and the established user-guide frontmatter contract.
+- Keep English and German pages in the same semantic section order with equivalent safety guidance.
+- Treat search results, prices, availability, documents, and extracted values as untrusted
+  suggestions until the user verifies them.
+- Clearly separate transient search state, unsaved vehicle-editor state, immediate server writes,
+  and saved vehicle data.
+- State every sequential, non-atomic workflow and its reload, compare, retry recovery sequence.
+- Link only to published pages. Do not activate links to planned settings, master-data, accessory,
+  administration, or digital-center chapters.
+- Do not change runtime behavior, APIs, schemas, dependencies, screenshots, or generated output.
+- Work only in `.worktrees/docs-user-guide-search-spares` on
+  `dev/docs-user-guide-search-spares`. Do not modify or push local `main`.
+- Preserve LF, UTF-8, approximately 100 to 120 character lines, and the existing documentation
+  style. Do not use em dashes or unfinished-content markers.
+- Merge only after local checks, independent review, and every required GitHub check pass for the
+  exact reviewed head SHA.
+
+---
+
+## File map
+
+| File | Responsibility |
+| --- | --- |
+| `docs/coverage.json` | Promote `vehicle-search-spares` to a published bilingual topic. |
+| `docs/site/guide/vehicles/search-and-spares.md` | English workflow and recovery reference. |
+| `docs/site/de/guide/vehicles/search-and-spares.md` | German semantic counterpart. |
+| `docs/.vitepress/config.mts` | Add both routes after the decoder/CV chapter. |
+| `docs/site/guide/index.md` | Add the English User Guide landing transition. |
+| `docs/site/de/guide/index.md` | Add the German User Guide landing transition. |
+| `docs/site/guide/vehicles/index.md` | Link from vehicle core data to search and spare parts. |
+| `docs/site/de/guide/vehicles/index.md` | German core-vehicle link. |
+| `docs/site/guide/vehicles/media.md` | Replace the specialist boundary with a published transition. |
+| `docs/site/de/guide/vehicles/media.md` | German media transition. |
+| `docs/site/guide/vehicles/maintenance.md` | Add the published related-page link. |
+| `docs/site/de/guide/vehicles/maintenance.md` | German maintenance link. |
+| `docs/site/guide/vehicles/decoder-cv.md` | Add the published related-page link. |
+| `docs/site/de/guide/vehicles/decoder-cv.md` | German decoder/CV link. |
+| `docs/aegis/work/2026-08-16-vehicle-search-spares-guide/*` | Maintain execution and evidence state. |
+
+---
+
+### Task 1: Publish the coverage contract and bilingual page pair
+
+**Files:**
+- Modify: `docs/coverage.json`
+- Create: `docs/site/guide/vehicles/search-and-spares.md`
+- Create: `docs/site/de/guide/vehicles/search-and-spares.md`
+- Reference: `docs/superpowers/specs/2026-08-16-railkeeper-vehicle-search-spares-guide-design.md`
+
+**Interfaces:**
+- Consumes: existing topic ID `vehicle-search-spares`, its assigned frontend/backend ownership,
+  and the stable-source facts in the approved specification.
+- Produces: the validated routes `/guide/vehicles/search-and-spares` and
+  `/de/guide/vehicles/search-and-spares` for Task 2.
+
+- [ ] **Step 1: Turn the existing coverage topic into an intentional failing gate**
+
+Change only this field on the `vehicle-search-spares` topic:
+
+```json
+"status": "documented"
+```
+
+Run from `docs`:
+
+```powershell
+node scripts/validate-docs.mjs
+```
+
+Expected: validation fails because both configured Markdown pages are absent. The failure must name
+the `vehicle-search-spares` paths. Any ownership or schema error is unexpected and must be fixed
+before continuing.
+
+- [ ] **Step 2: Create the English page with the exact contract and section order**
+
+Create `docs/site/guide/vehicles/search-and-spares.md` with this frontmatter and heading structure:
+
+```markdown
+---
+title: Article search, web documents, and spare parts
+description: Verify external article data, import web documents, and maintain vehicle spare parts.
+audience: user
+status: stable
+reviewedVersion: 0.1.17.6
+lastReviewed: 2026-08-16
+---
+
+# Article search, web documents, and spare parts
+
+## Prerequisites, settings, and access rights
+
+## Search for article data
+
+## Search by barcode or camera
+
+## Review and apply one result
+
+## Find and import web documents
+
+## Extract spare parts from an attachment
+
+## Maintain spare parts manually
+
+## Look up one stored spare part
+
+## Import a Piko or Roco manufacturer overview
+
+## Protect data during multi-step actions
+
+## Resolve empty, partial, and error states
+
+## Related pages
+
+## Documented RailKeeper version
+```
+
+Write complete operational prose under those headings. The page must include every item below,
+using the exact stable values shown:
+
+```text
+Prerequisites and roles
+- Article data web search is enabled by default and its enabled flag and source choices are local
+  to the current browser.
+- Default sources: manufacturer sites, Modellbahn-Fokus catalogs, dealer sites, and general web;
+  Modellbau Wiki is optional.
+- Normal search requires manufacturer, gauge, and article number or designation.
+- EAN-only search is the exception.
+- Admin and Editor can write. Viewer and Planner inspect stored data. Messe is excluded.
+- The Viewer-level search API does not make the read-only vehicle UI editable.
+
+Article and barcode search
+- Model-tab actions are Search barcode and Search article data.
+- Search sends the stable identity and non-empty searchable fields, uses a ten-second service
+  timeout, deduplicates by URL, sorts by score, and returns at most ten results.
+- Result review covers final query, active source classes, preferred domains, planned queries,
+  score, snippet, detail-page state, source, images, field status, and conflicts.
+- Cover all four field groups from the specification without inventing stable fields.
+- Camera requires HTTPS or localhost, browser support, and permission. It requests the
+  environment-facing camera, strips non-digits, requires at least eight digits, fills the field,
+  and never auto-submits.
+- Manual input and keyboard scanners remain the fallback.
+
+Review, apply, and vehicle persistence
+- Only fields whose current value is empty start selected. Equal/conflicting values do not.
+- Images never start selected. Failed previews disappear from selection.
+- Apply selected fields updates one local editor draft only. Boolean text is normalized.
+- Selected images become pending remote images and the first can become the main candidate.
+- Create or Save changes is required. Closing or reloading first loses draft changes.
+- Vehicle save writes the core vehicle first, then remote images sequentially.
+- A later image failure keeps the vehicle and earlier images. Reload, compare, retry only missing
+  images.
+
+Web documents
+- Found documents requires a saved vehicle and normal identity values.
+- Results deduplicate by URL or title. Imported detection uses the source URL stored in an
+  attachment description.
+- A stored row offers local download/open and cannot be selected again.
+- Imports become real local attachments and record source plus URL.
+- Category inference is Ersatzteilliste, Anleitung, or Dokumentation.
+- Only public HTTP(S) URLs are accepted. Redirects are rechecked. Private/internal targets, empty
+  content, disallowed types, and oversized content are rejected. Remote timeout is ten seconds.
+- Multi-document imports are sequential. Earlier success survives later failure.
+
+Attachment extraction
+- Extract spare parts first saves the selected attachment metadata, then analyzes only that
+  attachment, switches tabs, and reloads the vehicle.
+- A saved vehicle article number is required.
+- Analysis reads at most 12 MiB and returns at most 80 unique suggestions.
+- PDFs use direct text first; optional OCR may help scanned PDFs.
+- Stable extraction has no row preview or confirmation and creates all remaining candidates
+  sequentially.
+- Existing duplicates, empty rows, and document-title-like rows are removed.
+- An internal RailKeeper attachment-download URL is not stored as an external part link.
+- Metadata and earlier created rows survive a later failure.
+
+Manual spare parts
+- Fields: article number, description, free-text price, and external link.
+- Article number, description, or link is required. Price alone is invalid.
+- Initial sort is article number ascending. All four columns toggle ascending/descending.
+- Create identity uses normalized article number first, then normalized URL, then description.
+- Article normalization ignores ET prefix, punctuation, spaces, and case.
+- Create merge preserves existing non-empty values and fills only missing values.
+- Editing a selected row writes exactly its four submitted fields.
+- Save, apply, and delete write immediately and reload the full vehicle. Delete has no prompt.
+- A full reload replaces unrelated unsaved editor state.
+
+Lookup and manufacturer overview
+- Single-part search requires a stored part article number and returns at most five candidates.
+- Sort priority: has price, then has availability, then has link.
+- Apply price and link persists only price and URL. Availability is display-only.
+- If the selected result lacks price, stable code may apply another priced candidate's price and
+  URL from the same result list.
+- Opening the tab checks linked rows once. Piko/Roco use one overview request. Other manufacturers
+  inspect only the first four linked rows that have article numbers.
+- Availability remains an unverified suggestion.
+- Find available spare parts requires a saved Piko/Roco vehicle, vehicle article number, enabled
+  article search, and writable UI.
+- Overview import consolidates duplicates, updates existing rows first, then creates missing rows.
+- Existing article number, description, price, and URL win. Only missing price/URL are filled.
+- The sequence is non-atomic and has no preview. No missing spare parts found can mean every
+  suggestion already matched.
+
+Storage and recovery
+- Include the complete persistence/refresh matrix from the approved specification.
+- State that no later request rolls back an earlier successful sequential write.
+- Saved article-derived fields, imported images, attachment blobs, and spare parts are included in
+  application backup scope. Search responses, selections, and unsaved drafts are not.
+- Recommend a validated application backup before large imports, extraction, or cleanup.
+- Include all 17 empty, partial, and error situations from the approved specification.
+- Mention that stable English mode can still show some German backend/frontend messages.
+```
+
+End the English page with exactly these published links and version statement:
+
+```markdown
+## Related pages
+
+- [User Guide overview](/guide/)
+- [Vehicle inventory and basic data](/guide/vehicles/)
+- [Vehicle images and attachments](/guide/vehicles/media)
+- [Vehicle maintenance and condition](/guide/vehicles/maintenance)
+- [Decoder, functions, and CV data](/guide/vehicles/decoder-cv)
+
+## Documented RailKeeper version
+
+This page documents stable RailKeeper **v0.1.17.6** and was last reviewed on 2026-08-16.
+```
+
+- [ ] **Step 3: Create the German semantic counterpart**
+
+Create `docs/site/de/guide/vehicles/search-and-spares.md` with this frontmatter and matching
+section order:
+
+```markdown
+---
+title: Artikelsuche, Web-Dokumente und Ersatzteile
+description: Externe Artikeldaten prüfen, Web-Dokumente importieren und Fahrzeugersatzteile pflegen.
+audience: user
+status: stable
+reviewedVersion: 0.1.17.6
+lastReviewed: 2026-08-16
+---
+
+# Artikelsuche, Web-Dokumente und Ersatzteile
+
+## Voraussetzungen, Einstellungen und Zugriffsrechte
+
+## Nach Artikeldaten suchen
+
+## Mit Barcode oder Kamera suchen
+
+## Ein Suchergebnis prüfen und übernehmen
+
+## Web-Dokumente finden und importieren
+
+## Ersatzteile aus einer Beilage extrahieren
+
+## Ersatzteile manuell pflegen
+
+## Ein gespeichertes Ersatzteil nachschlagen
+
+## Eine Piko- oder Roco-Herstellerübersicht importieren
+
+## Daten bei mehrstufigen Aktionen schützen
+
+## Leere, teilweise und fehlerhafte Zustände beheben
+
+## Verwandte Seiten
+
+## Dokumentierte RailKeeper-Version
+```
+
+Translate every English requirement from Step 2 semantically, including every numeric bound,
+role, ordering rule, persistence boundary, partial-failure warning, and recovery action. Use the
+real German UI labels from stable translations where they exist. Keep technical stored category
+values `Ersatzteilliste`, `Anleitung`, and `Dokumentation` unchanged. Do not translate source names,
+API concepts, or Piko/Roco identity rules into behavior that stable code does not implement.
+
+End the German page with exactly:
+
+```markdown
+## Verwandte Seiten
+
+- [Übersicht des Benutzerhandbuchs](/de/guide/)
+- [Fahrzeugbestand und Grunddaten](/de/guide/vehicles/)
+- [Fahrzeugbilder und Beilagen](/de/guide/vehicles/media)
+- [Fahrzeugwartung und Zustand](/de/guide/vehicles/maintenance)
+- [Decoder, Funktionen und CV-Daten](/de/guide/vehicles/decoder-cv)
+
+## Dokumentierte RailKeeper-Version
+
+Diese Seite dokumentiert die stabile RailKeeper-Version **v0.1.17.6** und wurde zuletzt am
+16.08.2026 geprüft.
+```
+
+- [ ] **Step 4: Verify page parity and make the coverage gate pass**
+
+Run from the repository root:
+
+```powershell
+rg -n '^## ' docs/site/guide/vehicles/search-and-spares.md
+rg -n '^## ' docs/site/de/guide/vehicles/search-and-spares.md
+rg -n '10|12 MiB|80|first four|v0.1.17.6|sequential' docs/site/guide/vehicles/search-and-spares.md
+rg -n '10|12 MiB|80|ersten vier|v0.1.17.6|nacheinander' docs/site/de/guide/vehicles/search-and-spares.md
+$markers = @('TO' + 'DO', 'T' + 'BD', 'FIX' + 'ME', [char]0x2014)
+$pages = @(
+  'docs/site/guide/vehicles/search-and-spares.md',
+  'docs/site/de/guide/vehicles/search-and-spares.md'
+)
+Select-String -Path $pages -Pattern $markers
+git diff --check
+Set-Location docs
+npm.cmd run check
+```
+
+Expected: both pages have the same 13-section semantic order, key-fact scans find the stable
+bounds and sequential-write guidance, the marker scan and `git diff --check` print nothing, all 19
+tests pass, coverage validation succeeds, and VitePress builds.
+
+- [ ] **Step 5: Commit the coverage contract and paired chapter**
+
+Run from the repository root:
+
+```powershell
+git add docs/coverage.json docs/site/guide/vehicles/search-and-spares.md
+git add docs/site/de/guide/vehicles/search-and-spares.md
+git commit -m "docs: add vehicle search and spare parts guide"
+```
+
+---
+
+### Task 2: Connect sidebars, landing pages, and published related pages
+
+**Files:**
+- Modify: `docs/.vitepress/config.mts`
+- Modify: `docs/site/guide/index.md`
+- Modify: `docs/site/de/guide/index.md`
+- Modify: `docs/site/guide/vehicles/index.md`
+- Modify: `docs/site/de/guide/vehicles/index.md`
+- Modify: `docs/site/guide/vehicles/media.md`
+- Modify: `docs/site/de/guide/vehicles/media.md`
+- Modify: `docs/site/guide/vehicles/maintenance.md`
+- Modify: `docs/site/de/guide/vehicles/maintenance.md`
+- Modify: `docs/site/guide/vehicles/decoder-cv.md`
+- Modify: `docs/site/de/guide/vehicles/decoder-cv.md`
+
+**Interfaces:**
+- Consumes: the two validated routes from Task 1.
+- Produces: discoverable paired pages with links only among published user-guide owners.
+
+- [ ] **Step 1: Add the sidebar routes after decoder/CV**
+
+Add to the German sidebar immediately after the decoder/CV entry:
+
+```ts
+{
+  text: "Artikelsuche, Web-Dokumente und Ersatzteile",
+  link: "/de/guide/vehicles/search-and-spares",
+},
+```
+
+Add to the English sidebar immediately after its decoder/CV entry:
+
+```ts
+{
+  text: "Article search, web documents, and spare parts",
+  link: "/guide/vehicles/search-and-spares",
+},
+```
+
+- [ ] **Step 2: Add one landing-page transition per language**
+
+Append after the decoder/CV paragraph in `docs/site/guide/index.md`:
+
+```markdown
+
+[Article search, web documents, and spare parts](/guide/vehicles/search-and-spares) explains how to
+verify external suggestions, save selected article data and images, import documents, and maintain
+spare parts without overlooking partial writes.
+```
+
+Append the counterpart to `docs/site/de/guide/index.md`:
+
+```markdown
+
+[Artikelsuche, Web-Dokumente und Ersatzteile](/de/guide/vehicles/search-and-spares) erklärt, wie du
+externe Vorschläge prüfst, ausgewählte Artikeldaten und Bilder speicherst, Dokumente importierst und
+Ersatzteile pflegst, ohne teilweise Schreibvorgänge zu übersehen.
+```
+
+- [ ] **Step 3: Add the new page to eight existing related-page lists**
+
+Add this English item after decoder/CV in the core vehicle, media, and maintenance pages, and after
+maintenance in the decoder/CV page:
+
+```markdown
+- [Article search, web documents, and spare parts](/guide/vehicles/search-and-spares)
+```
+
+Add this German item at the equivalent position in all four German pages:
+
+```markdown
+- [Artikelsuche, Web-Dokumente und Ersatzteile](/de/guide/vehicles/search-and-spares)
+```
+
+In the media chapter's role/boundary paragraph, replace the claim that **Found documents**,
+**Extract spare parts**, web-document import, and remote article images are unexplained specialist
+boundaries. Keep CV files and maintenance editing as boundaries, and add a direct sentence linking
+article search/document/spare-part workflows to the new page. Make the same semantic correction in
+German.
+
+- [ ] **Step 4: Verify route counts, link boundaries, and the full documentation build**
+
+Run:
+
+```powershell
+rg -n 'vehicles/search-and-spares' docs/.vitepress/config.mts docs/site/guide docs/site/de/guide
+rg -n 'settings|master.data|accessor|digital cent|administration' `
+  docs/site/guide/vehicles/search-and-spares.md `
+  docs/site/de/guide/vehicles/search-and-spares.md
+git diff --check
+Set-Location docs
+npm.cmd run check
+```
+
+Expected: the route appears in two sidebars, two landing transitions, eight existing related-page
+lists, and five related links on each new page. No active link targets a planned owner. All 19
+tests pass, validation succeeds, and VitePress builds.
+
+- [ ] **Step 5: Commit navigation and cross-links**
+
+Run from the repository root:
+
+```powershell
+git add docs/.vitepress/config.mts docs/site/guide/index.md docs/site/de/guide/index.md
+git add docs/site/guide/vehicles/index.md docs/site/de/guide/vehicles/index.md
+git add docs/site/guide/vehicles/media.md docs/site/de/guide/vehicles/media.md
+git add docs/site/guide/vehicles/maintenance.md docs/site/de/guide/vehicles/maintenance.md
+git add docs/site/guide/vehicles/decoder-cv.md docs/site/de/guide/vehicles/decoder-cv.md
+git commit -m "docs: link vehicle search and spare parts guide"
+```
+
+---
+
+### Task 3: Audit stable-source fidelity and clear independent review
+
+**Files:**
+- Review: every file changed in `origin/main..HEAD`
+- Reference: `docs/superpowers/specs/2026-08-16-railkeeper-vehicle-search-spares-guide-design.md`
+- Reference: stable frontend, backend, route, OpenAPI, translation, migration, and backup sources.
+
+**Interfaces:**
+- Consumes: the committed coverage, page pair, navigation, and cross-link diff.
+- Produces: a review-cleared exact head with no Critical, Important, or valid completeness finding.
+
+- [ ] **Step 1: Recheck the highest-risk behavior directly at the stable tag**
+
+Run from the repository root:
+
+```powershell
+git show v0.1.17.6:frontend/src/features/vehicles/useArticleSearchController.ts
+git show v0.1.17.6:frontend/src/shared/articleSearch/ArticleSearchDialog.tsx
+git show v0.1.17.6:frontend/src/shared/articleSearch/BarcodeSearchDialog.tsx
+git show v0.1.17.6:frontend/src/shared/articleSearch/articleSearchPreferences.ts
+git show v0.1.17.6:frontend/src/features/vehicles/useVehicleDocumentsController.ts
+git show v0.1.17.6:frontend/src/features/vehicles/vehicleDocuments.ts
+git show v0.1.17.6:frontend/src/features/vehicles/useVehicleSparePartsController.ts
+git show v0.1.17.6:frontend/src/features/vehicles/VehicleSparePartsTab.tsx
+git show v0.1.17.6:frontend/src/features/vehicles/vehicleSparePartSearch.ts
+git show v0.1.17.6:frontend/src/features/vehicles/vehicleSpareParts.ts
+git show v0.1.17.6:backend/internal/application/article_search.go
+git show v0.1.17.6:backend/internal/application/article_search_spare_parts.go
+git show v0.1.17.6:backend/internal/application/vehicle_spare_parts_service.go
+git show v0.1.17.6:backend/internal/api/vehicle_operation_handlers.go
+git show v0.1.17.6:backend/internal/api/vehicle_attachment_handlers.go
+git show v0.1.17.6:backend/internal/api/vehicle_image_handlers.go
+git show v0.1.17.6:backend/internal/api/routes.go
+git show v0.1.17.6:backend/internal/application/backup.go
+git show v0.1.17.6:openapi/railkeeper.yaml
+```
+
+Confirm prerequisites, EAN exception, browser-local sources, search limits, selection defaults,
+camera behavior, write order, URL safety, categories, extraction bounds, OCR boundary, identity and
+merge rules, immediate refreshes, lookup sorting/application, availability checks, Piko/Roco import
+order, role boundaries, storage, and backup scope.
+
+- [ ] **Step 2: Inspect the complete diff and repository state**
+
+Run:
+
+```powershell
+git diff --check origin/main..HEAD
+git diff --stat origin/main..HEAD
+git status --short
+git log --oneline origin/main..HEAD
+```
+
+Expected: no whitespace error, no runtime file, no generated output, and no unrelated file appears.
+The worktree is clean after committed documentation changes.
+
+- [ ] **Step 3: Request an independent read-only review**
+
+Use the `requesting-code-review` workflow with this exact review brief:
+
+```text
+Base: output of git rev-parse origin/main
+Head: output of git rev-parse HEAD
+Specification: docs/superpowers/specs/2026-08-16-railkeeper-vehicle-search-spares-guide-design.md
+Focus: stable v0.1.17.6 fidelity, English/German parity, real labels, search prerequisites and
+limits, source trust, result selection defaults, transient versus stored state, vehicle/image save
+order, document import URL safety, extraction bounds and OCR, spare-part validation and identity,
+lookup application, availability checks, Piko/Roco conservative import, roles, immediate refreshes,
+partial sequential writes, backup scope, coverage, navigation, and unpublished-link boundaries.
+The reviewer must not mutate the worktree.
+```
+
+Fix every Critical and Important finding. Apply valid Minor findings that improve stable fidelity,
+parity, safety, or completeness.
+
+- [ ] **Step 4: Verify and commit review corrections**
+
+After each correction batch, run:
+
+```powershell
+Set-Location docs
+npm.cmd run check
+Set-Location ..
+git diff --check origin/main..HEAD
+git status --short
+```
+
+Expected: all 19 tests pass, validation and VitePress build succeed, and no diff error remains.
+Commit real corrections with:
+
+```powershell
+git add docs
+git commit -m "docs: refine vehicle search and spare parts guide"
+```
+
+Request a focused read-only re-review of every correction. Do not publish while a Critical,
+Important, or valid completeness finding remains.
+
+---
+
+### Task 4: Publish and merge only when the reviewed head is green
+
+**Files:**
+- No new source files expected.
+- Verify: committed branch `dev/docs-user-guide-search-spares`.
+
+**Interfaces:**
+- Consumes: a clean, independently reviewed branch with fresh local verification.
+- Produces: a merged pull request on `main`, guarded by the exact reviewed head SHA and confirmed
+  successful documentation publication.
+
+- [ ] **Step 1: Run fresh pre-push verification**
+
+Run:
+
+```powershell
+Set-Location docs
+npm.cmd run check
+Set-Location ..
+git diff --check origin/main..HEAD
+git status --short
+git rev-parse HEAD
+git merge-base HEAD origin/main
+```
+
+Expected: all 19 tests pass, validation and VitePress build succeed, no diff error or uncommitted
+file exists, and the merge base is the expected `origin/main` commit.
+
+- [ ] **Step 2: Push only the feature branch**
+
+Run:
+
+```powershell
+git push -u origin dev/docs-user-guide-search-spares
+```
+
+Do not modify or push local `main`.
+
+- [ ] **Step 3: Create and ready the pull request**
+
+Create a draft pull request against `main` titled:
+
+```text
+docs: add bilingual vehicle search and spare parts guide
+```
+
+Use this body:
+
+```markdown
+## Summary
+
+- add complete English and German vehicle search and spare-parts chapters for stable v0.1.17.6
+- document barcode/EAN search, result review, remote images, web documents, extraction, and lookup
+- explain immediate and partial writes, recovery, roles, storage, and backup boundaries
+- mark search/spare-parts coverage documented and connect published guide navigation
+
+## Verification
+
+- `npm.cmd run check`
+- stable-tag source audit against `v0.1.17.6`
+- independent English/German fidelity, persistence, and safety review
+
+No runtime or API behavior changes are included.
+```
+
+Mark the pull request ready only after its remote head SHA equals the locally reviewed SHA.
+
+- [ ] **Step 4: Monitor required checks and review threads for the exact SHA**
+
+Require these checks for the exact head:
+
+```text
+CI: success
+Trivy: success
+CodeQL: success
+```
+
+Inspect every review conversation. Resolve a thread only after correction or a source-backed reason
+that it is inapplicable. Any pushed correction invalidates the prior head review and check result.
+Rerun local verification, re-review the correction, and wait for all exact-head checks again.
+
+- [ ] **Step 5: Merge with expected-head protection and verify publication**
+
+Immediately before merge, confirm the pull request is open, non-draft, mergeable, has no unresolved
+review thread, and still points to the reviewed SHA. Merge with expected-head protection. Fetch PR
+metadata again and require `state: closed`, `merged: true`, and a non-empty merge commit SHA.
+
+Then monitor the merge-triggered workflows and require successful Documentation Pages publication
+for the merge commit. Verify both live routes return HTTP 200 and display `v0.1.17.6`. Leave the
+isolated worktree in place for traceability and do not modify or push local `main`.

--- a/docs/superpowers/plans/2026-08-16-railkeeper-vehicle-search-spares-guide.md
+++ b/docs/superpowers/plans/2026-08-16-railkeeper-vehicle-search-spares-guide.md
@@ -210,8 +210,9 @@ Lookup and manufacturer overview
 - Opening the tab checks linked rows once. Piko/Roco use one overview request. Other manufacturers
   inspect only the first four linked rows that have article numbers.
 - Availability remains an unverified suggestion.
-- Find available spare parts requires a saved Piko/Roco vehicle, vehicle article number, enabled
-  article search, and writable UI.
+- Find available spare parts requires a saved Piko/Roco vehicle, vehicle article number, and
+  writable UI. With article search disabled, selecting the enabled button stops before the request,
+  shows the Settings message, and writes nothing.
 - Overview import consolidates duplicates, updates existing rows first, then creates missing rows.
 - Existing article number, description, price, and URL win. Only missing price/URL are filled.
 - The sequence is non-atomic and has no preview. No missing spare parts found can mean every

--- a/docs/superpowers/specs/2026-08-16-railkeeper-vehicle-search-spares-guide-design.md
+++ b/docs/superpowers/specs/2026-08-16-railkeeper-vehicle-search-spares-guide-design.md
@@ -1,7 +1,8 @@
 # RailKeeper Vehicle Search and Spare Parts Guide Design
 
-Date: 2026-08-16  
-Status: Approved in conversation  
+Date: 2026-08-16
+
+Status: Approved in conversation
 Documented release: `v0.1.17.6`
 
 ## Objective

--- a/docs/superpowers/specs/2026-08-16-railkeeper-vehicle-search-spares-guide-design.md
+++ b/docs/superpowers/specs/2026-08-16-railkeeper-vehicle-search-spares-guide-design.md
@@ -233,7 +233,8 @@ and retry only missing URLs.
 
 Every stored attachment has **Extract spare parts**. The action first saves that attachment's
 currently edited description, category, and maintenance link. It then asks the server to analyze
-the selected attachment, switches to **Spare parts**, and reloads the vehicle.
+the selected attachment and creates the accepted suggestions. Only after the complete sequence
+succeeds does it reload the vehicle and switch to **Spare parts**.
 
 Extraction requires a saved vehicle article number. The server reads at most 12 MiB from the chosen
 attachment and returns at most 80 unique suggestions. Likely spare-parts PDFs, manuals, service
@@ -245,7 +246,8 @@ The stable extraction action has no confirmation or row preview. It cleans descr
 empty or document-title-like rows, removes duplicates already stored on the vehicle, and creates
 every remaining candidate sequentially. Attachment metadata and earlier spare parts remain stored
 if a later request fails. A source URL that points back to RailKeeper's own attachment download is
-not stored as the spare part's external link.
+not stored as the spare part's external link. The normal reload and tab switch do not occur after a
+failure.
 
 ## Maintain spare parts manually
 

--- a/docs/superpowers/specs/2026-08-16-railkeeper-vehicle-search-spares-guide-design.md
+++ b/docs/superpowers/specs/2026-08-16-railkeeper-vehicle-search-spares-guide-design.md
@@ -295,8 +295,10 @@ held by RailKeeper.
 - a saved vehicle;
 - a manufacturer name containing Piko or Roco;
 - a non-empty vehicle article number;
-- enabled article search;
 - Admin or Editor UI access.
+
+The button remains enabled when article search is disabled. Selecting it then stops before the
+external request, shows the Settings message, and writes nothing.
 
 RailKeeper searches the manufacturer overview, builds a conservative import plan, updates existing
 matches first, and creates missing parts second. Matching prefers normalized spare-part article

--- a/docs/superpowers/specs/2026-08-16-railkeeper-vehicle-search-spares-guide-design.md
+++ b/docs/superpowers/specs/2026-08-16-railkeeper-vehicle-search-spares-guide-design.md
@@ -1,0 +1,435 @@
+# RailKeeper Vehicle Search and Spare Parts Guide Design
+
+Date: 2026-08-16  
+Status: Approved in conversation  
+Documented release: `v0.1.17.6`
+
+## Objective
+
+Publish a complete English and German user-guide chapter for the stable vehicle article-search,
+barcode, web-document, and spare-parts workflows. The chapter follows one operational path:
+
+1. prepare reliable search criteria;
+2. search and inspect external suggestions;
+3. apply selected fields and images to the vehicle draft;
+4. save remote content locally;
+5. find and import real web documents;
+6. extract, maintain, and look up spare parts;
+7. recover safely from partial writes.
+
+The pages explain every visible stable action in this scope and clearly distinguish search results,
+unsaved local changes, and data already stored in RailKeeper.
+
+## Scope
+
+The chapter owns these stable user workflows:
+
+- article-data web search from a vehicle editor;
+- barcode or EAN entry, keyboard scanners, and camera scanning;
+- search sources, search trace, result score, detail-page state, conflicts, and source inspection;
+- selective transfer of article fields and remote images into a vehicle draft;
+- saving selected remote images with the vehicle;
+- discovery and import of web documents as local vehicle attachments;
+- spare-part extraction from stored attachments;
+- manual spare-part creation, update, sorting, linking, and deletion;
+- single-part price, link, and availability lookup;
+- Piko and Roco manufacturer-overview import;
+- roles, persistence, refreshes, partial failures, storage, backup, and recovery.
+
+## Non-goals
+
+The chapter does not explain:
+
+- general accessory inventory or accessory article search;
+- master-data editing, manufacturer-domain maintenance, or inventory-number schemes;
+- every option on the general Settings page;
+- deployment-level OCR installation or environment-variable reference;
+- external catalog correctness as authoritative data;
+- public sharing, cloud synchronization, or marketplace behavior;
+- unpublished or later-version search features.
+
+Those boundaries may be named in plain text or linked only when their owning page is already
+published.
+
+## Source and compatibility boundary
+
+Behavior claims come from the stable `v0.1.17.6` tag, not from later `main` development. Primary
+source owners include:
+
+- `frontend/src/features/vehicles/useArticleSearchController.ts`;
+- `frontend/src/shared/articleSearch/ArticleSearchDialog.tsx`;
+- `frontend/src/shared/articleSearch/BarcodeSearchDialog.tsx`;
+- `frontend/src/features/vehicles/useVehicleDocumentsController.ts`;
+- `frontend/src/features/vehicles/useVehicleSparePartsController.ts`;
+- `frontend/src/features/vehicles/VehicleSparePartsTab.tsx`;
+- `frontend/src/features/vehicles/vehicleSparePartSearch.ts`;
+- `frontend/src/features/vehicles/vehicleSpareParts.ts`;
+- `backend/internal/application/article_search*.go`;
+- `backend/internal/application/vehicle_spare_parts_service.go`;
+- `backend/internal/api/vehicle_operation_handlers.go`;
+- remote vehicle image and attachment handlers;
+- stable routes, OpenAPI operations, translations, migrations, and backup scope.
+
+## Pages and metadata
+
+Create this language pair:
+
+- `docs/site/guide/vehicles/search-and-spares.md`;
+- `docs/site/de/guide/vehicles/search-and-spares.md`.
+
+Both pages use the established user-guide frontmatter contract, name stable version `v0.1.17.6`,
+use matching section order, and state the review date as 2026-08-16.
+
+Suggested titles:
+
+- **Article search, web documents, and spare parts**;
+- **Artikelsuche, Web-Dokumente und Ersatzteile**.
+
+## Operational model
+
+External pages and extracted values are suggestions. A source URL, high score, recognized
+manufacturer domain, price, or availability label does not make the data authoritative. Users must
+open the source, check that manufacturer and article identity match, compare conflicts, and select
+only values that belong to the physical model.
+
+The chapter separates four states:
+
+| State | Meaning |
+| --- | --- |
+| Search result | External suggestion, not stored |
+| Applied field or selected image | Local vehicle-editor state, not yet stored |
+| Imported document or spare-part action | Immediate server-side write |
+| Saved vehicle | Core fields and pending images persisted through the vehicle-save workflow |
+
+## Prerequisites, settings, and roles
+
+Article search is enabled by default unless **Article data web search** is disabled in Settings.
+The enabled flag and selected sources are browser-local preferences. Default sources are
+manufacturer sites, Modellbahn-Fokus catalogs, dealer sites, and general web search. Modellbau Wiki
+is an optional fifth source. Older stored defaults are migrated to the current defaults by the
+stable frontend.
+
+Normal vehicle search requires:
+
+- manufacturer;
+- gauge;
+- article number or designation.
+
+An EAN-only barcode search is the exception and can run without those four identity values.
+Document search operates on a saved vehicle and uses the same normal identity requirement.
+
+Admin and Editor can use the editable vehicle UI and perform imports or spare-part writes. Viewer
+and Planner can inspect stored vehicle, attachment, and spare-part data. The article-search API has
+Viewer-level read access, but the stable read-only vehicle UI disables search and application
+controls. Image, attachment, and spare-part writes require Editor-level server access. Messe does
+not receive the general vehicle workflow.
+
+## Normal article search
+
+The **Model** section contains **Search barcode** and **Search article data**. The normal button is
+disabled until its required identity values exist. A search sends manufacturer, article number,
+designation, gauge, configured sources, and other non-empty searchable vehicle fields.
+
+The server trims the input, enriches a known manufacturer with configured aliases and preferred
+domains, constructs a search plan, and uses a ten-second service timeout. Results are scored,
+sorted, deduplicated by URL, and limited to ten. Piko and Roco may also provide direct
+manufacturer-specific spare-part results.
+
+The result dialog shows:
+
+- final query;
+- active source classes;
+- preferred manufacturer domains;
+- individual planned search queries;
+- result title, source, field count, score, and snippet;
+- whether the detail page was loaded, failed, or skipped;
+- an external **Open source** action;
+- found images;
+- conflicts with current fields;
+- current and found values with status.
+
+The stable field groups are:
+
+| Group | Visible fields |
+| --- | --- |
+| Model | Designation, article no., manufacturer, gauge, EAN, railway, epoch, series, vehicle no., subtype, category |
+| Mass / construction | Length, weight, color, lettering, load, interior, axles, axle count, traction tires |
+| Technology | Adapter, pickups, digital/decoder data, sound, lights, and technical descriptions |
+| More data | Description, additional information, production period, list price, and source URL |
+
+RailKeeper removes obviously unusable empty, advertising, cookie, manual-navigation, and implausible
+field values before display. This filtering is a quality aid, not proof that the remaining values
+are correct.
+
+## Barcode and camera search
+
+**Search barcode** opens an EAN field initialized from the current vehicle form. Users can type or
+paste a value, use a keyboard scanner, or start the camera.
+
+Submitting a non-empty value puts it into the local EAN field, leaves the article number unchanged,
+closes the barcode dialog, and runs an EAN-only search. The value is not stored until the vehicle is
+saved.
+
+Camera behavior:
+
+- it requires a secure browser context such as HTTPS or localhost;
+- it requires browser camera support and permission;
+- it requests the environment-facing camera when available;
+- non-digits are removed from a detected code;
+- a detected code must contain at least eight digits;
+- detection fills the field but does not submit the search automatically;
+- keyboard scanners and manual input remain available if the camera fails.
+
+## Review and apply one result
+
+Each result has independent field and image selections. Found fields are initially selected only
+when the corresponding current field is empty. Equal and conflicting existing values are not
+selected automatically. Images are never preselected. Failed image previews disappear and are
+removed from selection.
+
+**Apply selected fields** applies only the checked, valid fields from that one result. Boolean text
+is converted to the stable boolean representation. Selected images become pending remote images in
+the vehicle editor. If no image is currently pending, the first selected image becomes the main
+image candidate.
+
+Applying closes the result dialog but performs no server write. Users must inspect the complete
+vehicle form and pending image list, then use the vehicle's **Create** or **Save changes** action.
+Closing the vehicle editor or reloading before that save loses the applied draft changes.
+
+During vehicle save, RailKeeper writes the core vehicle first and downloads selected remote images
+sequentially afterward. A later image failure leaves the vehicle and earlier images stored. It does
+not roll them back or run the normal final refresh. Users must reload, compare, and retry only
+missing images. The media chapter owns image ordering, metadata, maintenance links, previews, and
+deletion after import.
+
+## Find and import web documents
+
+On the saved vehicle's **Uploads** tab, **Found documents** uses the current stable article search
+and the saved vehicle identity. The result list is deduplicated by URL or title and shows title,
+kind, and source.
+
+RailKeeper recognizes an already imported document when its URL occurs in an existing attachment
+description. Such a row cannot be selected again and instead offers local download and open
+actions. Users can import one remaining row or select all not-yet-imported rows.
+
+Import downloads the external content and stores a real local vehicle attachment. RailKeeper adds
+the source and source URL to its description and infers one of these categories:
+
+- `Ersatzteilliste` for spare-parts signals;
+- `Anleitung` for manual or instruction signals;
+- `Dokumentation` otherwise.
+
+The server accepts only public HTTP(S) locations, rechecks redirects, blocks private or internal
+destinations, enforces its configured attachment size and type rules, rejects empty files, and uses
+a ten-second remote request timeout. The media chapter owns the full supported-format and normal
+attachment-limit reference.
+
+Multi-document import sends requests sequentially. A later failure leaves earlier documents stored
+and prevents the normal success refresh and selection reset. Reload, compare the attachment list,
+and retry only missing URLs.
+
+## Extract spare parts from an attachment
+
+Every stored attachment has **Extract spare parts**. The action first saves that attachment's
+currently edited description, category, and maintenance link. It then asks the server to analyze
+the selected attachment, switches to **Spare parts**, and reloads the vehicle.
+
+Extraction requires a saved vehicle article number. The server reads at most 12 MiB from the chosen
+attachment and returns at most 80 unique suggestions. Likely spare-parts PDFs, manuals, service
+sheets, HTML, and supported text content can be analyzed. PDF text is extracted directly first.
+Scanned PDFs may use optional operator-provided OCR; without working OCR they can legitimately
+produce no suggestions.
+
+The stable extraction action has no confirmation or row preview. It cleans descriptions, discards
+empty or document-title-like rows, removes duplicates already stored on the vehicle, and creates
+every remaining candidate sequentially. Attachment metadata and earlier spare parts remain stored
+if a later request fails. A source URL that points back to RailKeeper's own attachment download is
+not stored as the spare part's external link.
+
+## Maintain spare parts manually
+
+The **Spare parts** tab becomes writable only after the vehicle exists. Its editor contains:
+
+- article number;
+- description;
+- price as free text;
+- external link.
+
+At least article number, description, or link is required; price alone is invalid. Add and update
+trim surrounding whitespace. The initial table order is article number ascending. Users can toggle
+ascending or descending sorting for article number, description, price, and link.
+
+Creating a part with an existing identity updates the matching entry rather than adding another
+row. Identity uses normalized article number first, otherwise normalized URL, otherwise
+description. Article-number normalization ignores an `ET` prefix, punctuation, spacing, and case.
+The create merge preserves existing non-empty fields and fills only missing values from the new
+input. Editing a specific row writes exactly its four submitted fields.
+
+Save, apply, and delete actions persist immediately and reload the complete vehicle on success.
+Delete has no additional confirmation. A reload replaces unrelated unsaved vehicle-editor state,
+so users must save or intentionally discard other changes first.
+
+## Look up one stored spare part
+
+A stored part with an article number can run **Search this spare part**. The lookup uses the vehicle
+manufacturer, the spare-part number, manufacturer and catalog sources, and a Piko or Roco lookup
+mode when applicable. The stable UI displays at most five candidates, preferring results with
+price, then availability, then link.
+
+Each result can show price, availability, source, and an external link. **Apply price and link**
+updates the stored part immediately. Article number and description remain unchanged.
+Availability is displayed but not stored. If a chosen candidate has no price, the stable controller
+may use another priced candidate's price and URL from the same result list.
+
+Opening the tab also checks linked spare parts once for the current vehicle state. Piko and Roco
+use one manufacturer-overview request. Other manufacturers check only the first four externally
+linked parts that also have article numbers. The indicator classifies recognizable availability
+text as available, limited, unavailable, or unknown. It remains a live suggestion, not inventory
+held by RailKeeper.
+
+## Import a Piko or Roco manufacturer overview
+
+**Find available spare parts** is enabled only for:
+
+- a saved vehicle;
+- a manufacturer name containing Piko or Roco;
+- a non-empty vehicle article number;
+- enabled article search;
+- Admin or Editor UI access.
+
+RailKeeper searches the manufacturer overview, builds a conservative import plan, updates existing
+matches first, and creates missing parts second. Matching prefers normalized spare-part article
+number, then description, then URL. Existing article number and description are retained. Existing
+price and external URL are also retained; only missing price or URL is filled. Repeated suggestions
+are consolidated.
+
+Updates and creates run sequentially without one transaction or confirmation preview. A later
+failure leaves earlier rows stored and prevents the normal final refresh. Reload and compare before
+retrying. **No missing spare parts found** can mean that all manufacturer entries already match,
+not that the manufacturer has no spare parts.
+
+## Persistence and refresh matrix
+
+| Action | Persists data | Full vehicle refresh |
+| --- | --- | --- |
+| Run article or barcode search | No | No |
+| Apply result fields or images | No, local editor only | No |
+| Save vehicle after applying a result | Core vehicle, then remote images sequentially | Only after full success |
+| Search found documents | No | No |
+| Import one web document | Immediately | After success |
+| Import selected web documents | Sequentially | Only after full success |
+| Extract spare parts | Attachment metadata, then parts sequentially | Only after full success |
+| Add, update, apply lookup, or delete one spare part | Immediately | After success |
+| Check price or availability | No | No |
+| Import Piko/Roco overview | Updates, then creates sequentially | Only after full success |
+
+No later failed request rolls back an earlier successful request in the same sequential workflow.
+
+## Storage and backup
+
+Search responses, result selections, and unsaved vehicle-form changes are transient browser state
+and are not part of a backup. Once saved, article-derived vehicle fields, imported images,
+attachments and their blobs, and vehicle spare parts belong to local RailKeeper application data
+and are included in the application backup scope.
+
+Before a large manufacturer import, document batch, extraction run, or cleanup, users should create
+and validate a current application backup. Search URLs and spare-part links still point to external
+systems and do not guarantee future external availability.
+
+## Empty, partial, and error states
+
+Both pages cover at least:
+
+| Situation | Documented response |
+| --- | --- |
+| Article search is disabled | Enable it in Settings for this browser or continue without external suggestions. |
+| Normal search button is disabled | Enter manufacturer, gauge, and article number or designation. |
+| Camera does not start | Use HTTPS/localhost, check permission and support, or scan manually. |
+| No article result | Refine identity values and sources; do not weaken source verification. |
+| Detail page failed or was skipped | Open the source and trust only fields that can be verified. |
+| A found image disappears | Its preview failed; choose another source image. |
+| Applied values vanish | They were local draft state; apply again and save the vehicle. |
+| Remote image save partly fails | Reload and compare stored images before retrying. |
+| No web documents are found | Check vehicle identity and sources; not every source exposes documents. |
+| Document import fails | Check public URL, redirect, type, size, and remote availability. |
+| Batch document import partly fails | Earlier documents remain stored; reload and retry missing URLs only. |
+| Extraction finds nothing | Check vehicle article number, attachment type/content, text extraction, and optional OCR. |
+| Extraction partly fails | Attachment metadata and earlier parts may already be stored; reload and compare. |
+| Spare-part form is rejected | Enter article number, description, or link; price alone is insufficient. |
+| Single lookup is disabled | Store a spare-part article number and enable article search. |
+| Availability is unknown | Treat it as unverified external status and open the source. |
+| Manufacturer overview is disabled | It requires Piko or Roco plus the vehicle article number. |
+| Manufacturer import partly fails | Reload, compare, and rerun only after understanding stored results. |
+| Spare part was deleted without a prompt | Deletion is immediate; recovery requires a suitable backup. |
+
+The stable backend and some frontend branches still emit German errors in English mode. The
+English page identifies this as a stable UI limitation.
+
+## Navigation and cross-links
+
+Add exact sidebar entries after the decoder/CV chapter:
+
+```ts
+{ text: "Article search, web documents, and spare parts", link: "/guide/vehicles/search-and-spares" }
+```
+
+```ts
+{ text: "Artikelsuche, Web-Dokumente und Ersatzteile", link: "/de/guide/vehicles/search-and-spares" }
+```
+
+Add concise entries to both User Guide landing pages. Add the new chapter to the related-page lists
+of the core vehicle, media, maintenance, and decoder/CV chapters. Replace the media chapter's
+specialist-boundary wording with a direct transition where appropriate.
+
+The new chapter links only to published owners:
+
+- User Guide overview;
+- vehicle inventory and core records;
+- vehicle images and attachments;
+- vehicle maintenance and condition;
+- decoder, functions, and CV data.
+
+Do not create active links to planned settings, master-data, accessory, or administration pages.
+
+## Coverage contract
+
+Change only `vehicle-search-spares` from `planned` to `documented`. Preserve its established page
+paths and ownership:
+
+- translations below `settings.articleSearch`;
+- translations below `vehicles.articleSearch`, `vehicles.barcode`, and `vehicles.search`;
+- translations below `vehicles.spareParts`;
+- translations below `vehicles.uploads.extractSpareParts`, `vehicles.uploads.webDocument`, and
+  `vehicles.uploads.webDocuments`;
+- API prefixes for vehicle image and attachment URL import;
+- `/api/v1/vehicles/{id}/spare-parts`;
+- `/api/v1/article-search`.
+
+The implementation first proves the missing-page gate after changing coverage status, then adds the
+paired pages.
+
+## Verification and review
+
+Verification includes:
+
+1. stable-tag source checks for criteria, sources, roles, fields, defaults, limits, result state,
+   local application, persistence, remote imports, extraction, deduplication, lookup, refresh, and
+   backup;
+2. matching English and German frontmatter and section order;
+3. route, navigation, cross-link, unfinished-marker, line-length, and whitespace scans;
+4. an intentional missing-page validation failure after the coverage change;
+5. `npm.cmd run check` from `docs`, including 19 unit tests, coverage validation, and VitePress
+   production build;
+6. independent read-only review of source fidelity, parity, data trust, role boundaries, transient
+   versus stored state, remote import safety, partial writes, and recovery;
+7. correction and focused re-review of every valid finding;
+8. pull request from the isolated branch only;
+9. merge only when CI, Documentation, Trivy, and CodeQL pass for the reviewed head.
+
+## Expected outcome
+
+Users can move from a reliable vehicle identity to inspected external suggestions, deliberately
+apply and save fields and images, store real manufacturer documents, and maintain spare parts
+without confusing previews with persisted data. They understand which actions are immediate,
+which workflows are sequential and non-atomic, how to verify external sources, and how to recover
+after partial failure.


### PR DESCRIPTION
## Summary

- add complete English and German vehicle search and spare-parts chapters for stable v0.1.17.6
- document barcode/EAN search, result review, remote images, web documents, extraction, and lookup
- explain immediate and partial writes, recovery, roles, storage, and backup boundaries
- mark search/spare-parts coverage documented and connect published guide navigation

## Verification

- `npm.cmd run check`
- stable-tag source audit against `v0.1.17.6`
- independent English/German fidelity, persistence, and safety review

No runtime or API behavior changes are included.
