### PR TITLE
docs: fix German compound rendering

### DIFF
--- a/docs/site/de/guide/vehicles/search-and-spares.md
+++ b/docs/site/de/guide/vehicles/search-and-spares.md
@@ -112,8 +112,9 @@ wird aus der Auswahl entfernt.
 
 Öffne die Quelle und vergleiche die Artikelidentität, bevor du etwas auswählst. Prüfe Konflikte und
 Plausibilität über alle Feldgruppen. **Ausgewählte Felder übernehmen** überträgt anschließend nur
-markierte, gültige Felder dieses Ergebnisses. Wahrheitswerte werden in die stabile RailKeeper-
-Darstellung umgewandelt. Ausgewählte Bilder werden als vorgemerkte externe Bilder geführt. Ist
+markierte, gültige Felder dieses Ergebnisses. Wahrheitswerte werden in die stabile
+RailKeeper-Darstellung umgewandelt. Ausgewählte Bilder werden als vorgemerkte externe Bilder
+geführt. Ist
 noch kein Bild vorgemerkt, wird das erste ausgewählte Bild zum Kandidaten für das Hauptbild.
 
 Die Übernahme schließt den Ergebnisdialog, schreibt aber nichts auf den Server. Prüfe das gesamte


### PR DESCRIPTION
Fix the rendered German compound on the search and spare-parts guide. Verification: npm.cmd run check and focused read-only review.