### PR TITLE
docs: add bilingual accessories guide

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -56,6 +56,15 @@ export default defineConfig({
                 },
               ],
             },
+            {
+              text: "Zubehör",
+              items: [
+                { text: "Zubehörübersicht", link: "/de/guide/accessories/" },
+                { text: "Artikelstammdaten und Fachangaben", link: "/de/guide/accessories/article-records" },
+                { text: "Bestand, Käufe und Dokumente", link: "/de/guide/accessories/stock-purchases-documents" },
+                { text: "Reservierungen, Einbauten und Verwendung", link: "/de/guide/accessories/allocations-history" },
+              ],
+            },
           ],
           "/de/administration/": [
             {
@@ -129,6 +138,15 @@ export default defineConfig({
               text: "Article search, web documents, and spare parts",
               link: "/guide/vehicles/search-and-spares",
             },
+          ],
+        },
+        {
+          text: "Accessories",
+          items: [
+            { text: "Accessories overview", link: "/guide/accessories/" },
+            { text: "Article records and technical data", link: "/guide/accessories/article-records" },
+            { text: "Stock, purchases, and documents", link: "/guide/accessories/stock-purchases-documents" },
+            { text: "Reservations, installations, and usage", link: "/guide/accessories/allocations-history" },
           ],
         },
       ],

--- a/docs/coverage.json
+++ b/docs/coverage.json
@@ -53,7 +53,7 @@
     {
       "id": "accessories",
       "audience": "user",
-      "status": "planned",
+      "status": "documented",
       "englishPath": "guide/accessories/index.md",
       "germanPath": "de/guide/accessories/index.md"
     },

--- a/docs/site/de/guide/accessories/allocations-history.md
+++ b/docs/site/de/guide/accessories/allocations-history.md
@@ -194,6 +194,7 @@ verwendet kein zweiter Befehl einen alten Verfügbarkeits- oder Lebenszyklusstan
 
 ## Verwandte Seiten
 
+- [Überblick zum Benutzerhandbuch](/de/guide/)
 - [Zubehörübersicht](./)
 - [Artikelstammdaten und Fachangaben](./article-records)
 - [Bestand, Käufe und Dokumente](./stock-purchases-documents)

--- a/docs/site/de/guide/accessories/allocations-history.md
+++ b/docs/site/de/guide/accessories/allocations-history.md
@@ -1,0 +1,204 @@
+---
+title: Reservierungen, Einbauten und Verwendung
+description: Zubehör reservieren, Einbauten erfassen und die Verwendungshistorie verstehen.
+audience: user
+status: stable
+reviewedVersion: 0.1.17.6
+lastReviewed: 2026-08-16
+---
+
+# Reservierungen, Einbauten und Verwendung
+
+Reservierungen ordnen verfügbaren Zubehörbestand einer künftigen Verwendung zu. Einbauten halten
+fest, dass der Bestand das Lager physisch verlassen hat und verwendet wird. RailKeeper hält beide
+Schritte, Einzelstück-Lebenszyklus, Bestandsbewegungen, Zustände und Verwendungshistorie in einer
+lokalen Transaktion konsistent.
+
+## Rollen und Zuordnungsziele
+
+Administratoren und Bearbeiter können reservieren, stornieren, einbauen, Zustände ändern und
+Einbauten ausbauen. Ein Planer kann im ansonsten schreibgeschützten Artikeldialog Reservierungen
+anlegen und stornieren, aber weder einbauen, ausbauen, Zustände ändern noch allgemeinen Bestand
+verwalten. Betrachter besitzen Leserecht. Messe hat keinen allgemeinen Zubehörzugriff.
+
+Jede Reservierung und jeder Einbau benötigt genau ein Ziel:
+
+| Ziel | Auswahl im stabilen Dialog |
+| --- | --- |
+| Fahrzeug | Inventarnummer und Fahrzeugname. |
+| Anlage | Eine nicht archivierte Anlage. |
+| Anlageneinheit | Eine nicht archivierte Anlageneinheit. |
+
+Der Dialog verwendet diese Ziele, legt aber keine Anlagen an und bearbeitet sie nicht. Fehlt das
+benötigte Ziel, pflegen Sie es zuerst in seinem zuständigen Arbeitsbereich.
+
+Fünf optionale Felder begleiten beide Abläufe: **Platzierung**, **Digitaladresse**,
+**Decoderausgang**, **Anschluss** und **Verdrahtungshinweise**. Sie beschreiben, wo und wie das
+Zubehör vorgesehen beziehungsweise tatsächlich angeschlossen ist. **Notizen** sind davon getrennte
+private Arbeitsnotizen.
+
+## Zuordnungsübersicht lesen
+
+Übersicht und Zuordnungsdienst leiten abhängig von der Bestandsstrategie diese Mengen ab:
+
+| Wert | Stabile Bedeutung |
+| --- | --- |
+| Eigenbestand | Weiterhin eigene physische Einheiten: eingelagerte plus aktiv eingebaute Mengeneinheiten oder alle Einzelstücke. Hybrid kombiniert Mengenbestand, Einzelstücke und aktive Mengeneinbauten, ohne individualisierte Stücke doppelt zu zählen. |
+| Eingelagert | Mengenbestand plus, soweit unterstützt, Einzelstücke an einem Lagerort mit Lebenszyklus Eingelagert oder Reserviert. |
+| Reserviert | Menge aller aktiven Reservierungen, einschließlich eins je reserviertem Einzelstück. |
+| Eingebaut | Menge aller noch nicht ausgebauten Einbauten. |
+| Verfügbar | `max(Eingelagert - Reserviert, 0)`. |
+| Fehlend | Betrag, um den Reserviert größer als Eingelagert ist. Normale Befehle verhindern dies, wiederhergestellte oder historische Daten können es zeigen. |
+
+Bei Mengenbestand senkt ein Einbau Eingelagert, bleibt aber bis zum Ausbau im Eigenbestand. Ein
+Einzelstück in Wartung oder Ausgemustert bleibt Eigentum, zählt aber nicht als Eingelagert oder
+Verfügbar.
+
+## Bestand reservieren
+
+1. Wählen Sie Fahrzeug, Anlage oder Anlageneinheit und das genaue Ziel.
+2. Erfassen Sie optional die fünf technischen Platzierungsfelder.
+3. Wählen Sie bei einem Hybridartikel **Menge** oder **Einzelstück** als Quelle.
+4. Wählen Sie einen aktiven Lagerort. Bei Einzelverwaltung wählen Sie ein dort eingelagertes
+   Einzelstück, die Menge ist fest eins. Andernfalls geben Sie eine positive ganze Menge ein.
+5. Ergänzen Sie optional eine Notiz, wählen Sie **Reservierung speichern** und bestätigen Sie.
+
+Die bestätigte Transaktion prüft Artikel, Ziel, aktiven Lagerort, Strategie und verfügbare Quelle.
+Eine Mengenreservierung erzeugt eine aktive Reservierung und senkt nur Verfügbar. Sie ändert weder
+die physische Menge noch das Bestandsjournal. Eine Einzelstückreservierung ändert zusätzlich den
+Lebenszyklus von Eingelagert zu Reserviert, behält aber den Lagerort. Dasselbe Einzelstück kann
+nicht erneut aktiv reserviert werden.
+
+Ist die verfügbare Menge zu klein, gehört das Einzelstück zu einem anderen Artikel oder Lagerort,
+ist es nicht Eingelagert oder ist ein Ziel ungültig, scheitert die ganze Reservierung ohne
+Teilzustand.
+
+## Reservierung stornieren
+
+Nur eine aktive Reservierung bietet **Stornieren** an. Der Befehl öffnet eine Bestätigung. Die
+Bestätigung setzt den Status auf Storniert und lädt die zugehörigen Ressourcen neu. Mengenbestand
+bleibt physisch unverändert und wird wieder verfügbar. Ein reserviertes Einzelstück wechselt am
+bestehenden Lagerort von Reserviert zu Eingelagert.
+
+Eine erfüllte oder bereits stornierte Reservierung ist unveränderlich. Erfüllt bedeutet, dass ein
+Einbau sie verbraucht hat. Bauen Sie diesen Einbau aus, statt die Reservierung wieder zu öffnen.
+
+## Einbau erfassen
+
+Ein Administrator oder Bearbeiter öffnet den Artikel zum Bearbeiten und wählt entweder eine aktive
+Reservierung oder **Ohne Reservierung**.
+
+Mit Reservierung sind Ziel, Quelllagerort, gegebenenfalls Einzelstück und Menge an die Reservierung
+gebunden. Ihre Platzierungsdaten werden in das Einbauformular übernommen. Ein nicht leerer
+Einbauwert kann einen geerbten Platzierungswert ersetzen, ein leerer Wert erhält den
+Reservierungswert. Zustand und Einbaunotizen bleiben wählbar.
+
+Ohne Reservierung wählen Sie Ziel, optionale Platzierungsdaten, Quelle, positive ganze Menge oder
+ein eingelagertes Einzelstück, Zustand und optionale Notizen. Hybridartikel erlauben erneut Menge
+oder Einzelstück. Der direkte Einbau eines Einzelstücks wird abgelehnt, wenn es aktiv reserviert ist.
+
+**Einbau speichern** öffnet eine Bestätigung. Die erfolgreiche Transaktion wirkt so:
+
+| Quelle | Physischer Bestand oder Einzelstück | Reservierung | Einbau und Journal |
+| --- | --- | --- | --- |
+| Menge | Zieht die Menge am Quelllagerort ab. Ein direkter Einbau schützt alle aktiven Reservierungen dieses Ortes. | Gewählte aktive Reservierung wird Erfüllt. | Erzeugt einen aktiven Einbau und eine Bewegung Einbau mit negativer Menge. |
+| Einzelstück | Setzt das gewählte eingelagerte oder reservierte Einzelstück auf Eingebaut, entfernt den Lagerort und setzt den gewählten Zustand. | Gewählte aktive Reservierung wird Erfüllt. | Erzeugt einen aktiven Einbau. Es entsteht keine Mengenbewegung. |
+
+Gültige Einbauzustände sind Einsatzbereit, Wartung fällig, Defekt und Unbekannt. Die manuelle
+Oberfläche beginnt mit Einsatzbereit. Änderungen an Bestand, Einzelstück, Reservierung, Einbau,
+Bewegung und Audit sind atomar. Scheitert eine Prüfung, bleibt nichts davon erhalten.
+
+## Einbauzustand ändern
+
+Wählen Sie bei einem aktiven Einbau Einsatzbereit, Wartung fällig, Defekt oder Unbekannt und danach
+**Zustand aktualisieren**. Auch bei scheinbar unveränderter Auswahl erscheint eine Bestätigung.
+
+Die Bestätigung aktualisiert den Einbau, ergänzt den Zustandsverlauf um vorherigen und neuen Wert
+und übernimmt den Zustand bei einem eingebauten Einzelstück. Bei Mengenbestand existiert kein
+Einzelstück zum Aktualisieren. Ein ausgebauter Einbau lässt sich nicht mehr ändern. Nach Erfolg
+werden die Ressourcen neu geladen.
+
+## Einbau ausbauen
+
+Wählen Sie **Ausbauen** an einem aktiven Einbau, bestimmen Sie den Verbleib, ergänzen Sie optionale
+Ausbaunotizen und bestätigen Sie den eigenen Ausbaudialog.
+
+| Verbleib | Ergebnis bei Menge | Ergebnis beim Einzelstück |
+| --- | --- | --- |
+| Eingelagert | Erfordert einen aktiven Zielort, führt die vollständige Menge zurück und schreibt eine positive Bewegung Ausbau. | Lebenszyklus Eingelagert, gewählter Lagerort, Zustand bleibt erhalten. |
+| In Wartung | Führt keine Menge in den Bestand zurück. | Lebenszyklus Wartung, kein Lagerort, Zustand bleibt erhalten. |
+| Defekt | Führt keine Menge in den Bestand zurück. | Lebenszyklus Wartung, kein Lagerort, Zustand wird Defekt. |
+| Ausgemustert | Führt keine Menge in den Bestand zurück. | Lebenszyklus Ausgemustert, kein Lagerort, Zustand bleibt erhalten. |
+
+Der Ausbau schließt den Einbau mit Bearbeiter, Zeit, Verbleib und getrennten Ausbaunotizen. Er
+löscht ihn nicht. Ein geschlossener Einbau kann weder erneut ausgebaut noch im Zustand geändert
+werden. Bestands- oder Einzelstückänderung, Abschluss, gegebenenfalls Bewegung und Audit bilden
+eine Transaktion.
+
+## Verwendungshistorie lesen
+
+Der Reiter **Verwendungshistorie** erscheint, sobald Reservierungs-, Einbau- oder Verlaufsdaten
+vorliegen. Sein oberer Bereich wiederholt nur aktuelle aktive Reservierungen und noch nicht
+ausgebaute Einbauten schreibgeschützt.
+
+Danach zeigt die Historie Ereignisse vom ältesten zum neuesten mit Datum und Uhrzeit, Ereignisart,
+Menge, Ziel und Zustand oder Verbleib:
+
+| Ereignis | Entsteht bei |
+| --- | --- |
+| Reservierung | Anlegen der Reservierung. Ihr Datensatz trägt später Aktiv, Erfüllt oder Storniert. Die Stornierung ist keine eigene Ereigniszeile. |
+| Einbau | Anlegen des Einbaus. |
+| Zustandsänderung | Bestätigter Zustand eines aktiven Einbaus, vorheriger und neuer Zustand bleiben erhalten. |
+| Ausbau | Schließen des Einbaus mit seinem endgültigen Verbleib. |
+
+Einbau- und Ausbaunotizen sowie detaillierte Platzierungsfelder bleiben gespeichert, werden in der
+kompakten stabilen Historientabelle jedoch nicht angezeigt. Verwenden Sie den aktuellen
+Zuordnungsdatensatz und Sicherungen, wenn diese Angaben betrieblich wichtig sind.
+
+## Bestand und Lebenszyklus konsistent halten
+
+Verwenden Sie den Ablauf, der das reale Ereignis beschreibt. Ersetzen Sie einen Einbau nicht durch
+eine negative Bestandskorrektur und einen Ausbau nicht durch eine positive. Solche Abkürzungen
+ließen Ziel, Einbaudatensatz, Einzelstück-Lebenszyklus und Verwendungshistorie aus.
+
+| Aktion | Mengenverfügbarkeit | Einzelstück-Lebenszyklus | Dauerhafter Verlauf |
+| --- | --- | --- | --- |
+| Reservieren | Verfügbar sinkt, Eingelagert unverändert. | Eingelagert zu Reserviert. | Reservierungsdatensatz und -ereignis. |
+| Stornieren | Verfügbar wird frei, Eingelagert unverändert. | Reserviert zu Eingelagert. | Reservierung bleibt Storniert. |
+| Einbauen | Eingelagert sinkt, Eingebaut steigt. | Eingelagert/Reserviert zu Eingebaut, Lagerort entfällt. | Einbauereignis und gegebenenfalls Mengenbewegung. |
+| Zustand ändern | Keine Mengenänderung. | Zustand des eingebauten Stücks folgt dem Einbau. | Ereignis Zustandsänderung. |
+| Eingelagert ausbauen | Eingelagert steigt, Eingebaut sinkt. | Eingebaut zu Eingelagert am Zielort. | Ausbauereignis und gegebenenfalls Mengenbewegung. |
+| Anders ausbauen | Eingebaut sinkt ohne Rückkehr in Mengenbestand. | Eingebaut zu Wartung oder Ausgemustert, Defekt setzt zusätzlich den Zustand. | Ausbauereignis. |
+
+Eine Änderung der Artikel-Bestandsstrategie ist gesperrt, solange bestehende Mengen- oder
+Einzelstückabhängigkeiten danach nicht mehr darstellbar wären. Klären Sie aktive und historische
+Abhängigkeiten bewusst, statt eine Klassifikationsänderung zu erzwingen.
+
+## Zuordnungsfehler beheben
+
+| Situation | Nächster Schritt |
+| --- | --- |
+| Speichern ist deaktiviert | Wählen Sie genau ein Ziel und einen aktiven Lagerort, bei Einzelverwaltung zusätzlich ein eingelagertes Einzelstück. |
+| Bestand reicht nicht | Prüfen Sie aktive Reservierungen an der Quelle und reduzieren Sie die Menge oder wählen Sie einen anderen Lagerort. |
+| Einzelstückkonflikt | Prüfen Sie Artikel, Lagerort, Lebenszyklus Eingelagert/Reserviert und eine andere aktive Reservierung oder einen Einbau. |
+| Reservierung lässt sich nicht stornieren | Nur aktive Reservierungen sind stornierbar. Eine erfüllte gehört zu einem Einbau. |
+| Einbau aus Reservierung kollidiert | Ändern Sie Ziel, Lagerort, Einzelstück und Menge nicht. Wählen Sie die aktuelle aktive Reservierung erneut. |
+| Verbleib Eingelagert ist gesperrt oder fehlerhaft | Wählen Sie einen aktiven Zielort mit ebenfalls aktiver übergeordneter Kette. Andere Verbleibe dürfen keinen Ort enthalten. |
+| Zustand oder Ausbau kollidiert | Laden Sie neu. Eine andere Aktion kann den Einbau bereits geändert oder geschlossen haben. |
+| Schreiben möglicherweise erfolgreich, Neuladen fehlgeschlagen | Wiederholen Sie nichts. Verwenden Sie **Erneut versuchen** und prüfen Sie Status, Einbau, Einzelstück, Journal und Historie. |
+| Berechtigung fehlt | Planer dürfen nur reservieren und stornieren. Einbau, Zustand und Ausbau erfordern Administrator oder Bearbeiter. |
+
+Ein fehlgeschlagenes Neuladen nach dem Schreiben markiert den Editor als veraltet und sperrt
+weitere Zuordnungs- und Bestandsaktionen, bis ein vollständiger Wiederholungsversuch gelingt. So
+verwendet kein zweiter Befehl einen alten Verfügbarkeits- oder Lebenszyklusstand.
+
+## Verwandte Seiten
+
+- [Zubehörübersicht](./)
+- [Artikelstammdaten und Fachangaben](./article-records)
+- [Bestand, Käufe und Dokumente](./stock-purchases-documents)
+- [Fahrzeugbestand und Stammdaten](../vehicles/)
+
+## Dokumentierte RailKeeper-Version
+
+Diese Seite dokumentiert RailKeeper **v0.1.17.6** und wurde zuletzt am 16.08.2026 geprüft.

--- a/docs/site/de/guide/accessories/allocations-history.md
+++ b/docs/site/de/guide/accessories/allocations-history.md
@@ -29,8 +29,8 @@ Jede Reservierung und jeder Einbau benötigt genau ein Ziel:
 | Anlage | Eine nicht archivierte Anlage. |
 | Anlageneinheit | Eine nicht archivierte Anlageneinheit. |
 
-Der Dialog verwendet diese Ziele, legt aber keine Anlagen an und bearbeitet sie nicht. Fehlt das
-benötigte Ziel, pflegen Sie es zuerst in seinem zuständigen Arbeitsbereich.
+Der Dialog verwendet vorhandene Ziele, legt aber keine Anlagen an und bearbeitet sie nicht. Dieses
+Kapitel dokumentiert weder das Anlegen noch das Bearbeiten von Anlagen.
 
 Fünf optionale Felder begleiten beide Abläufe: **Platzierung**, **Digitaladresse**,
 **Decoderausgang**, **Anschluss** und **Verdrahtungshinweise**. Sie beschreiben, wo und wie das
@@ -61,7 +61,7 @@ Verfügbar.
 3. Wählen Sie bei einem Hybridartikel **Menge** oder **Einzelstück** als Quelle.
 4. Wählen Sie einen aktiven Lagerort. Bei Einzelverwaltung wählen Sie ein dort eingelagertes
    Einzelstück, die Menge ist fest eins. Andernfalls geben Sie eine positive ganze Menge ein.
-5. Ergänzen Sie optional eine Notiz, wählen Sie **Reservierung speichern** und bestätigen Sie.
+5. Ergänzen Sie optional eine Notiz, wählen Sie **Reservierung anlegen** und bestätigen Sie.
 
 Die bestätigte Transaktion prüft Artikel, Ziel, aktiven Lagerort, Strategie und verfügbare Quelle.
 Eine Mengenreservierung erzeugt eine aktive Reservierung und senkt nur Verfügbar. Sie ändert weder
@@ -97,7 +97,7 @@ Ohne Reservierung wählen Sie Ziel, optionale Platzierungsdaten, Quelle, positiv
 ein eingelagertes Einzelstück, Zustand und optionale Notizen. Hybridartikel erlauben erneut Menge
 oder Einzelstück. Der direkte Einbau eines Einzelstücks wird abgelehnt, wenn es aktiv reserviert ist.
 
-**Einbau speichern** öffnet eine Bestätigung. Die erfolgreiche Transaktion wirkt so:
+**Einbau erfassen** öffnet eine Bestätigung. Die erfolgreiche Transaktion wirkt so:
 
 | Quelle | Physischer Bestand oder Einzelstück | Reservierung | Einbau und Journal |
 | --- | --- | --- | --- |
@@ -111,7 +111,7 @@ Bewegung und Audit sind atomar. Scheitert eine Prüfung, bleibt nichts davon erh
 ## Einbauzustand ändern
 
 Wählen Sie bei einem aktiven Einbau Einsatzbereit, Wartung fällig, Defekt oder Unbekannt und danach
-**Zustand aktualisieren**. Auch bei scheinbar unveränderter Auswahl erscheint eine Bestätigung.
+**Zustand speichern**. Auch bei scheinbar unveränderter Auswahl erscheint eine Bestätigung.
 
 Die Bestätigung aktualisiert den Einbau, ergänzt den Zustandsverlauf um vorherigen und neuen Wert
 und übernimmt den Zustand bei einem eingebauten Einzelstück. Bei Mengenbestand existiert kein

--- a/docs/site/de/guide/accessories/article-records.md
+++ b/docs/site/de/guide/accessories/article-records.md
@@ -21,8 +21,8 @@ sie ansehen, die Artikelfelder bleiben jedoch schreibgeschützt. Ein Planer kann
 schreibgeschützten Dialog Reservierungen anlegen oder stornieren. Daraus folgt kein Recht, den
 Artikel selbst zu ändern. Die Rolle Messe hat keinen allgemeinen Zugriff auf Zubehör.
 
-Der Dialog trennt **Artikel**, **Bestand**, **Einkäufe & Dokumente**, den artikelspezifischen Reiter
-und bei vorhandenen Daten den **Nutzungsverlauf**. Die zentrale Aktion **Speichern** schreibt das
+Der Dialog trennt **Artikel**, **Bestand**, **Kauf & Dokumente**, den artikelspezifischen Reiter
+und bei vorhandenen Daten **Verwendung & Historie**. Die zentrale Aktion **Änderungen speichern** schreibt das
 Artikelformular einschließlich Artikelart, Fachangaben, Bestandsstrategie und Mindestbestand.
 Bestandsbewegungen, Einkäufe, Dokumente, Reservierungen und Einbauten besitzen eigene Aktionen und
 können bereits gespeichert sein, während andere Artikelfelder noch ungespeichert sind. Schließen
@@ -41,7 +41,7 @@ Ressourcen erst speichern, nachdem der Artikelstamm einmal erfolgreich gespeiche
 4. Füllen Sie bekannte Fachangaben im Reiter der gewählten Artikelart aus.
 5. Wählen Sie unter **Bestand** Bestandsstrategie und Mindestbestand. Die Folgen beschreibt
    [Bestand, Einkäufe und Dokumente](./stock-purchases-documents) im Detail.
-6. Wählen Sie **Speichern** und bearbeiten Sie markierte Reiter oder die Dublettenwarnung.
+6. Wählen Sie **Änderungen speichern** und bearbeiten Sie markierte Reiter oder die Dublettenwarnung.
 
 Pflichtfelder sind Hersteller, Name, Unterart, Bestandseinheit und eine positive ganzzahlige
 Verpackungseinheit. Der Mindestbestand muss eine ganze Zahl ab null sein. Technische Zahlen müssen
@@ -176,8 +176,8 @@ Dokumente noch Nutzungen eines anderen Artikels.
 ## Bearbeiten ohne Datenverlust
 
 Öffnen Sie **Artikel bearbeiten**, ändern Sie den Entwurf und verwenden Sie die zentrale Aktion
-**Speichern**. Die Validierung wechselt zum ersten betroffenen Reiter in dieser Reihenfolge:
-Artikel, Bestand, Einkäufe & Dokumente, danach der artikelspezifische Reiter. Rote Markierungen an
+**Änderungen speichern**. Die Validierung wechselt zum ersten betroffenen Reiter in dieser Reihenfolge:
+Artikel, Bestand, Kauf & Dokumente, danach der artikelspezifische Reiter. Rote Markierungen an
 Reitern kennzeichnen noch ungültige Werte.
 
 Eine geänderte Bestandsstrategie ist nur erlaubt, wenn alle vorhandenen Bestands- und

--- a/docs/site/de/guide/accessories/article-records.md
+++ b/docs/site/de/guide/accessories/article-records.md
@@ -228,7 +228,6 @@ rückgängig machen. Prüfen Sie vorher eine aktuelle Sicherung.
 - [Bestand, Einkäufe und Dokumente](./stock-purchases-documents)
 - [Zuordnungen und Nutzungsverlauf](./allocations-history)
 - [Artikelsuche, Web-Dokumente und Ersatzteile](../vehicles/search-and-spares)
-- [Stammdatenverwaltung](/de/administration/#lebenszyklus-der-stammdaten)
 
 ## Dokumentierte RailKeeper-Version
 

--- a/docs/site/de/guide/accessories/article-records.md
+++ b/docs/site/de/guide/accessories/article-records.md
@@ -1,0 +1,234 @@
+---
+title: Artikelstammdaten und Fachangaben
+description: Zubehörartikel anlegen, ihre Identität pflegen und technische Angaben prüfen.
+audience: user
+status: stable
+reviewedVersion: 0.1.17.6
+lastReviewed: 2026-08-16
+---
+
+# Artikelstammdaten und Fachangaben
+
+Ein Zubehörartikel ist der gemeinsame Produktdatensatz für Bestand, Einkäufe, Dokumente,
+Reservierungen und Einbauten. Legen Sie ihn einmal für einen Hersteller- und Katalogartikel an und
+erfassen Sie anschließend Mengen oder Einzelstücke dazu. Dieses Kapitel beschreibt die
+Artikelidentität und die artabhängigen Fachangaben in RailKeeper v0.1.17.6.
+
+## Zugriffsrechte und Speichern
+
+Administratoren und Bearbeiter können Artikel anlegen und bearbeiten. Betrachter und Planer können
+sie ansehen, die Artikelfelder bleiben jedoch schreibgeschützt. Ein Planer kann im ansonsten
+schreibgeschützten Dialog Reservierungen anlegen oder stornieren. Daraus folgt kein Recht, den
+Artikel selbst zu ändern. Die Rolle Messe hat keinen allgemeinen Zugriff auf Zubehör.
+
+Der Dialog trennt **Artikel**, **Bestand**, **Einkäufe & Dokumente**, den artikelspezifischen Reiter
+und bei vorhandenen Daten den **Nutzungsverlauf**. Die zentrale Aktion **Speichern** schreibt das
+Artikelformular einschließlich Artikelart, Fachangaben, Bestandsstrategie und Mindestbestand.
+Bestandsbewegungen, Einkäufe, Dokumente, Reservierungen und Einbauten besitzen eigene Aktionen und
+können bereits gespeichert sein, während andere Artikelfelder noch ungespeichert sind. Schließen
+Sie einen Entwurf ab oder verwerfen Sie ihn bewusst, bevor Sie eine solche Sofortaktion beginnen.
+
+Beim Schließen mit geänderten Artikelfeldern, vorgemerkten Suchbildern oder einem unfertigen
+Unterformular erscheint eine Verwerfbestätigung. Im Anlegemodus lassen sich Bestand und zugehörige
+Ressourcen erst speichern, nachdem der Artikelstamm einmal erfolgreich gespeichert wurde.
+
+## Artikel anlegen
+
+1. Öffnen Sie **Zubehör** und wählen Sie **Artikel anlegen**.
+2. Wählen Sie unter **Artikel** Hersteller, Artikelart und Unterart und geben Sie den Namen ein.
+3. Ergänzen Sie Katalogidentität, Spurweiten, Maßstab, Verpackungseinheit, Bestandseinheit und
+   optionale Referenzdaten.
+4. Füllen Sie bekannte Fachangaben im Reiter der gewählten Artikelart aus.
+5. Wählen Sie unter **Bestand** Bestandsstrategie und Mindestbestand. Die Folgen beschreibt
+   [Bestand, Einkäufe und Dokumente](./stock-purchases-documents) im Detail.
+6. Wählen Sie **Speichern** und bearbeiten Sie markierte Reiter oder die Dublettenwarnung.
+
+Pflichtfelder sind Hersteller, Name, Unterart, Bestandseinheit und eine positive ganzzahlige
+Verpackungseinheit. Der Mindestbestand muss eine ganze Zahl ab null sein. Technische Zahlen müssen
+den angezeigten Bereich und die Schrittweite einhalten. Als Dezimaltrennzeichen wird auch ein Komma
+akzeptiert.
+
+RailKeeper vergibt die Artikel-Inventarnummer erst in der erfolgreichen Anlegetransaktion. Dafür
+wird das aktive Inventarnummernschema **Artikel** verwendet, dessen Standardformat Werte wie
+`RK-ART-000001` erzeugt. Ein fehlgeschlagener Anlageversuch verbraucht die vorgemerkte Nummer nicht.
+Das Feld lässt sich im Artikeldialog weder eingeben noch ändern. Fehlt ein aktives Schema, bleibt
+das Anlegen gesperrt, bis ein Administrator die Inventarnummernkonfiguration repariert.
+
+Bei einem neuen Datensatz wählt RailKeeper die erste aktive konfigurierte Artikelart. Ist keine
+aktive Artikelart verfügbar, bleibt das Anlegen gesperrt. Anfangswerte sind Verpackungseinheit 1,
+Bestandseinheit **Stück**, Mindestbestand 0, Bestandsstrategie **Mengenbestand** und
+Herstellerstatus **Unbekannt**.
+
+## Referenz der allgemeinen Felder
+
+| Feld | Stabiles Verhalten |
+| --- | --- |
+| Inventarnummer | Automatisch aus dem Schema **Artikel** vergeben und schreibgeschützt. |
+| Hersteller | Erforderliche aktive Stammdatenauswahl. Ein gespeicherter inaktiver oder historischer Wert bleibt sichtbar, kann aber nicht neu gewählt werden. |
+| Artikelnummer | Optionale Hersteller- oder Katalognummer. Wenn ausgefüllt, aktiviert sie zusammen mit dem Hersteller die Dublettenprüfung. |
+| Name | Erforderlicher Artikelname. |
+| EAN / GTIN | Optionaler Barcodewert und eigenständiges Kriterium der Artikelsuche. |
+| Herstellerstatus | Angekündigt, Verfügbar, Ausgelaufen oder Unbekannt. |
+| Artikelart | Gleis, Signal, Decoder, Elektrik / Steuerung, Gebäude / Ausstattung, Landschaftsverbrauchsmaterial, Beleuchtung oder Sonstiges, abhängig von der aktiven Konfiguration. |
+| Unterart | Erforderliche konfigurierte Unterart der gewählten Artikelart. Eine unveränderte historische Unterart bleibt lesbar und kann beibehalten werden. |
+| Spurweiten | Keine, eine oder mehrere aktive Spurweiten aus den Stammdaten. Vorhandene inaktive Werte bleiben sichtbar. |
+| Maßstab | Optionaler Text. Solange automatisch verwaltet, folgt er der ersten gewählten aktiven Spurweite mit hinterlegtem Maßstab. |
+| Verpackungseinheit | Erforderliche positive ganze Zahl, wie viele Bestandseinheiten eine Packung enthält. |
+| Bestandseinheit | Erforderlicher aktiver Stammdatenwert, zum Beispiel Stück. Vorhandene inaktive Werte bleiben sichtbar. |
+| Beschreibung | Optionaler Freitext. |
+| Hersteller-URL | Optionale Herstellerreferenz. Die stabile Zubehör-Trefferauswahl füllt sie nicht. |
+| Produkt-URL | Optionale Produktreferenz. Suchtreffer können sie nur aus einer HTTP- oder HTTPS-Quelle übernehmen. |
+| Alternative Artikelnummern | Optionale, durch Komma oder Zeilenumbruch getrennte Werte. Leere Einträge werden entfernt. |
+| Schlagwörter | Optionale, durch Komma oder Zeilenumbruch getrennte Begriffe. Vorschläge kombinieren Name, Hersteller, Artikelart und Unterart ohne Dubletten unabhängig von Groß- und Kleinschreibung. |
+| Kompatibilität | Optionaler Freitext für unterstützte Systeme oder Produkte. |
+| Interne Notizen | Optionale lokale Notizen. |
+
+Bei normalen Textfeldern entfernt RailKeeper führende und nachgestellte Leerzeichen. Eine manuelle
+Änderung an **Maßstab** oder **Schlagwörter** beendet den jeweiligen Vorschlagsautomatismus für die
+aktuelle Bearbeitung. Die Automatik arbeitet beim Anlegen und Bearbeiten, nie in der Leseansicht.
+
+Hersteller, Artikelarten, Unterarten, Spurweiten, Bestandseinheiten und eigene Felder stammen aus
+den Stammdaten. RailKeeper erhält einen unveränderten inaktiven Wert eines bestehenden Artikels,
+erlaubt aber weder sein neues Hinzufügen noch seine Änderung. So bleiben historische Datensätze
+bearbeitbar, ohne ihre Klassifikation stillschweigend zu ersetzen.
+
+## Artikelart und Fachangaben wählen
+
+Der letzte Hauptreiter trägt den Namen der gewählten Artikelart. Seine Felder sind optional, sofern
+die lokale Stammdatenkonfiguration nichts anderes verlangt. Jeder eingetragene Wert wird jedoch
+geprüft. Ganzzahlige Felder verwenden die Schrittweite 1. Andere nicht negative Zahlen haben keine
+feste Schrittweite, sofern nachfolgend nichts anderes angegeben ist.
+
+| Artikelart | Stabile Fachfelder |
+| --- | --- |
+| Gleis | Gleissystem; Länge und Radius in mm; Winkel von 0 bis 360° in 0,1°-Schritten; Richtung Links, Rechts oder Symmetrisch; Herzstückwinkel von 0 bis 180° in 0,1°-Schritten; Schwellenart; Profilhöhe in mm; Bettung; nicht negative ganze Anzahl Anschlüsse; Digitaltauglich. |
+| Signal | Vorbild; Epochen I bis VI; Signalbegriffe Halt, Fahrt, Langsamfahrt und Rangierfahrt; nicht negative ganze Anzahl LEDs; Bauhöhe in mm; nicht negative Betriebsspannung AC und DC; Montageart Aufbau, Unterflur, Mast oder Wand; Antrieb Manuell, Motor, Servo oder Magnetantrieb; Integrierter Decoder; Steuermodul. |
+| Decoder | Schnittstelle Kabel, NEM 651, NEM 652, PluX16, PluX22, 21MTC oder Next18; Protokolle DCC, Motorola, Selectrix, mfx und RailCom; nicht negative ganze Funktions- und Servoausgänge; nicht negativer Motor-, Ausgangs- und Summenstrom in mA; RailCom; SUSI; Abmessungen; Firmware. |
+| Elektrik / Steuerung | Nicht negative Eingangs- und Ausgangsspannung, Strom in A und Leistung in W; nicht negative ganze Anzahl Kanäle; Protokolle DCC, Motorola, Selectrix, LocoNet, CAN und S88; Anschlussarten Schraubklemme, Steckverbinder, RJ45, Busanschluss und Kabel; Schutzfunktionen Kurzschluss, Überlast, Übertemperatur und Verpolung; kompatible Artikelarten Gleis, Signal, Decoder und Beleuchtung. |
+| Gebäude / Ausstattung | Epochen I bis VI; Abmessungen; Grundfläche; Material; Bauform Bausatz, Fertigmodell oder Teilbausatz; nicht negative ganze Teilezahl; Schwierigkeitsgrad Einfach, Mittel oder Anspruchsvoll; Beleuchtungsmöglichkeiten Innenbeleuchtung, Bahnsteigbeleuchtung, Straßenbeleuchtung und Effektbeleuchtung; Grundriss vorhanden. |
+| Landschaftsverbrauchsmaterial | Material; Farbe; Jahreszeit; nicht negativer Inhalt; Inhaltseinheit Stück, Packung, Meter, Gramm oder Milliliter; Faser- oder Korngröße; Reichweite; geeignete Maßstäbe Z, N, TT, H0, 0, 1 und G; Sicherheitshinweise. |
+| Beleuchtung | Lichtfarbe; nicht negative Farbtemperatur in K, Spannung in V und Strom in mA; Stromart Wechselstrom, Gleichstrom oder Wechsel- oder Gleichstrom; nicht negative ganze Anzahl LEDs; Dimmbar; Abmessungen; Montageart Aufbau, Unterflur, Mast oder Wand. |
+| Sonstiges | Aktive konfigurierte eigene Felder. Unterstützt werden Text, Zahl, Ja/Nein, Datum, Einfachauswahl und Mehrfachauswahl. Auswahlfelder erscheinen nur mit konfigurierten Auswahlwerten. |
+
+Ja/Nein-Felder unterscheiden ein ausdrücklich gewähltes Ja oder Nein von einem nicht gespeicherten
+Wert. Mehrfachauswahlen lehnen unbekannte oder doppelte Auswahlwerte ab. Negative Zahlen, Werte
+außerhalb eines genannten Bereichs und Werte entgegen einer genannten Schrittweite verhindern das
+Speichern und markieren den artikelspezifischen Reiter.
+
+Ein Wechsel der Artikelart leert die Unterart. Würde der Wechsel die Unterart, einen Fachwert oder
+eine unfertige Zahl verwerfen, fragt RailKeeper nach einer Bestätigung. Kompatible Felder mit
+gleichem Schlüssel und Datentyp bleiben erhalten. Unvereinbare Felder werden erst nach Bestätigung
+entfernt. Brechen Sie die Bestätigung ab, um die aktuelle Artikelart und ihre Werte zu behalten.
+
+Für **Sonstiges** werden die Felder durch aktive `accessory_custom_field`-Stammdaten definiert. Ein
+historischer eigener Wert, dessen Definition inaktiv geworden oder verschwunden ist, bleibt nur
+unverändert erhalten. Er kann weder neu hinzugefügt noch bearbeitet werden.
+
+## Barcode und Artikeldatensuche verwenden
+
+Der Reiter **Artikel** verwendet denselben geprüften Trefferablauf wie die Fahrzeugsuche, jedoch
+mit zubehörspezifischen Eingaben und Zielfeldern. Die normale Suche ist verfügbar, wenn entweder:
+
+- eine EAN vorhanden ist oder
+- Hersteller und erste gewählte Spurweite zusammen mit entweder Artikelnummer oder Name vorhanden
+  sind.
+
+RailKeeper übermittelt Hersteller, Artikelnummer, Name, erste Spurweite, aktuelle allgemeine Felder
+und die aktuellen Fachangaben an die konfigurierten Suchquellen. Ist die Artikelsuche in den
+Einstellungen deaktiviert, endet die Aktion ohne Änderung am Artikel.
+
+Der Trefferdialog kann Hersteller, Artikelnummer, Name, EAN, Maßstab, Beschreibung, Produkt-URL und
+Spurweite übernehmen. Hersteller oder Spurweite sind nur auswählbar, wenn sie einem aktiven
+bekannten Stammdatenwert entsprechen. Eine gewählte Spurweite wird den vorhandenen hinzugefügt.
+Ungültige allgemeine Werte und Produkt-URLs außerhalb von HTTP oder HTTPS werden ignoriert. In
+v0.1.17.6 bietet die Trefferauswahl technische Ergebnisfelder nur für **Gleis** an. Andere
+Artikelarten können die allgemeinen Treffergruppen, aber keine Fachangaben übernehmen.
+
+Nur Felder mit aktuell leerem Formularwert sind in der Prüfung vorausgewählt. Vorhandene Werte sind
+nicht zum Ersetzen markiert. Bilder werden nie automatisch gewählt. Wählen Sie nur vertrauenswürdige
+Werte und übernehmen Sie diese in den lokalen Entwurf. Gespeichert wird erst nach erfolgreichem
+Speichern des Artikels.
+
+**Barcode** öffnet den Scanner mit der aktuellen EAN. Ein nicht leerer gescannter oder manuell
+eingegebener Wert ersetzt die lokale EAN und startet sofort eine reine EAN-Suche. Kamerafreigabe und
+manuelle Eingabe beschreibt [Artikelsuche, Web-Dokumente und Ersatzteile](../vehicles/search-and-spares).
+
+Gewählte Suchbilder werden vorgemerkt. Nach dem Speichern des Artikelstamms importiert RailKeeper
+sie nacheinander. Das erste erfolgreiche Bild wird nur dann zum Hauptbild, wenn der Zubehörartikel
+noch kein Hauptbild besitzt. Ein fehlerhaftes Bild setzt weder den Artikel noch frühere Bilder
+zurück. Spätere vorgemerkte Bilder werden trotzdem versucht. Der Dialog bleibt mit dem ersten
+Importfehler geöffnet und behält fehlgeschlagene Bilder als Vormerkung. Schließen Sie ihn erst,
+nachdem Sie über Wiederholen oder Verwerfen entschieden haben.
+
+## Dublettenkandidaten prüfen
+
+Ist die Artikelnummer nicht leer, prüft RailKeeper vor dem Speichern auf eine exakte Kombination
+aus Hersteller und Artikelnummer. Führende und nachgestellte Leerzeichen sowie Groß- und
+Kleinschreibung werden dabei ignoriert. Beim Bearbeiten ist der aktuelle Artikel ausgeschlossen.
+Name, EAN, Spurweite und
+Unterart ändern den Treffer nicht.
+
+Bei Kandidaten zeigt RailKeeper diese vor dem Schreiben an. Mit **Abbrechen** kehren Sie zum Entwurf
+zurück. **Trotzdem speichern** legt die festgehaltenen Werte an oder aktualisiert sie. Die Warnung
+erlaubt beabsichtigte Varianten. Sie führt keine Datensätze zusammen und überträgt weder Bestand,
+Dokumente noch Nutzungen eines anderen Artikels.
+
+## Bearbeiten ohne Datenverlust
+
+Öffnen Sie **Artikel bearbeiten**, ändern Sie den Entwurf und verwenden Sie die zentrale Aktion
+**Speichern**. Die Validierung wechselt zum ersten betroffenen Reiter in dieser Reihenfolge:
+Artikel, Bestand, Einkäufe & Dokumente, danach der artikelspezifische Reiter. Rote Markierungen an
+Reitern kennzeichnen noch ungültige Werte.
+
+Eine geänderte Bestandsstrategie ist nur erlaubt, wenn alle vorhandenen Bestands- und
+Zuordnungsdaten darstellbar bleiben. RailKeeper blockiert insbesondere den Wechsel von einer
+mengenfähigen Strategie zu reiner Einzelverwaltung, solange Mengenbestand, Mengenreservierungen
+oder Mengeneinbauten bestehen. Ebenso wird das Entfernen der Einzelverwaltung blockiert, solange
+Einzelstücke oder deren Reservierungen, Einbauten oder Zustandsverlauf vorhanden sind. Bereinigen
+oder beenden Sie diese Abhängigkeiten bewusst und versuchen Sie es erneut. Eine abgelehnte
+Aktualisierung lässt den gespeicherten Artikel unverändert.
+
+Können erforderliche Stammdaten oder Definitionen eigener Felder nicht geladen werden, markiert der
+Editor seine Ressourcen als veraltet und sperrt betroffene Schreibaktionen. Verwenden Sie
+**Erneut versuchen**, ersetzen Sie angezeigte historische Werte nicht aus dem Gedächtnis und
+speichern Sie erst nach erfolgreichem Laden. Ist bereits das Artikeldetail fehlgeschlagen, schließen
+und öffnen Sie es neu, statt einen unvollständigen Ersatzstand zu bearbeiten.
+
+## Artikel archivieren, wiederherstellen oder löschen
+
+Administratoren und Bearbeiter können einen Artikel in der Übersicht archivieren oder
+wiederherstellen. Beide Aktionen schreiben sofort und ohne Bestätigung. Archivierte Artikel
+verschwinden aus der normalen Liste, bleiben über den Statusfilter **Archiviert** erreichbar und
+können wiederhergestellt werden.
+
+Nur ein Administrator kann einen Artikel endgültig löschen. RailKeeper verlangt dafür eine
+Bestätigung. Ein Bestand ungleich null, Einzelstücke, Bestandsbewegungen, Einkäufe, Reservierungen,
+Einbauten oder technische Anlagenpositionen mit Artikelverweis blockieren das Löschen.
+Artikeldokumente allein blockieren es nicht. Ihre Metadaten werden entfernt, anschließend versucht
+RailKeeper nicht mehr referenzierte gespeicherte Dateien zu entfernen. Das Löschen lässt sich nicht
+rückgängig machen. Prüfen Sie vorher eine aktuelle Sicherung.
+
+## Validierungs- und Ressourcenfehler beheben
+
+| Situation | Nächster Schritt |
+| --- | --- |
+| Pflichtfeld oder Zahl ist ungültig | Öffnen Sie den markierten Reiter und korrigieren Sie jede Feldmeldung. |
+| Es kann keine Inventarnummer vergeben werden | Lassen Sie das Inventarnummernschema **Artikel** durch einen Administrator aktivieren oder reparieren. |
+| Artikelart, Unterart oder Stammdaten fehlen | Laden Sie die Ressourcen erneut. Nur aktive konfigurierte Werte können neu gewählt werden. |
+| Dublettenkandidaten erscheinen | Vergleichen Sie Hersteller und Artikelnummer und brechen Sie ab oder speichern Sie die Variante bewusst. |
+| Strategieänderung meldet einen Konflikt | Klären Sie unvereinbaren Bestand, Einzelstücke, Reservierungen, Einbauten oder Zustandsverlauf. |
+| Suche kann nicht starten | Ergänzen Sie EAN oder die erforderliche Kombination aus Hersteller, Name, Artikelnummer und Spurweite und prüfen Sie die Einstellungen. |
+| Suchbild kann nicht importiert werden | Der Artikel kann bereits gespeichert sein. Wiederholen oder verwerfen Sie nur die fehlgeschlagenen vorgemerkten Bilder. |
+| Speichern ist verboten | Verwenden Sie ein Administrator- oder Bearbeiterkonto. Planungsrecht für Reservierungen ist kein Artikel-Bearbeitungsrecht. |
+
+## Verwandte Seiten
+
+- [Zubehörübersicht](./)
+- [Bestand, Einkäufe und Dokumente](./stock-purchases-documents)
+- [Zuordnungen und Nutzungsverlauf](./allocations-history)
+- [Artikelsuche, Web-Dokumente und Ersatzteile](../vehicles/search-and-spares)
+- [Stammdatenverwaltung](/de/administration/#lebenszyklus-der-stammdaten)
+
+## Dokumentierte RailKeeper-Version
+
+Diese Seite dokumentiert RailKeeper **v0.1.17.6** und wurde zuletzt am 16.08.2026 geprüft.

--- a/docs/site/de/guide/accessories/article-records.md
+++ b/docs/site/de/guide/accessories/article-records.md
@@ -223,6 +223,7 @@ rückgängig machen. Prüfen Sie vorher eine aktuelle Sicherung.
 
 ## Verwandte Seiten
 
+- [Überblick zum Benutzerhandbuch](/de/guide/)
 - [Zubehörübersicht](./)
 - [Bestand, Einkäufe und Dokumente](./stock-purchases-documents)
 - [Zuordnungen und Nutzungsverlauf](./allocations-history)

--- a/docs/site/de/guide/accessories/index.md
+++ b/docs/site/de/guide/accessories/index.md
@@ -118,7 +118,7 @@ Die Tabelle bietet neun Datenspalten:
 
 | Spalte | Angezeigter Wert |
 | --- | --- |
-| Bild | Primäres Zubehörbild oder Platzhalter. |
+| Bild | Primäres Zubehörbild oder allgemeines Bildsymbol. |
 | Inventarnummer | Lokale Artikelidentität in RailKeeper. |
 | Hersteller | Produkthersteller. |
 | Artikelnummer | Hersteller- oder Katalognummer. |

--- a/docs/site/de/guide/accessories/index.md
+++ b/docs/site/de/guide/accessories/index.md
@@ -1,0 +1,208 @@
+---
+title: Zubehörübersicht
+description: Zubehörartikel finden, filtern, prüfen und sicher verwalten.
+audience: user
+status: stable
+reviewedVersion: 0.1.17.6
+lastReviewed: 2026-08-16
+---
+
+# Zubehörübersicht
+
+**Zubehör** ist RailKeepers Katalog- und Bestandsbereich für Gleise, Signale, Decoder, elektrische
+Bauteile, Landschaftsbau, Beleuchtung und weitere Modellbahnartikel. Er verbindet Produktidentität,
+gelagerte und gebundene Mengen, Bilder, Lagerorte und Aktionen im Artikellebenszyklus. Dieses
+Kapitel beschreibt den stabilen RailKeeper-Stand v0.1.17.6.
+
+Ein Artikel ist der gemeinsame Produktdatensatz. Sein Bestand kann aus austauschbaren Mengen,
+einzeln geführten Stücken oder beidem bestehen. Reservierungen und Einbauten binden einen Teil
+davon an ein Fahrzeug oder ein anderes konfiguriertes Ziel. Die Übersicht fasst diese Zustände
+zusammen, verändert den Bestand aber nicht selbst.
+
+## Zugriffsrechte und Arbeitsbereich
+
+Admin, Editor, Viewer und Planner können **Zubehör** öffnen und Artikeldaten einsehen. Ihre
+Schreibrechte unterscheiden sich:
+
+| Rolle | Stabiler Zugriff in der Übersicht |
+| --- | --- |
+| Viewer | Artikel und ihre gespeicherten Ressourcen ansehen. |
+| Planner | Artikel ansehen und später Reservierungen anlegen oder stornieren. Die allgemeine Artikel- und Bestandsbearbeitung bleibt schreibgeschützt. |
+| Editor | Artikel anlegen und bearbeiten, archivieren oder wiederherstellen sowie Bestand und Lebenszyklus verwalten. |
+| Admin | Besitzt die Editor-Rechte und kann zusätzlich einen vollständig unbenutzten Artikel endgültig löschen. |
+| Messe | Erhält allein durch die Rolle Messe keinen Zugriff auf Zubehör. |
+
+Die Seite zeigt Viewern und Plannern einen ausdrücklichen Schreibschutz-Hinweis. Die serverseitigen
+Rollenprüfungen sind maßgeblich. Ein sichtbarer Wert oder eine Leseaktion verleiht kein
+Schreibrecht.
+
+Kennzahlen und Zeilen stammen aus der lokalen RailKeeper-Datenbank. Jede Änderung an Suche,
+Filterung oder Sortierung startet eine neue Serveranfrage. Der Ergebniszähler beschreibt deshalb
+die aktuelle gesuchte und gefilterte Liste, während die vier Kennzahlen immer alle nicht
+archivierten Artikel zusammenfassen.
+
+## Kennzahlen lesen
+
+Oberhalb der Artikelliste stehen vier Kennzahlenkarten:
+
+| Kennzahl | Stabile Bedeutung und Aktion |
+| --- | --- |
+| **Artikelbestand** | Anzahl nicht archivierter Artikeldatensätze und unterschiedlicher Artikelarten. Die Auswahl entfernt alle aktiven Filter. |
+| **Verfügbar** | Gesamte freie Menge und Anzahl unterschiedlicher Lagerorte mit Bezug zu aktiven Artikeln. Die Auswahl zeigt Artikel mit mehr als null verfügbaren Einheiten. |
+| **Gebunden** | Summe aktiver Reservierungen und aktiver Einbauten. Die Auswahl zeigt Artikel mit reservierter oder eingebauter Menge. |
+| **Pflegehinweise** | Gesamtzahl unvollständiger Angaben in aktiven Artikeln. Die Karte dient nur der Information und besitzt keine Filteraktion. |
+
+**Pflegehinweise** zählt fehlende Felder, nicht betroffene Artikel. Ein Artikel kann mehrere
+Hinweise beitragen. Der stabile Stand prüft fehlenden Hersteller, fehlende Artikelnummer,
+Artikelart und Bestandseinheit. Bei Gleis-, Signal-, Decoder-, Elektrik-/Steuerungs-,
+Gebäude-/Ausstattungs- und Beleuchtungsartikeln erzeugt auch eine fehlende Spurweite einen Hinweis.
+Für Landschaftsverbrauchsmaterial und **Sonstiges** verlangt diese Kennzahl keine Spurweite.
+
+Die Kennzahlen ignorieren die aktuelle Suche und Filterauswahl. Die Größe des sichtbaren
+Ergebnisses steht im Ergebniszähler darunter.
+
+## Artikel suchen und filtern
+
+Gib Text unter **Artikel suchen** ein. Der Server sucht ohne Beachtung der Groß-/Kleinschreibung
+nach Teilzeichenfolgen in genau fünf Feldern:
+
+- Inventarnummer
+- Hersteller
+- Artikelnummer
+- Name
+- EAN
+
+Beschreibung, Schlagwörter, alternative Nummern, Fachangaben, Lagerhinweise, Kaufdaten und
+Verwendungshistorie gehören im stabilen Stand nicht zur Freitextsuche.
+
+Zusätzlich stehen diese Filter bereit:
+
+| Filter | Auswahl und Verhalten |
+| --- | --- |
+| Artikelart | Arten, die in aktiven Artikeln vorkommen. |
+| Hersteller | Hersteller, die in aktiven Artikeln vorkommen. |
+| Spurweite | Spurweiten, die in aktiven Artikeln vorkommen. |
+| Status | Verfügbar, Reserviert, Eingebaut, Wartung fällig, Defekt oder Archiviert. |
+| Lagerort | Aktive Lagerorte. Ein Artikel passt, wenn Mengenbestand oder ein Einzelstück diesem Lagerort zugeordnet ist. |
+
+Unterschiedliche Filtergruppen werden mit UND verknüpft. Eine Zeile muss den Suchtext und jede
+ausgewählte Gruppe erfüllen. **Gebunden** aus der Kennzahlenkarte ist der einzige kombinierte
+Status: Er entspricht **Reserviert** ODER **Eingebaut**. Die normale Liste schließt archivierte
+Artikel aus. **Archiviert** ersetzt diesen Standard und zeigt archivierte Zeilen, die auch zu den
+übrigen Filtern passen.
+
+Die Statusfilter bedeuten:
+
+| Status | Enthaltene Artikel |
+| --- | --- |
+| Verfügbar | Nach aktiven Reservierungen sind mehr als null Einheiten frei. |
+| Reserviert | Mindestens eine Einheit gehört zu einer aktiven Reservierung. |
+| Eingebaut | Mindestens eine Einheit gehört zu einem aktiven Einbau. |
+| Wartung fällig | Ein Einzelstück oder aktiver Einbau hat den Zustand **Wartung fällig**. |
+| Defekt | Ein Einzelstück oder aktiver Einbau hat den Zustand **Defekt**. |
+| Archiviert | Der Artikeldatensatz ist archiviert. |
+
+**Filter zurücksetzen** entfernt Suchtext und alle fünf Filtergruppen. Desktopansicht, sichtbare
+Spalten und Sortierung bleiben unverändert.
+
+## Spalten, Ansicht und Sortierung wählen
+
+Auf breiten Bildschirmen kannst du zwischen Tabellen- und Kachelansicht wechseln. RailKeeper
+speichert diese Wahl im lokalen Speicher des aktuellen Browsers. Sie gehört nicht zum Benutzerkonto
+und folgt dir nicht in einen anderen Browser.
+
+Bis zu einer Breite von 900 Pixeln zeigt RailKeeper immer die kompakte Liste. Die gespeicherte
+Tabellen-/Kachelwahl gilt wieder, sobald das Fenster breiter wird.
+
+Die Tabelle bietet neun Datenspalten:
+
+| Spalte | Angezeigter Wert |
+| --- | --- |
+| Bild | Primäres Zubehörbild oder Platzhalter. |
+| Inventarnummer | Lokale Artikelidentität in RailKeeper. |
+| Hersteller | Produkthersteller. |
+| Artikelnummer | Hersteller- oder Katalognummer. |
+| Name | Artikelname und Einstieg in die Leseansicht. |
+| Art / Unterart | Konfigurierte Artikelklassifikation. |
+| Spur | Alle dem Artikel zugeordneten Spurweiten. |
+| Bestand | Gesamtbestand sowie freie, reservierte und eingebaute Mengen. |
+| Lagerung | Erster Lagerort und Anzahl weiterer Lagerorte. |
+
+Jede sichtbare Datenspalte ist sortierbar. Die Anfangsreihenfolge ist Inventarnummer aufsteigend.
+Wähle die aktive Überschrift erneut, um die Richtung umzukehren. Eine andere Überschrift beginnt
+aufsteigend. Bei sonst gleichen Werten verwendet RailKeeper die interne ID als stabilen
+Tie-Breaker.
+
+Die Spaltenauswahl ist nur in der Tabellenansicht verfügbar. Auch sie wird im aktuellen Browser
+gespeichert. Anfangs sind alle neun Spalten sichtbar. Inventarnummer und Name können nicht
+gleichzeitig ausgeblendet werden, damit mindestens eine Artikelidentität sichtbar bleibt.
+
+Die Kachelansicht betont Bild, Identität, Art, Spurweite, Lagerung und Bestand. Die kompakte Liste
+zeigt eine kleinere Identitäts- und Bestandszusammenfassung. Beide folgen der aktuellen
+Serversortierung, bieten aber keine eigenen Sortieraktionen.
+
+## Artikel auswählen, öffnen und verwalten
+
+Kontrollkästchen in der Tabelle wählen eine Zeile oder alle aktuell sichtbaren Zeilen aus. Eine
+Auswahl verschwindet, wenn ein neues Such- oder Filterergebnis den Artikel nicht mehr enthält. Der
+stabile Stand v0.1.17.6 bietet keine Sammelaktion für diese Auswahl. Sie ist nur visueller Zustand
+und keine vorgemerkte Archivierung, Auswertung oder Bestandsbuchung.
+
+Öffne über Artikelname, Bild oder **Artikel ansehen** den schreibgeschützten Artikeldialog. Abhängig
+von Rolle und Artikelzustand bieten die Zeilen außerdem:
+
+| Aktion | Rolle und Speicherung |
+| --- | --- |
+| Artikel ansehen | Jede Rolle mit Zubehör-Lesezugriff. Kein Schreibvorgang. |
+| Artikel bearbeiten | Admin oder Editor. Das Formular bleibt Entwurf, bis es gespeichert wird. |
+| Artikel archivieren | Admin oder Editor. Schreibt sofort ohne Nachfrage und lädt die Übersicht neu. |
+| Artikel wiederherstellen | Admin oder Editor. Schreibt sofort ohne Nachfrage und lädt die Übersicht neu. |
+| Artikel löschen | Nur Admin. Öffnet eine Bestätigung für das endgültige Löschen. |
+
+Endgültiges Löschen gelingt nur bei einem vollständig unbenutzten Artikel. Bestand ungleich null,
+Einzelstücke, Bestandsbewegungen, Käufe, Reservierungen, Einbauten oder eine technische
+Layoutposition mit Artikelbezug blockieren es. Gespeicherte Artikeldokumente blockieren einen
+ansonsten unbenutzten Artikel nicht. RailKeeper entfernt beim Löschen ihre Metadaten und versucht
+anschließend, auch die gespeicherten Dateien zu entfernen.
+
+Löschen kann nicht rückgängig gemacht werden. Erstelle und validiere vor dem Entfernen eines
+wichtigen Datensatzes eine aktuelle Anwendungssicherung. Die vollständigen Lösch- und
+Wiederherstellungsregeln gehören zum Artikellebenszyklus.
+
+## Lade-, Leer- und Fehlerzustände beheben
+
+| Situation | Verhalten und nächster Schritt |
+| --- | --- |
+| Erstes Laden | **Artikel werden geladen ...** erscheint bis zum Abschluss der ersten Anfrage. |
+| Kein Artikel vorhanden | **Noch keine Artikel vorhanden.** Admin oder Editor kann den ersten Artikel anlegen. |
+| Filter ohne Treffer | **Keine Artikel entsprechen den aktiven Filtern.** Suche oder Filter anpassen oder zurücksetzen. |
+| Laden schlägt vor einem Ergebnis fehl | Nur der Fehler erscheint oberhalb des leeren Listenbereichs. Sitzung und Verbindung prüfen, danach durch Ändern oder Zurücksetzen eines Filters erneut anfragen. |
+| Laden schlägt nach einer Anzeige fehl | Der Fehler erscheint, während frühere Zeilen sichtbar bleiben können. Nicht als aktuell behandeln, sondern die Anfrage vor einer Aktion wiederholen. |
+| Stammdatenbezeichnungen laden nicht | Zeilen können auf stabile übersetzte Art-/Unterartbezeichnungen zurückfallen. Einen Artikel erst bearbeiten, wenn die erforderlichen Editor-Ressourcen geladen sind. |
+| Archivieren oder Wiederherstellen scheitert | Der Fehler erscheint oberhalb der Liste. Den Artikel bis zu einem erfolgreichen Neuladen als unverändert behandeln. |
+| Löschen ist blockiert | Der Datensatz bleibt bestehen. Vor dem nächsten Versuch alle gemeldeten Bestands- oder Verwendungsbezüge auflösen. |
+| Schreiben ist verboten | Mit der erforderlichen Editor- oder Admin-Berechtigung anmelden. Lesezugriff ersetzt keine serverseitige Schreibberechtigung. |
+
+## Mit einem Artikelablauf fortfahren
+
+Der ausführliche Zubehörbereich trennt drei Arbeitsabläufe:
+
+- Artikeldatensatz und Fachangaben anlegen und pflegen;
+- Bestand, Käufe, Einzelstücke, Bilder und Dokumente verwalten;
+- Bestand reservieren oder einbauen und die Verwendungshistorie lesen.
+
+Diese Abläufe teilen sich einen Artikeldialog, besitzen aber unterschiedliche Speicher- und
+Berechtigungsregeln. Speichere oder verwirf ungespeicherte Artikelfelder bewusst, bevor du eine
+sofortige Bestands- oder Lebenszyklusaktion startest.
+
+## Verwandte Seiten
+
+- [Überblick zum Benutzerhandbuch](/de/guide/)
+- [Übersicht, Kennzahlen und Datenqualität](/de/guide/overview/)
+- [Fahrzeugbestand und Grunddaten](/de/guide/vehicles/)
+- [Artikelsuche, Web-Dokumente und Ersatzteile](/de/guide/vehicles/search-and-spares)
+
+## Dokumentierter RailKeeper-Stand
+
+Diese Seite dokumentiert den stabilen RailKeeper-Stand **v0.1.17.6** und wurde zuletzt am
+2026-08-16 geprüft.

--- a/docs/site/de/guide/accessories/index.md
+++ b/docs/site/de/guide/accessories/index.md
@@ -198,6 +198,9 @@ sofortige Bestands- oder Lebenszyklusaktion startest.
 ## Verwandte Seiten
 
 - [Überblick zum Benutzerhandbuch](/de/guide/)
+- [Artikelstammdaten und Fachangaben](./article-records)
+- [Bestand, Käufe und Dokumente](./stock-purchases-documents)
+- [Reservierungen, Einbauten und Verwendung](./allocations-history)
 - [Übersicht, Kennzahlen und Datenqualität](/de/guide/overview/)
 - [Fahrzeugbestand und Grunddaten](/de/guide/vehicles/)
 - [Artikelsuche, Web-Dokumente und Ersatzteile](/de/guide/vehicles/search-and-spares)

--- a/docs/site/de/guide/accessories/stock-purchases-documents.md
+++ b/docs/site/de/guide/accessories/stock-purchases-documents.md
@@ -246,7 +246,6 @@ bereits aus der Liste entfernten Eintrag folgen. Laden Sie neu, bevor Sie erneut
 - [Zubehörübersicht](./)
 - [Artikelstammdaten und Fachangaben](./article-records)
 - [Reservierungen, Einbauten und Verwendung](./allocations-history)
-- [Administration und Betrieb](/de/administration/)
 
 ## Dokumentierte RailKeeper-Version
 

--- a/docs/site/de/guide/accessories/stock-purchases-documents.md
+++ b/docs/site/de/guide/accessories/stock-purchases-documents.md
@@ -242,6 +242,7 @@ bereits aus der Liste entfernten Eintrag folgen. Laden Sie neu, bevor Sie erneut
 
 ## Verwandte Seiten
 
+- [Überblick zum Benutzerhandbuch](/de/guide/)
 - [Zubehörübersicht](./)
 - [Artikelstammdaten und Fachangaben](./article-records)
 - [Reservierungen, Einbauten und Verwendung](./allocations-history)

--- a/docs/site/de/guide/accessories/stock-purchases-documents.md
+++ b/docs/site/de/guide/accessories/stock-purchases-documents.md
@@ -1,0 +1,252 @@
+---
+title: Bestand, Käufe und Dokumente
+description: Zubehörmengen, Einzelstücke, Käufe, Bilder und Dokumente verwalten.
+audience: user
+status: stable
+reviewedVersion: 0.1.17.6
+lastReviewed: 2026-08-16
+---
+
+# Bestand, Käufe und Dokumente
+
+RailKeeper kann austauschbare Zubehöreinheiten als Menge zählen, physische Stücke einzeln verwalten
+oder Einheiten bei Bedarf aus dem Mengenbestand in die Einzelverwaltung überführen. Käufe und
+Dokumente gehören zum selben Artikel, besitzen aber eigene Sofortaktionen zum Speichern. Dieses
+Kapitel beschreibt das stabile Verhalten von RailKeeper v0.1.17.6.
+
+Administratoren und Bearbeiter können diese Ressourcen verwalten. Betrachter und Planer können sie
+ansehen. Das Reservierungsrecht eines Planers umfasst jedoch keine Änderungen an Bestand, Käufen,
+Einzelstücken oder Dokumenten. Speichern Sie den Artikelstamm einmal, bevor Sie zugehörige
+Ressourcen anlegen.
+
+## Bestandsstrategie wählen
+
+Die Strategie wird zusammen mit dem Artikel über die zentrale Aktion **Speichern** gesichert. Sie
+bestimmt, welche Bestandsbefehle und Datensätze verfügbar sind:
+
+| Strategie | Mengenbestand | Einzelstücke | In Bestand gebuchter Kauf |
+| --- | --- | --- | --- |
+| **Mengenbestand** | Mengen je Lagerort korrigieren und umbuchen. | Nicht verfügbar. | Addiert die Kaufmenge am gewählten Lagerort und schreibt eine Bewegung Kauf. |
+| **Einzelverwaltung** | Keine Mengenkorrektur oder Umbuchung. | Ein Datensatz je physischem Stück. | Erzeugt je gekaufter Einheit ein eingelagertes Einzelstück mit Zustand Unbekannt. Es entsteht keine Mengenbewegung. |
+| **Menge, später einzeln** | Mengen korrigieren und umbuchen. | Jeweils eine verfügbare Einheit in ein Einzelstück überführen. | Erhöht den Mengenbestand wie Mengenbestand. Gekaufte Einheiten können später individualisiert werden. |
+
+Verwenden Sie **Mengenbestand** für austauschbares Material, **Einzelverwaltung**, wenn jede Einheit
+eine eigene Identität oder einen eigenen Zustand benötigt, und die Hybridstrategie, wenn Packungen
+zunächst als Menge beginnen und einzelne Stücke später einen Lebenszyklus erhalten sollen.
+
+Ein Strategiewechsel kann durch vorhandenen Bestand und Zuordnungen blockiert sein. Mengenwerte,
+Mengenreservierungen oder Mengeneinbauten verhindern den Wechsel zur reinen Einzelverwaltung.
+Vorhandene Einzelstücke und deren Reservierungs-, Einbau- oder Zustandsverlauf verhindern das
+Entfernen der Einzelverwaltung. Ein abgelehnter Wechsel schreibt nichts.
+
+Der **Mindestbestand** ist ein nicht negativer ganzzahliger Planungswert. Er wird mit dem Artikel
+gespeichert und legt selbst weder Bestand noch Reservierung oder Bestellung an.
+
+## Bestand und Verfügbarkeit lesen
+
+Der Reiter **Bestand** zeigt die gezählte Menge für jeden referenzierten Lagerort. Die Summe ergibt
+den Mengenbestand. Einzelstücke stehen in einer separaten Tabelle und werden nicht zu dieser Summe
+addiert.
+
+Der Mengenbestand ist die physisch vorhandene Menge. Die **verfügbare** Menge ist kleiner, wenn
+aktive Mengenreservierungen bestehen. RailKeeper verhindert deshalb, dass eine Korrektur,
+Umbuchung oder Individualisierung einen Lagerort unter seine aktiv reservierte Menge senkt.
+Eingebaute Mengeneinheiten wurden bereits aus dem eingelagerten Bestand entfernt.
+
+Das Bestandsjournal ist absteigend chronologisch sortiert und enthält diese stabilen Bewegungsarten:
+
+| Bewegung | Menge und Quelle |
+| --- | --- |
+| Kauf | Positive Kaufmenge am Ziellagerort, mit dem Kauf verknüpft. Nur Mengen- und Hybridstrategie. |
+| Korrektur | Vorzeichenbehaftete manuelle Änderung an einem Lagerort. |
+| Umbuchung Ausgang | Negative Menge an der Quelle, mit derselben Umbuchung wie der Eingang verknüpft. |
+| Umbuchung Eingang | Positive Menge am Ziel. |
+| Individualisierung | `-1` an der Quelle, mit dem neu erzeugten Einzelstück verknüpft. |
+| Einbau | Negative eingebaute Menge an der Quelle bei einem Mengeneinbau. |
+| Ausbau | Positive zurückgeführte Menge am Ziel, wenn ein Mengeneinbau wieder eingelagert wird. |
+
+Das Journal zeigt Datum, Bewegungsart, vorzeichenbehaftete Menge und Notiz. Eine Umbuchung schreibt
+zwei Zeilen in einer Transaktion. Das Anlegen oder Stornieren einer Reservierung erzeugt keine
+Bestandsbewegung, weil sich die Verfügbarkeit, nicht die eigene Menge ändert.
+
+## Mengenbestand korrigieren
+
+Verwenden Sie **Bestand korrigieren** für eine physische Korrektur, die weder Kauf noch Umbuchung
+ist:
+
+1. Wählen Sie einen aktiven Lagerort.
+2. Geben Sie eine ganze Zahl ungleich null ein. Ein positiver Wert fügt Einheiten hinzu, ein
+   negativer entfernt sie.
+3. Wählen Sie **Buchen** und prüfen Sie die Bestätigung mit vorzeichenbehafteter Menge und
+   Artikelname.
+4. Bestätigen Sie, um neue Lagermenge, eine Journalzeile Korrektur und das Audit-Ereignis in einer
+   Transaktion zu schreiben.
+
+Die Aktion gibt es nur für Mengen- und Hybridartikel. RailKeeper lehnt inaktive Lagerorte, null,
+nicht ganzzahlige Werte oder eine Absenkung unter aktive Reservierungen ab. Ein Abbruch der
+Bestätigung schreibt nichts. Nach Erfolg werden alle Artikelressourcen neu geladen.
+
+Verwenden Sie Käufe für Wareneingänge, zu denen Händler oder Rechnung erfasst werden sollen. Eine
+positive manuelle Korrektur erzeugt keinen Kaufdatensatz. Der stabile Korrekturbefehl besitzt kein
+Notizfeld.
+
+## Bestand zwischen Lagerorten umbuchen
+
+Wählen Sie verschiedene aktive Quell- und Ziellagerorte, geben Sie eine positive ganze Menge und
+optional eine Notiz ein. **Umbuchen** öffnet eine Bestätigung. Die Bestätigung führt atomar aus:
+
+- Die Menge wird an der Quelle abgezogen, ohne reservierte Einheiten anzutasten.
+- Die Menge wird am Ziel addiert.
+- Verknüpfte Journalzeilen Umbuchung Ausgang und Umbuchung Eingang erhalten dieselbe optionale
+  Notiz.
+- Die Artikelressourcen werden neu geladen.
+
+Die Umbuchung ändert keinen Lagerort, wenn die Quelle nicht genügend verfügbare Menge besitzt,
+Quelle und Ziel gleich sind, ein Lagerort oder ein übergeordneter Lagerort archiviert ist oder ein
+Pflichtwert fehlt. Der Befehl ist nur bei Mengen- und Hybridartikeln vorhanden.
+
+## Einzelstücke verwalten
+
+Einzel- und Hybridartikel zeigen die Einzelstücktabelle. Bei einem Einzelartikel fügt
+**Einzelstück anlegen** einen physischen Datensatz hinzu, ohne den Mengenbestand zu ändern. Bei
+einem Hybridartikel verbraucht **Individualisieren** genau eine verfügbare Mengeneinheit am
+gewählten Lagerort und erzeugt das Einzelstück in derselben Transaktion. Zusätzlich entsteht die
+Bewegung Individualisierung mit `-1`.
+
+| Feld des Einzelstücks | Stabile Regel |
+| --- | --- |
+| Inventarnummer | Optionale Stückidentität. Wenn angegeben, muss sie ohne Beachtung der Groß- und Kleinschreibung unter allen Zubehör-Einzelstücken eindeutig sein. Sie ist von der Artikel-Inventarnummer getrennt. |
+| Seriennummer | Optionale Herstellerseriennummer. |
+| Zustand | Einsatzbereit, Wartung fällig, Defekt oder Unbekannt. Bei manueller Erfassung anfangs Einsatzbereit. |
+| Lebenszyklus | Eingelagert, Wartung oder Ausgemustert. Anfangswert Eingelagert. Reserviert und Eingebaut werden durch Zuordnungsbefehle gesteuert und sind hier nicht wählbar. |
+| Lagerort | Im stabilen Formular erforderlicher aktiver Lagerort. Beim Hybridartikel stammt das Einzelstück aus genau diesem Lagerort. |
+| Kaufdatum | Optionales Kalenderdatum, gespeichert im Format `JJJJ-MM-TT`. |
+| Kaufpreis | Optionale nicht negative Zahl in Schritten von 0,01. |
+| Garantie bis | Optionales Kalenderdatum. |
+| Notizen | Optionaler lokaler Text. |
+
+**Einzelstück speichern** öffnet immer eine Bestätigung. Bei einem Hybridartikel bricht eine zu
+kleine verfügbare Menge die gesamte Individualisierung einschließlich des neuen Einzelstücks ab.
+Leere Inventar- und Seriennummern sind erlaubt, eine doppelte nicht leere Inventarnummer nicht.
+
+Über das Bearbeitungssymbol laden Sie ein vorhandenes Einzelstück in dasselbe Formular. Auch das
+Speichern der Bearbeitung verlangt eine Bestätigung und ändert nur dieses Einzelstück. Ein
+Einzelstück mit Lebenszyklus Reserviert oder Eingebaut besitzt in dieser Tabelle keine
+Bearbeitungsaktion. Ändern Sie es über die zugehörige Reservierung oder den Einbau, damit
+Lebenszyklus, Lagerort und Verlauf konsistent bleiben.
+
+## Käufe erfassen
+
+Die Kaufliste ist eine stabile, absteigend chronologische Historie. RailKeeper v0.1.17.6 bietet das
+Hinzufügen, aber keine Aktion zum Bearbeiten oder Löschen eines Kaufs.
+
+| Kauffeld | Stabile Regel |
+| --- | --- |
+| Kaufdatum | Erforderliches gültiges Datum, anfangs der heutige Tag. |
+| Händler | Optionaler Text. |
+| Menge | Erforderliche positive ganze Zahl. |
+| Stückpreis | Optionaler Wert. Ein Zahlenwert erzeugt die angezeigte Vorschau Menge mal Stückpreis. |
+| Währung | Das stabile Formular verwendet EUR. Der gespeicherte API-Wert ist, sofern vorhanden, ein dreistelliger Großbuchstabencode. |
+| Rechnungsnummer | Optionaler Text. |
+| Garantie bis | Optionales gültiges Datum. |
+| In Bestand buchen | Ohne Auswahl entsteht nur der Kaufdatensatz. Bei Auswahl ist ein aktives Ziel erforderlich und der Bestand entsteht in derselben Transaktion. |
+| Lagerort | Nur für In Bestand buchen erforderlich. |
+| Notizen | Optionaler Text, der bei Mengenbestand in die Bewegung Kauf übernommen wird. |
+
+**Kauf buchen** schreibt sofort und ohne Bestätigung. Die Wirkung hängt von der Artikelstrategie ab:
+
+| Strategie und Option | Atomares Ergebnis |
+| --- | --- |
+| Beliebige Strategie, In Bestand buchen aus | Ein Kaufdatensatz, keine Änderung an Bestand, Einzelstücken oder Bewegungen. |
+| Mengenbestand, In Bestand buchen an | Ein Kauf, die vollständige Menge am Lagerort und eine verknüpfte Bewegung Kauf. |
+| Hybrid, In Bestand buchen an | Wie Mengenbestand. Gewählte Einheiten können später individualisiert werden. |
+| Einzelverwaltung, In Bestand buchen an | Ein Kauf und je Einheit ein eingelagertes Einzelstück. Jedes übernimmt Kaufdatum, Stückpreis, Garantie, Lagerort und Kaufverknüpfung, der Zustand beginnt mit Unbekannt. Es entsteht keine Mengenbewegung. |
+
+Kauf und optionale Bestandsbuchung laufen in einer Datenbanktransaktion. Scheitert ein Teil, werden
+weder Kauf noch Bestand oder Einzelstücke gespeichert. Nach Erfolg wird das Formular zurückgesetzt
+und RailKeeper lädt die zugehörigen Ressourcen neu.
+
+## Bilder und Dokumente verwalten
+
+Der Dokumentbereich zeigt Originaldateiname und Kategorie. Jeder Benutzer mit Leserecht für
+Zubehör kann ein Dokument herunterladen. Administratoren und Bearbeiter können hochladen, das
+Hauptbild wählen und löschen.
+
+| Aktion | Bestätigung und Wirkung |
+| --- | --- |
+| Hochladen | Keine Bestätigung. Datei, Kategorie und optionale Beschreibung wählen. Das erste hochgeladene Bild wird zum Hauptbild, wenn noch keines vorhanden ist. Anschließend werden die Ressourcen neu geladen. |
+| Als Hauptbild festlegen | Keine Bestätigung. Bei einem Bild verfügbar, das nicht Hauptbild ist. Entfernt in einer Transaktion die bisherige Hauptmarkierung, setzt dieses Bild und lädt neu. |
+| Herunterladen | Kein Schreiben und keine Bestätigung. Bilder können direkt angezeigt, andere Typen als Anhang heruntergeladen werden. |
+| Löschen | Destruktive Bestätigung. Entfernt die Dokumentmetadaten, löscht danach die gespeicherte Datei nur ohne weitere Referenz und lädt neu. Beim Löschen des Hauptbilds wird kein anderes Bild automatisch nachgerückt. |
+
+Die Kategorien sind Rechnung, Lieferschein, Anleitung, Datenblatt, Grundriss, Bild und Sonstiges.
+Nur ein Bild kann Hauptbild sein.
+
+Akzeptierte Dateiendungen sind `.pdf`, `.jpg`, `.jpeg`, `.png`, `.webp`, `.zip`, `.txt`, `.csv`,
+`.json` und `.xml`. Der erkannte Inhalt muss zur Endung passen. JSON, CSV und XML werden zusätzlich
+strukturell geprüft. Leere Dateien, unsichere Namen, ausführbare oder skriptartige Typen, HTML,
+abweichende MIME-Typen und Dateien oberhalb der konfigurierten Anhangsgrenze werden abgelehnt. Die
+Standardgrenze beträgt 25 MB über `RAILKEEPER_MAX_ATTACHMENT_MB`. Hochgeladene Dateien bleiben im
+lokalen Datenmodell von RailKeeper. Der Download erfordert eine autorisierte Anfrage an die
+Anwendung.
+
+Bilder aus der Artikeldatensuche verwenden einen separaten URL-Import. RailKeeper akzeptiert nur
+öffentliche HTTP- oder HTTPS-Adressen, lehnt localhost sowie private oder interne Adressen vor der
+Verbindung und bei Weiterleitungen ab, folgt höchstens fünf Weiterleitungen, verwendet eine
+Anfragegrenze von zehn Sekunden und akzeptiert nur erkannten JPEG-, PNG- oder WebP-Inhalt innerhalb
+derselben Größenbegrenzung. Der Idempotenzschlüssel verhindert, dass dasselbe vorgemerkte Bild für
+den Artikel doppelt gespeichert wird.
+
+Zubehörartikel, Mengenbestände, Bewegungen, Einzelstücke, Käufe, Dokumentmetadaten und gespeicherte
+Dateien sind in der Anwendungssicherung enthalten. Halten Sie vor destruktiver Dokument- oder
+Bestandsbereinigung eine aktuelle geprüfte Sicherung bereit.
+
+## Daten bei Sofortaktionen schützen
+
+Bestandsbefehle, Speichern von Einzelstücken, Kaufanlage, Dokument-Upload, Hauptbildwechsel und
+Dokumentlöschung speichern unabhängig von der zentralen Artikelaktion **Speichern**. Ihre
+Bestätigungen schützen den jeweils genannten Befehl, nicht ungespeicherte Artikelfelder an anderer
+Stelle im Dialog.
+
+Nach jeder erfolgreichen Unteraktion fragt RailKeeper Bestand, Journal, Einzelstücke, Käufe,
+Dokumente, Reservierungen, Einbauten, Verlauf, Lagerorte, Fahrzeuge und Anlagenressourcen erneut ab.
+Diese Lesevorgänge können teilweise fehlschlagen, nachdem der Schreibvorgang bereits bestätigt ist.
+Dann gilt:
+
+1. Behandeln Sie den Befehl als möglicherweise erfolgreich. Senden Sie ihn nicht aus veralteten
+   Daten erneut.
+2. Lesen Sie den Ressourcenfehler im Editor. RailKeeper kennzeichnet die Ressourcen als veraltet
+   und sperrt weitere Bestands-, Dokument-, Reservierungs- und Einbauaktionen.
+3. Wählen Sie **Erneut versuchen**, bis ein vollständiges Neuladen gelingt.
+4. Prüfen Sie Lagerzeile, Einzelstück, Kauf, Dokument und Journal, bevor Sie über einen weiteren
+   Schreibvorgang entscheiden.
+
+Dasselbe gilt nach einer Dokumentlöschung. Die Metadatenlöschung wird vor der Bereinigung einer
+nicht mehr referenzierten Datei bestätigt. Ein Fehler bei der Bereinigung kann deshalb auf einen
+bereits aus der Liste entfernten Eintrag folgen. Laden Sie neu, bevor Sie erneut löschen.
+
+## Bestands- und Dokumentfehler beheben
+
+| Situation | Nächster Schritt |
+| --- | --- |
+| Korrektur oder Umbuchung meldet zu wenig Bestand | Prüfen Sie aktive Reservierungen an der Quelle. Verwenden Sie nur die freie Menge. |
+| Lagerort fehlt oder wird abgelehnt | Wählen Sie einen aktiven Lagerort, dessen übergeordnete Orte ebenfalls aktiv sind. Die Lagerortverwaltung liegt außerhalb dieses Artikeldialogs. |
+| Individualisierung scheitert | Prüfen Sie Hybridstrategie und mindestens eine nicht reservierte Mengeneinheit am gewählten Lagerort. |
+| Inventarnummer des Einzelstücks kollidiert | Verwenden Sie eine andere Nummer oder bearbeiten Sie das vorhandene Stück. Andere Groß- und Kleinschreibung erzeugt keine eigene Nummer. |
+| Reserviertes oder eingebautes Stück ist nicht bearbeitbar | Beenden oder stornieren Sie seine Zuordnung über die Reservierungs- oder Einbausteuerung. |
+| Kauf wird abgelehnt | Prüfen Sie Kaufdatum, positive ganze Menge, Garantiedatum und Ziel bei Bestandsbuchung. |
+| Dateityp wird nicht unterstützt | Verwenden Sie eine zulässige Endung mit tatsächlich passendem Inhalt. Umbenennen reicht nicht. |
+| Datei ist zu groß | Verkleinern Sie sie unter die konfigurierte Anhangsgrenze oder lassen Sie die Grenze durch den Betreiber prüfen. |
+| URL-Bild wird abgelehnt | Verwenden Sie eine öffentliche HTTP(S)-Adresse zu JPEG, PNG oder WebP ohne Weiterleitung auf eine private Adresse. |
+| Schreiben erfolgreich, Neuladen fehlgeschlagen | Wiederholen Sie den Befehl nicht. Laden Sie die Ressourcen erneut und prüfen Sie zuerst Journal oder Ressourcenliste. |
+
+## Verwandte Seiten
+
+- [Zubehörübersicht](./)
+- [Artikelstammdaten und Fachangaben](./article-records)
+- [Reservierungen, Einbauten und Verwendung](./allocations-history)
+- [Administration und Betrieb](/de/administration/)
+
+## Dokumentierte RailKeeper-Version
+
+Diese Seite dokumentiert RailKeeper **v0.1.17.6** und wurde zuletzt am 16.08.2026 geprüft.

--- a/docs/site/de/guide/accessories/stock-purchases-documents.md
+++ b/docs/site/de/guide/accessories/stock-purchases-documents.md
@@ -21,7 +21,7 @@ Ressourcen anlegen.
 
 ## Bestandsstrategie wählen
 
-Die Strategie wird zusammen mit dem Artikel über die zentrale Aktion **Speichern** gesichert. Sie
+Die Strategie wird zusammen mit dem Artikel über **Änderungen speichern** gesichert. Sie
 bestimmt, welche Bestandsbefehle und Datensätze verfügbar sind:
 
 | Strategie | Mengenbestand | Einzelstücke | In Bestand gebuchter Kauf |
@@ -204,7 +204,7 @@ Bestandsbereinigung eine aktuelle geprüfte Sicherung bereit.
 ## Daten bei Sofortaktionen schützen
 
 Bestandsbefehle, Speichern von Einzelstücken, Kaufanlage, Dokument-Upload, Hauptbildwechsel und
-Dokumentlöschung speichern unabhängig von der zentralen Artikelaktion **Speichern**. Ihre
+Dokumentlöschung speichern unabhängig von der Artikelaktion **Änderungen speichern**. Ihre
 Bestätigungen schützen den jeweils genannten Befehl, nicht ungespeicherte Artikelfelder an anderer
 Stelle im Dialog.
 

--- a/docs/site/de/guide/index.md
+++ b/docs/site/de/guide/index.md
@@ -41,3 +41,7 @@ Speichern.
 [Artikelsuche, Web-Dokumente und Ersatzteile](/de/guide/vehicles/search-and-spares) erklärt, wie du
 externe Vorschläge prüfst, ausgewählte Artikeldaten und Bilder speicherst, Dokumente importierst und
 Ersatzteile pflegst, ohne teilweise Schreibvorgänge zu übersehen.
+
+[Zubehör](/de/guide/accessories/) beschreibt den getrennten Zubehör-Artikelbestand, technische
+Produktdaten, Mengen- und Einzelbestand, Käufe, Dokumente, Reservierungen, Einbauten und
+Verwendungshistorie.

--- a/docs/site/de/guide/overview/index.md
+++ b/docs/site/de/guide/overview/index.md
@@ -206,6 +206,7 @@ gespeichert.
 ## Verwandte Seiten
 
 - [Überblick zum Benutzerhandbuch](/de/guide/)
+- [Zubehörübersicht](/de/guide/accessories/)
 - [Fahrzeugwartung und Zustand](/de/guide/vehicles/maintenance)
 - [Ersteinrichtung und Anmeldung](/de/guide/getting-started/)
 - [Überblick zur Administration](/de/administration/)

--- a/docs/site/de/guide/vehicles/search-and-spares.md
+++ b/docs/site/de/guide/vehicles/search-and-spares.md
@@ -307,6 +307,8 @@ was bereits geschrieben worden sein kann.
 ## Verwandte Seiten
 
 - [Übersicht des Benutzerhandbuchs](/de/guide/)
+- [Zubehörübersicht](/de/guide/accessories/) für Zubehörartikel und -bestand, getrennt von
+  fahrzeugspezifischen Ersatzteildatensätzen
 - [Fahrzeugbestand und Grunddaten](/de/guide/vehicles/)
 - [Fahrzeugbilder und Beilagen](/de/guide/vehicles/media)
 - [Fahrzeugwartung und Zustand](/de/guide/vehicles/maintenance)

--- a/docs/site/guide/accessories/allocations-history.md
+++ b/docs/site/guide/accessories/allocations-history.md
@@ -190,6 +190,7 @@ availability or lifecycle state.
 
 ## Related pages
 
+- [User Guide overview](/guide/)
 - [Accessories overview](./)
 - [Article records and technical data](./article-records)
 - [Stock, purchases, and documents](./stock-purchases-documents)

--- a/docs/site/guide/accessories/allocations-history.md
+++ b/docs/site/guide/accessories/allocations-history.md
@@ -28,8 +28,8 @@ Every reservation and installation requires exactly one target:
 | Layout | One non-archived layout. |
 | Layout unit | One non-archived layout unit. |
 
-The dialog consumes these targets but does not create or edit layouts. If the needed target is
-missing, maintain it in its owning workspace first.
+The dialog consumes existing targets but does not create or edit layouts. This chapter does not
+document layout creation or editing.
 
 Five optional placement fields can accompany either workflow: **Placement**, **Digital address**,
 **Decoder output**, **Connection**, and **Wiring notes**. They describe where and how the accessory
@@ -58,7 +58,7 @@ individual item, maintenance and retired items remain owned but are not Stored o
 3. For a hybrid article, choose **Quantity** or **Individual item** as the source.
 4. Select an active storage location. For individual tracking, select a Stored item at that same
    location; its quantity is fixed to 1. Otherwise enter a positive whole quantity.
-5. Add an optional note, select **Save reservation**, and confirm.
+5. Add an optional note, select **Create reservation**, and confirm.
 
 The confirmed transaction validates the article, target, active location, strategy, and available
 source. A counted reservation creates an Active reservation and reduces Available only. It neither
@@ -94,7 +94,7 @@ Without a reservation, select target, optional placement data, source, positive 
 one Stored item, condition, and optional notes. Hybrid articles again allow the quantity or item
 path. Direct item installation is rejected if the item has an active reservation.
 
-**Save installation** opens a confirmation. The successful transaction has these effects:
+**Record installation** opens a confirmation. The successful transaction has these effects:
 
 | Source | Physical stock or item | Reservation | Installation and journal |
 | --- | --- | --- | --- |
@@ -108,7 +108,7 @@ atomic. If one check fails, none is kept.
 ## Update installation condition
 
 For an active installation, choose Ready, Maintenance due, Defective, or Unknown and select
-**Update condition**. A confirmation appears even when the selection looks unchanged.
+**Save condition**. A confirmation appears even when the selection looks unchanged.
 
 Confirming updates the installation, appends a condition-history row with previous and new value,
 and updates the condition of an installed individual item. Counted stock has no item record to
@@ -133,7 +133,7 @@ one transaction.
 
 ## Read usage history
 
-The **Usage history** tab appears when the article has reservation, installation, or history data.
+The **Usage & history** tab appears when the article has reservation, installation, or history data.
 Its upper section repeats only current Active reservations and installations not yet removed in
 read-only form.
 

--- a/docs/site/guide/accessories/allocations-history.md
+++ b/docs/site/guide/accessories/allocations-history.md
@@ -1,0 +1,200 @@
+---
+title: Reservations, installations, and usage
+description: Reserve accessory stock, record installations, and understand usage history.
+audience: user
+status: stable
+reviewedVersion: 0.1.17.6
+lastReviewed: 2026-08-16
+---
+
+# Reservations, installations, and usage
+
+Reservations assign available accessory stock to a future use. Installations record that the stock
+has physically left storage and is in use. RailKeeper keeps both steps, the item lifecycle, stock
+movements, conditions, and usage history consistent in one local transaction.
+
+## Roles and allocation targets
+
+Admin and Editor users can reserve, cancel, install, update conditions, and remove installations.
+A Planner can create and cancel reservations in the otherwise read-only article dialog, but cannot
+install, remove, change condition, or manage general stock. Viewer is read-only. Messe has no
+general accessories access.
+
+Every reservation and installation requires exactly one target:
+
+| Target | Selection shown by the stable dialog |
+| --- | --- |
+| Vehicle | Inventory number and vehicle name. |
+| Layout | One non-archived layout. |
+| Layout unit | One non-archived layout unit. |
+
+The dialog consumes these targets but does not create or edit layouts. If the needed target is
+missing, maintain it in its owning workspace first.
+
+Five optional placement fields can accompany either workflow: **Placement**, **Digital address**,
+**Decoder output**, **Connection**, and **Wiring notes**. They describe where and how the accessory
+is intended to be or is actually connected. **Notes** is a separate private workflow note.
+
+## Read the allocation summary
+
+The overview and allocation service derive these quantities from the selected inventory strategy:
+
+| Value | Stable meaning |
+| --- | --- |
+| Owned | Physical units still owned: stored plus actively installed counted units, or all individual items. Hybrid combines counted stock, individual items, and active counted installations without double counting individualized units. |
+| Stored | Counted stock plus, where supported, items at a storage location with lifecycle Stored or Reserved. |
+| Reserved | Quantity of all active reservations, including one per reserved item. |
+| Installed | Quantity of all installations not yet removed. |
+| Available | `max(Stored - Reserved, 0)`. |
+| Missing | Any amount by which Reserved exceeds Stored. Normal commands prevent this, but restored or legacy data can expose it. |
+
+For counted stock, an installation reduces Stored but stays in Owned until removal. For an
+individual item, maintenance and retired items remain owned but are not Stored or Available.
+
+## Reserve stock
+
+1. Select vehicle, layout, or layout unit and the exact target.
+2. Optionally enter the five technical placement fields.
+3. For a hybrid article, choose **Quantity** or **Individual item** as the source.
+4. Select an active storage location. For individual tracking, select a Stored item at that same
+   location; its quantity is fixed to 1. Otherwise enter a positive whole quantity.
+5. Add an optional note, select **Save reservation**, and confirm.
+
+The confirmed transaction validates the article, target, active location, strategy, and available
+source. A counted reservation creates an Active reservation and reduces Available only. It neither
+changes physical stock nor writes a stock movement. An item reservation additionally changes that
+item from Stored to Reserved while keeping its storage location. The same item cannot have another
+active reservation.
+
+If available counted quantity is too small, the item belongs to another article or location, the
+item is not Stored, or any target is invalid, the entire reservation fails without a partial state.
+
+## Cancel a reservation
+
+Only an Active reservation offers **Cancel**. The command opens a confirmation. Confirming changes
+its status to Cancelled and reloads the related resources. Counted stock remains physically
+unchanged and becomes available again. A reserved item returns from Reserved to Stored at its
+existing location.
+
+A Fulfilled or already Cancelled reservation is immutable and cannot be cancelled. Fulfilled means
+that an installation consumed it; remove that installation instead of trying to reopen the
+reservation.
+
+## Record an installation
+
+Admin or Editor opens the article in edit mode and chooses either an Active reservation or
+**Without reservation**.
+
+With a reservation, target, source location, item where applicable, and quantity are fixed to the
+reservation. Its placement data is copied into the installation form. A non-empty installation
+value can replace an inherited placement value; an empty value retains the reservation value.
+Condition and installation notes remain selectable.
+
+Without a reservation, select target, optional placement data, source, positive whole quantity or
+one Stored item, condition, and optional notes. Hybrid articles again allow the quantity or item
+path. Direct item installation is rejected if the item has an active reservation.
+
+**Save installation** opens a confirmation. The successful transaction has these effects:
+
+| Source | Physical stock or item | Reservation | Installation and journal |
+| --- | --- | --- | --- |
+| Counted quantity | Subtracts the quantity from the source location. Direct installation protects every active reservation at that location. | Selected Active reservation becomes Fulfilled. | Creates an active installation and an Installation movement with the negative quantity. |
+| Individual item | Changes the selected Stored or Reserved item to Installed, clears its storage location, and sets the selected condition. | Selected Active reservation becomes Fulfilled. | Creates an active installation. No quantity movement is written. |
+
+The valid installation conditions are Ready, Maintenance due, Defective, and Unknown. Manual UI
+entry starts with Ready. All stock, item, reservation, installation, movement, and audit changes are
+atomic. If one check fails, none is kept.
+
+## Update installation condition
+
+For an active installation, choose Ready, Maintenance due, Defective, or Unknown and select
+**Update condition**. A confirmation appears even when the selection looks unchanged.
+
+Confirming updates the installation, appends a condition-history row with previous and new value,
+and updates the condition of an installed individual item. Counted stock has no item record to
+update. A removed installation cannot be changed. Resources reload after success.
+
+## Remove an installation
+
+Select **Remove** on an active installation, choose the disposition, add optional removal notes,
+and confirm the separate removal dialog.
+
+| Disposition | Counted quantity result | Individual item result |
+| --- | --- | --- |
+| Stored | Requires an active destination, returns the full quantity, and writes a positive Removal movement. | Lifecycle Stored, selected storage location, condition preserved. |
+| Maintenance | Does not return counted quantity to stock. | Lifecycle Maintenance, no storage location, condition preserved. |
+| Defective | Does not return counted quantity to stock. | Lifecycle Maintenance, no storage location, condition set to Defective. |
+| Retired | Does not return counted quantity to stock. | Lifecycle Retired, no storage location, condition preserved. |
+
+Removal closes the installation with remover, time, disposition, and separate removal notes. It
+does not delete the installation. A closed installation cannot be removed again or have its
+condition changed. The stock/item change, closure, movement where applicable, and audit event are
+one transaction.
+
+## Read usage history
+
+The **Usage history** tab appears when the article has reservation, installation, or history data.
+Its upper section repeats only current Active reservations and installations not yet removed in
+read-only form.
+
+The history table then shows events from oldest to newest with date and time, event type, quantity,
+target, and condition or removal disposition:
+
+| Event | Created when |
+| --- | --- |
+| Reservation | The reservation is created. Its record later carries Active, Fulfilled, or Cancelled status; cancellation is not a separate event row. |
+| Installation | The installation is created. |
+| Condition change | An active installation condition is confirmed, with previous and new condition retained. |
+| Removal | The installation is closed, with its final disposition. |
+
+Installation notes, removal notes, and detailed placement fields remain stored but the condensed
+stable history table does not display them. Use the current allocation record and backups when
+those details are operationally important.
+
+## Keep stock and lifecycle state consistent
+
+Use the workflow command that describes the real event. Do not compensate for an installation with
+a manual negative stock adjustment, or for a removal with a positive adjustment. Those shortcuts
+would omit the target, installation record, item lifecycle, and usage history.
+
+| Action | Quantity availability | Item lifecycle | Durable history |
+| --- | --- | --- | --- |
+| Reserve | Decreases Available, Stored unchanged. | Stored to Reserved. | Reservation record/event. |
+| Cancel | Restores Available, Stored unchanged. | Reserved to Stored. | Reservation remains Cancelled. |
+| Install | Stored decreases and Installed increases. | Stored/Reserved to Installed; location cleared. | Installation event and quantity movement where applicable. |
+| Change condition | No quantity change. | Installed item condition follows installation. | Condition-change event. |
+| Remove to storage | Stored increases and Installed decreases. | Installed to Stored at target location. | Removal event and quantity movement where applicable. |
+| Remove otherwise | Installed decreases without counted stock return. | Installed to Maintenance or Retired, Defective also sets condition. | Removal event. |
+
+Changing the article's inventory strategy is blocked while existing quantity or item dependencies
+would become unrepresentable. Resolve active and historical dependencies deliberately instead of
+forcing a classification change.
+
+## Resolve allocation errors
+
+| Situation | Next step |
+| --- | --- |
+| Save is disabled | Select an exact target and active location; for individual tracking also select a Stored item. |
+| Insufficient stock | Check active reservations at that source and reduce the quantity or choose another location. |
+| Item conflict | Verify article, location, Stored/Reserved lifecycle, and whether another active reservation or installation uses it. |
+| Reservation cannot be cancelled | Only Active reservations can be cancelled. A Fulfilled reservation belongs to an installation. |
+| Installation from reservation conflicts | Do not change its target, location, item, or quantity. Reselect the current Active reservation and retry. |
+| Stored removal is disabled or rejected | Select an active destination whose parent chain is active. Other dispositions must not include a location. |
+| Condition or removal conflicts | Reload. Another action may already have closed or changed the installation. |
+| Write may have succeeded but refresh failed | Do not repeat it. Use **Retry**, then verify reservation status, installation, item lifecycle, stock journal, and history. |
+| Permission is denied | Planner can reserve and cancel only. Installation, condition, and removal require Admin or Editor. |
+
+A failed post-write resource reload marks the editor stale and disables further allocation and
+stock writes until a complete retry succeeds. This prevents a second command from using an old
+availability or lifecycle state.
+
+## Related pages
+
+- [Accessories overview](./)
+- [Article records and technical data](./article-records)
+- [Stock, purchases, and documents](./stock-purchases-documents)
+- [Vehicle inventory and core records](../vehicles/)
+
+## Documented RailKeeper version
+
+This page documents stable RailKeeper **v0.1.17.6** and was last reviewed on 2026-08-16.

--- a/docs/site/guide/accessories/article-records.md
+++ b/docs/site/guide/accessories/article-records.md
@@ -208,6 +208,7 @@ unreferenced stored blobs. Deletion has no undo, so validate a current backup fi
 
 ## Related pages
 
+- [User Guide overview](/guide/)
 - [Accessories overview](./)
 - [Stock, purchases, and documents](./stock-purchases-documents)
 - [Allocations and usage history](./allocations-history)

--- a/docs/site/guide/accessories/article-records.md
+++ b/docs/site/guide/accessories/article-records.md
@@ -213,7 +213,6 @@ unreferenced stored blobs. Deletion has no undo, so validate a current backup fi
 - [Stock, purchases, and documents](./stock-purchases-documents)
 - [Allocations and usage history](./allocations-history)
 - [Article search, web documents, and spare parts](../vehicles/search-and-spares)
-- [Master-data administration](/administration/#master-data-lifecycle)
 
 ## Documented RailKeeper version
 

--- a/docs/site/guide/accessories/article-records.md
+++ b/docs/site/guide/accessories/article-records.md
@@ -1,0 +1,219 @@
+---
+title: Article records and technical data
+description: Create accessory records, maintain their identity, and verify technical data.
+audience: user
+status: stable
+reviewedVersion: 0.1.17.6
+lastReviewed: 2026-08-16
+---
+
+# Article records and technical data
+
+An accessory article is the shared product record behind stock, purchases, documents,
+reservations, and installations. Create it once for a manufacturer and catalogue article, then
+record quantities or individual items against it. This chapter covers the article identity and the
+type-specific data in stable RailKeeper v0.1.17.6.
+
+## Access rights and persistence
+
+Admin and Editor users can create and edit article records. Viewer and Planner users can inspect
+them, but article fields remain read-only. A Planner can create or cancel a reservation in the
+otherwise read-only dialog; that does not grant permission to change the article itself. The Messe
+role has no general accessories access.
+
+The dialog separates **Article**, **Stock**, **Purchases & documents**, the article-type tab, and,
+when data exists, **Usage history**. The main **Save** action persists the article form, including
+the article type, technical fields, inventory strategy, and minimum stock. Stock movements,
+purchases, documents, reservations, and installations use their own actions and can already be
+stored while other article fields remain unsaved. Finish or deliberately discard a draft before
+starting one of those immediate writes.
+
+Closing the dialog with changed article fields, pending searched images, or an unfinished subform
+opens a discard confirmation. In create mode, stock and related resources cannot be persisted until
+the core article has been saved once.
+
+## Create an article
+
+1. Open **Accessories** and select **Create article**.
+2. On **Article**, select a manufacturer, article type, and subtype, then enter the name.
+3. Add catalogue identity, gauges, scale, package quantity, stock unit, and optional reference data.
+4. Complete the tab named after the selected article type where technical data is known.
+5. On **Stock**, choose the inventory strategy and minimum stock. The detailed consequences are
+   covered in [Stock, purchases, and documents](./stock-purchases-documents).
+6. Select **Save** and resolve any marked tab or duplicate warning.
+
+The required fields are manufacturer, name, subtype, stock unit, and a positive whole package
+quantity. Minimum stock must be a whole number of zero or more. Technical numbers must respect the
+displayed range and increment. A comma is accepted as the decimal separator.
+
+RailKeeper assigns the article inventory number only during the successful create transaction. It
+uses the active **Artikel** inventory-number scheme, whose default format produces values such as
+`RK-ART-000001`. A failed create does not consume the reserved number. The field cannot be entered
+or changed in the article dialog. If no active scheme exists, creating the article is blocked until
+an administrator repairs the inventory-number configuration.
+
+For a new record, RailKeeper selects the first active configured article type. If no active article
+type is available, creation remains blocked. The initial values are package quantity 1, stock unit
+**Piece**, minimum stock 0, inventory strategy **Quantity**, and manufacturer status **Unknown**.
+
+## Common field reference
+
+| Field | Stable behavior |
+| --- | --- |
+| Inventory number | Assigned automatically from the **Artikel** scheme and read-only. |
+| Manufacturer | Required active master-data selection. A stored inactive or historical value remains visible but cannot be newly selected. |
+| Article number | Optional manufacturer or catalogue number. When present, it activates the duplicate check together with manufacturer. |
+| Name | Required article name. |
+| EAN / GTIN | Optional barcode value and an independent article-search criterion. |
+| Manufacturer status | Announced, Available, Discontinued, or Unknown. |
+| Article type | Track, Signal, Decoder, Electrical / control, Building / equipment, Landscape consumable, Lighting, or Other, subject to active configuration. |
+| Subtype | Required configured subtype belonging to the selected article type. An unchanged historical subtype remains readable and preservable. |
+| Gauges | Zero or more active gauge master-data values. Existing inactive values remain displayed. |
+| Scale | Optional text. While automatically managed, it follows the first selected active gauge that defines a scale. |
+| Package quantity | Required positive whole number describing how many stock units a package contains. |
+| Stock unit | Required active master-data value, for example Piece. Existing inactive values remain displayed. |
+| Description | Optional free text. |
+| Manufacturer URL | Optional manufacturer reference. It is not filled by the stable accessory result picker. |
+| Product URL | Optional product reference. Search results can fill it only from an HTTP or HTTPS source. |
+| Alternative article numbers | Optional values separated by commas or line breaks. Empty entries are removed. |
+| Keywords | Optional comma- or line-break-separated terms. Automatic suggestions combine name, manufacturer, article type, and subtype without case-insensitive duplicates. |
+| Compatibility notes | Optional free text for supported systems or products. |
+| Internal notes | Optional local notes. |
+
+Leading and trailing whitespace is removed from ordinary text fields. Manually changing **Scale**
+or **Keywords** stops the respective automatic suggestion for the current edit session. The
+automation runs in create and edit mode, never in read-only view.
+
+Manufacturers, article types, subtypes, gauges, stock units, and custom fields come from master
+data. RailKeeper preserves an unchanged inactive value on an existing article, but does not allow
+it to be newly added or changed. This makes historical records editable without silently replacing
+their classification.
+
+## Choose article type and technical data
+
+The last main tab is named after the selected article type. Its fields are optional unless the
+local master-data configuration says otherwise, but every entered value is validated. Whole-number
+fields use increment 1; other non-negative numbers have no fixed increment unless listed below.
+
+| Article type | Stable technical fields |
+| --- | --- |
+| Track | Track system; length and radius in mm; angle 0 to 360° in 0.1° steps; direction Left, Right, or Symmetric; frog angle 0 to 180° in 0.1° steps; sleeper type; rail height in mm; Roadbed; non-negative whole connection count; Digital ready. |
+| Signal | Prototype; epochs I to VI; aspects Stop, Proceed, Caution, and Shunting; non-negative whole LED count; height in mm; non-negative AC and DC operating voltage; mounting Surface, Flush, Mast, or Wall; drive Manual, Motor, Servo, or Solenoid; Integrated decoder; control module. |
+| Decoder | Interface Wired, NEM 651, NEM 652, PluX16, PluX22, 21MTC, or Next18; protocols DCC, Motorola, Selectrix, mfx, and RailCom; non-negative whole function outputs and servo outputs; non-negative motor, output, and total current in mA; RailCom; SUSI; dimensions; firmware. |
+| Electrical / control | Non-negative input voltage, output voltage, current in A, and power in W; non-negative whole channel count; protocols DCC, Motorola, Selectrix, LocoNet, CAN, and S88; connectors Screw, Plug, RJ45, Bus, and Wire; protections Short circuit, Overload, Temperature, and Reverse polarity; compatible article types Track, Signal, Decoder, and Lighting. |
+| Building / equipment | Epochs I to VI; dimensions; footprint; material; construction type Kit, Finished model, or Semi-finished kit; non-negative whole part count; difficulty Easy, Medium, or Advanced; lighting options Interior lighting, Platform lighting, Street lighting, and Effect lighting; Floor plan available. |
+| Landscape consumable | Material; color; season; non-negative content; content unit Piece, Pack, Meter, Gram, or Milliliter; fibre or grain size; coverage; suitable scales Z, N, TT, H0, 0, 1, and G; safety notes. |
+| Lighting | Light color; non-negative color temperature in K, voltage in V, and current in mA; power type AC, DC, or AC or DC; non-negative whole LED count; Dimmable; dimensions; mounting Surface, Flush, Mast, or Wall. |
+| Other | Active configured custom fields. Supported kinds are text, number, yes/no, date, single selection, and multiple selection. Selection fields appear only when they have configured choices. |
+
+Boolean fields distinguish an explicit Yes or No from no stored value. Multiple-selection fields
+reject unknown or repeated choices. Negative values, values outside a listed range, and values that
+do not match a listed increment prevent saving and mark the article-type tab.
+
+Changing the article type clears the subtype. If the change would discard the subtype, a technical
+value, or an unfinished number, RailKeeper asks for confirmation. Compatible fields with the same
+key and data type remain; incompatible fields are removed only after confirmation. Cancel the
+confirmation to keep the current type and values.
+
+For **Other**, the fields are defined by active `accessory_custom_field` master data. A historical
+custom value whose definition has become inactive or disappeared is preserved only while it remains
+unchanged. It cannot be newly added or edited.
+
+## Use barcode and article-data search
+
+The **Article** tab offers the same reviewed-result workflow used by vehicle article search, with
+accessory-specific inputs and target fields. The normal search is available when either:
+
+- EAN is present; or
+- manufacturer and the first selected gauge are present, together with either article number or
+  name.
+
+RailKeeper sends manufacturer, article number, name, the first gauge, current common fields, and
+the current technical attributes to the configured search sources. If article search is disabled in
+Settings, the command stops without changing the article.
+
+The result dialog can apply manufacturer, article number, name, EAN, scale, description, product
+URL, and gauge. A manufacturer or gauge is selectable only when it matches an active known master-
+data value. A selected gauge is added to the existing gauges. Invalid common values and non-HTTP(S)
+product URLs are ignored. In stable v0.1.17.6, selectable technical result fields are exposed only
+for **Track** articles; other article types can apply the common result groups but not their
+technical attributes.
+
+Fields whose current form value is empty start selected in the review. Existing values are not
+preselected for replacement. Images are never selected automatically. Select only trusted values,
+then apply them to the local draft. Nothing is saved until the article save succeeds.
+
+**Barcode** opens the scanner with the current EAN. A non-empty scanned or manually entered value
+replaces the local EAN and immediately starts an EAN-only search. Camera permission and manual-entry
+behavior are described in [Article search, web documents, and spare parts](../vehicles/search-and-spares).
+
+Selected search images are queued. After the core article saves, RailKeeper imports them one after
+another. The first successful image becomes primary only when the article has no primary accessory
+image. A failed image does not roll back the article or earlier images, and later queued images are
+still attempted. The dialog remains open with the first import error and keeps failed images
+pending; close it only after deciding whether to retry or discard them.
+
+## Review duplicate candidates
+
+When article number is not empty, saving first checks for an exact manufacturer and article-number
+match after trimming and without case sensitivity. The current article is excluded while editing.
+Name, EAN, gauge, and subtype do not change this match.
+
+If candidates exist, RailKeeper lists them before writing. Select **Cancel** to return to the draft
+or **Save anyway** to create or update the captured values. This warning permits intentional
+variants; it is not a merge and does not transfer stock, documents, or usage from another article.
+
+## Edit without losing data
+
+Open **Edit article**, change the draft, and use the main **Save** action. Validation moves to the
+first affected tab in this order: Article, Stock, Purchases & documents, then the article-type tab.
+Red tab markers identify tabs that still contain invalid values.
+
+Changing inventory strategy is allowed only when all existing inventory and allocation data remain
+representable. In particular, RailKeeper blocks a change from quantity-capable tracking to
+individual-only while quantity stock, quantity reservations, or quantity installations exist. It
+also blocks removing individual tracking while individual items or their reservation,
+installation, or condition history exists. Remove or complete those dependencies deliberately,
+then retry. A rejected update leaves the stored article unchanged.
+
+If required master data or custom-field definitions fail to load, the editor marks its resources
+as stale and disables affected writes. Use **Retry**, do not replace displayed historical values
+from memory, and save only after the resources have loaded. If the article detail itself failed to
+load, close and reopen it rather than editing an incomplete fallback.
+
+## Archive, restore, or delete an article
+
+Admin and Editor users can archive or restore an article from the overview. Both actions write
+immediately without a confirmation. Archived articles leave the normal list but remain available
+through the **Archived** status filter and can be restored.
+
+Only an Admin can permanently delete an article, and RailKeeper asks for confirmation. Deletion is
+blocked by non-zero stock, individual items, stock movements, purchases, reservations,
+installations, or layout technical positions that reference the article. Article documents alone
+do not block deletion; their metadata is removed and RailKeeper then attempts to remove
+unreferenced stored blobs. Deletion has no undo, so validate a current backup first.
+
+## Resolve validation and resource errors
+
+| Situation | Next step |
+| --- | --- |
+| Required field or number is invalid | Open the marked tab and correct every field message. |
+| No inventory number can be assigned | Ask an administrator to activate or repair the **Artikel** inventory-number scheme. |
+| Article type, subtype, or master data is unavailable | Retry resource loading. Only active configured values can be newly selected. |
+| Duplicate candidates appear | Compare manufacturer and article number, then cancel or deliberately save the variant. |
+| Strategy change reports a conflict | Resolve incompatible stock, items, reservations, installations, or condition history first. |
+| Search cannot start | Add EAN, or complete the required manufacturer/name/article-number/gauge criteria; also verify Settings. |
+| Search image import fails | The article may already be saved. Retry or discard only the failed pending images. |
+| Save is forbidden | Use an Admin or Editor account. Planner reservation authority is not article-edit authority. |
+
+## Related pages
+
+- [Accessories overview](./)
+- [Stock, purchases, and documents](./stock-purchases-documents)
+- [Allocations and usage history](./allocations-history)
+- [Article search, web documents, and spare parts](../vehicles/search-and-spares)
+- [Master-data administration](/administration/#master-data-lifecycle)
+
+## Documented RailKeeper version
+
+This page documents stable RailKeeper **v0.1.17.6** and was last reviewed on 2026-08-16.

--- a/docs/site/guide/accessories/article-records.md
+++ b/docs/site/guide/accessories/article-records.md
@@ -21,8 +21,8 @@ them, but article fields remain read-only. A Planner can create or cancel a rese
 otherwise read-only dialog; that does not grant permission to change the article itself. The Messe
 role has no general accessories access.
 
-The dialog separates **Article**, **Stock**, **Purchases & documents**, the article-type tab, and,
-when data exists, **Usage history**. The main **Save** action persists the article form, including
+The dialog separates **Article**, **Stock**, **Purchase & documents**, the article-type tab, and,
+when data exists, **Usage & history**. The main **Save changes** action persists the article form, including
 the article type, technical fields, inventory strategy, and minimum stock. Stock movements,
 purchases, documents, reservations, and installations use their own actions and can already be
 stored while other article fields remain unsaved. Finish or deliberately discard a draft before
@@ -40,7 +40,7 @@ the core article has been saved once.
 4. Complete the tab named after the selected article type where technical data is known.
 5. On **Stock**, choose the inventory strategy and minimum stock. The detailed consequences are
    covered in [Stock, purchases, and documents](./stock-purchases-documents).
-6. Select **Save** and resolve any marked tab or duplicate warning.
+6. Select **Save changes** and resolve any marked tab or duplicate warning.
 
 The required fields are manufacturer, name, subtype, stock unit, and a positive whole package
 quantity. Minimum stock must be a whole number of zero or more. Technical numbers must respect the
@@ -165,8 +165,8 @@ variants; it is not a merge and does not transfer stock, documents, or usage fro
 
 ## Edit without losing data
 
-Open **Edit article**, change the draft, and use the main **Save** action. Validation moves to the
-first affected tab in this order: Article, Stock, Purchases & documents, then the article-type tab.
+Open **Edit article**, change the draft, and use the main **Save changes** action. Validation moves to the
+first affected tab in this order: Article, Stock, Purchase & documents, then the article-type tab.
 Red tab markers identify tabs that still contain invalid values.
 
 Changing inventory strategy is allowed only when all existing inventory and allocation data remain

--- a/docs/site/guide/accessories/index.md
+++ b/docs/site/guide/accessories/index.md
@@ -115,7 +115,7 @@ The table offers these nine data columns:
 
 | Column | Displayed value |
 | --- | --- |
-| Image | Primary accessory image, or a placeholder. |
+| Image | Primary accessory image, or the generic image symbol. |
 | Inventory number | RailKeeper's local article identity. |
 | Manufacturer | Product manufacturer. |
 | Article number | Manufacturer or catalogue number. |

--- a/docs/site/guide/accessories/index.md
+++ b/docs/site/guide/accessories/index.md
@@ -1,0 +1,202 @@
+---
+title: Accessories overview
+description: Find, filter, inspect, and safely manage accessory articles.
+audience: user
+status: stable
+reviewedVersion: 0.1.17.6
+lastReviewed: 2026-08-16
+---
+
+# Accessories overview
+
+**Accessories** is RailKeeper's catalogue and inventory workspace for track, signals, decoders,
+electrical components, scenery, lighting, and other model railway articles. It combines product
+identity, stored and allocated quantities, images, storage locations, and article lifecycle actions.
+This chapter describes stable RailKeeper v0.1.17.6.
+
+An article is the common product record. Its stock can consist of interchangeable quantities,
+individually tracked items, or both. Reservations and installations bind some of that stock to a
+vehicle or another configured target. The overview combines those states but does not change stock
+by itself.
+
+## Access rights and workspace model
+
+Admin, Editor, Viewer, and Planner users can open **Accessories** and inspect article data. Their
+write rights differ:
+
+| Role | Stable overview access |
+| --- | --- |
+| Viewer | View articles and their stored resources. |
+| Planner | View articles and later create or cancel reservations. General article and stock editing remains read-only. |
+| Editor | Create and edit articles, archive or restore them, and manage their stock and lifecycle. |
+| Admin | Has Editor rights and can additionally delete a completely unused article permanently. |
+| Messe | Has no accessories access through the Messe role alone. |
+
+The page shows an explicit read-only note to Viewer and Planner users. Server-side role checks are
+authoritative. A visible value or read action does not grant write permission.
+
+The counts and rows come from the local RailKeeper database. Changing search, a filter, or sorting
+starts a new server request. The result counter therefore describes the current searched and
+filtered list, while the four metrics always summarize all non-archived articles.
+
+## Read the overview metrics
+
+Four metric cards appear above the article list:
+
+| Metric | Stable meaning and action |
+| --- | --- |
+| **Article inventory** | Number of non-archived article records and distinct article types. Selecting it clears every active filter. |
+| **Available** | Total free quantity plus the number of distinct storage locations referenced by active articles. Selecting it shows articles with more than zero available units. |
+| **Allocated** | Total active reservations plus active installations. Selecting it shows articles that have either reserved or installed quantity. |
+| **Care hints** | Total number of incomplete-data hints across active articles. It is informative and has no filter action. |
+
+**Care hints** is a count of missing fields, not a count of affected articles. One article can
+contribute several hints. Stable v0.1.17.6 checks for missing manufacturer, article number, article
+type, and stock unit. Track, signal, decoder, electrical/control, building/equipment, and lighting
+articles also contribute a hint when they have no gauge. Landscape consumables and **Other** do not
+require a gauge for this metric.
+
+The metric cards ignore the current search and filter selection. Use the result counter below them
+for the size of the visible result.
+
+## Search and filter articles
+
+Enter text in **Search articles**. The server performs a case-insensitive substring search in five
+fields:
+
+- Inventory number
+- Manufacturer
+- Article number
+- Name
+- EAN
+
+Description, keywords, alternative numbers, technical attributes, storage notes, purchase data,
+and usage history are not part of the stable free-text search.
+
+The additional filters are:
+
+| Filter | Choices and behavior |
+| --- | --- |
+| Article type | Types that occur on active articles. |
+| Manufacturer | Manufacturers that occur on active articles. |
+| Gauge | Gauges that occur on active articles. |
+| Status | Available, Reserved, Installed, Maintenance due, Defective, or Archived. |
+| Storage location | Active storage locations. An article matches when quantity stock or an individual item is linked to that location. |
+
+Different filter groups combine with AND logic. A row must match the text and every selected
+group. **Allocated** from the metric card is the one combined status: it matches **Reserved** OR
+**Installed**. The normal list excludes archived articles. Selecting **Archived** replaces that
+default and shows archived rows matching the remaining filters.
+
+The status filters mean:
+
+| Status | Included articles |
+| --- | --- |
+| Available | More than zero units are currently free after active reservations. |
+| Reserved | At least one unit is in an active reservation. |
+| Installed | At least one unit is in an active installation. |
+| Maintenance due | An individual item or active installation has condition **Maintenance due**. |
+| Defective | An individual item or active installation has condition **Defective**. |
+| Archived | The article record is archived. |
+
+**Reset filters** clears text and all five filter groups. It does not change the selected desktop
+view, visible columns, or sorting.
+
+## Choose columns, view, and sorting
+
+At desktop widths, select table or card view. RailKeeper stores that choice in the current
+browser's local storage. It is not saved to the user account and does not follow the user to another
+browser.
+
+At widths up to 900 pixels, RailKeeper always shows the compact list. The stored table/card choice
+remains available when the window becomes wider again.
+
+The table offers these nine data columns:
+
+| Column | Displayed value |
+| --- | --- |
+| Image | Primary accessory image, or a placeholder. |
+| Inventory number | RailKeeper's local article identity. |
+| Manufacturer | Product manufacturer. |
+| Article number | Manufacturer or catalogue number. |
+| Name | Article name and entry point to the read-only view. |
+| Type / subtype | Configured article classification. |
+| Gauge | Every gauge assigned to the article. |
+| Stock | Total owned plus free, reserved, and installed quantities. |
+| Storage | First storage location and the number of additional locations. |
+
+Every displayed data column is sortable. The initial order is inventory number ascending. Select
+the current sort header again to reverse its direction; selecting another header starts that column
+ascending. Rows with otherwise equal values use their internal ID as a stable tie-breaker.
+
+The column chooser is available only in table view. Column visibility is also stored in the current
+browser. All nine columns start visible. Inventory number and Name cannot both be hidden, so the
+table always retains at least one visible article identity.
+
+Card view emphasizes image, identity, type, gauge, storage, and stock. The compact list keeps a
+smaller identity and stock summary. Both follow the current server sort but do not expose separate
+sort controls.
+
+## Select, open, and manage an article
+
+Table checkboxes select one row or all currently visible rows. Selection is removed when a new
+search or filter result no longer contains the article. Stable v0.1.17.6 provides no bulk action for
+this selection. It is visual state only and must not be treated as a pending archive, report, or
+stock command.
+
+Select the article name, image, or **View article** to open the read-only article dialog. Depending
+on the role and article state, row actions also provide:
+
+| Action | Role and persistence |
+| --- | --- |
+| View article | Every role with accessories read access. No write. |
+| Edit article | Admin or Editor. The article form remains draft state until saved. |
+| Archive article | Admin or Editor. Writes immediately without a confirmation and reloads the overview. |
+| Restore article | Admin or Editor. Writes immediately without a confirmation and reloads the overview. |
+| Delete article | Admin only. Opens a permanent-deletion confirmation. |
+
+Permanent deletion succeeds only for a completely unused article. Non-zero stock, individual
+items, stock-movement history, purchases, reservations, installations, or a layout technical
+position referencing the article blocks it. Stored article documents do not block an otherwise
+unused article; RailKeeper removes their metadata and then attempts to remove their stored blobs as
+part of the deletion workflow.
+
+There is no undo for deletion. Create and validate a current application backup before deleting an
+important record. Full deletion and recovery rules are covered with the article-record lifecycle.
+
+## Resolve loading, empty, and error states
+
+| Situation | RailKeeper behavior and next step |
+| --- | --- |
+| Initial load | **Loading articles...** appears until the first request completes. |
+| No article exists | **No articles have been created yet.** Admin or Editor can create the first article. |
+| Filters have no match | **No articles match the active filters.** Reset or adjust the search and filters. |
+| Loading fails before any result | Only the error appears above the empty list area. Check the session and connection, then retry by changing or resetting a filter. |
+| Loading fails after data was shown | The error appears while the earlier rows can remain visible. Do not treat them as current; retry the request before acting on the result. |
+| Master-data labels fail to load | Rows can fall back to stable translated type/subtype labels. Open the article only after required editor resources load successfully. |
+| Archive or restore fails | The error appears above the list. Treat the article as unchanged until a successful reload confirms otherwise. |
+| Delete is blocked | The confirmation remains relevant, but the record is not deleted. Resolve every reported stock or usage reference before retrying. |
+| Write is forbidden | Sign in with the required Editor or Admin authority. Read access does not override server write checks. |
+
+## Continue with an article workflow
+
+The detailed accessories section separates three workflows:
+
+- create and maintain the article record and its technical data;
+- manage stock, purchases, individual items, images, and documents;
+- reserve or install stock and read its usage history.
+
+These workflows share one article dialog but have different persistence and permission rules. Save
+or intentionally discard unsaved article fields before starting an immediate stock or lifecycle
+write.
+
+## Related pages
+
+- [User Guide overview](/guide/)
+- [Overview, metrics, and data quality](/guide/overview/)
+- [Vehicle inventory and core records](/guide/vehicles/)
+- [Article search, web documents, and spare parts](/guide/vehicles/search-and-spares)
+
+## Documented RailKeeper version
+
+This page documents stable RailKeeper **v0.1.17.6** and was last reviewed on 2026-08-16.

--- a/docs/site/guide/accessories/index.md
+++ b/docs/site/guide/accessories/index.md
@@ -193,6 +193,9 @@ write.
 ## Related pages
 
 - [User Guide overview](/guide/)
+- [Article records and technical data](./article-records)
+- [Stock, purchases, and documents](./stock-purchases-documents)
+- [Reservations, installations, and usage](./allocations-history)
 - [Overview, metrics, and data quality](/guide/overview/)
 - [Vehicle inventory and core records](/guide/vehicles/)
 - [Article search, web documents, and spare parts](/guide/vehicles/search-and-spares)

--- a/docs/site/guide/accessories/stock-purchases-documents.md
+++ b/docs/site/guide/accessories/stock-purchases-documents.md
@@ -20,7 +20,7 @@ the article record once before creating any related resource.
 
 ## Choose an inventory strategy
 
-The strategy is stored with the article through the main **Save** action. It controls which stock
+The strategy is stored with the article through the main **Save changes** action. It controls which stock
 commands and records are available:
 
 | Strategy | Counted stock | Individual items | Purchase booked to stock |
@@ -195,7 +195,7 @@ document or inventory cleanup.
 ## Protect data during immediate writes
 
 Stock commands, item saves, purchase creation, document upload, primary-image changes, and document
-deletion persist independently of the main article **Save** action. Their confirmations protect the
+deletion persist independently of the main article **Save changes** action. Their confirmations protect the
 command shown above, not unsaved article fields elsewhere in the dialog.
 
 After each successful sub-action, RailKeeper requests stock, journal, items, purchases, documents,

--- a/docs/site/guide/accessories/stock-purchases-documents.md
+++ b/docs/site/guide/accessories/stock-purchases-documents.md
@@ -230,6 +230,7 @@ Reload before attempting to delete again.
 
 ## Related pages
 
+- [User Guide overview](/guide/)
 - [Accessories overview](./)
 - [Article records and technical data](./article-records)
 - [Reservations, installations, and usage](./allocations-history)

--- a/docs/site/guide/accessories/stock-purchases-documents.md
+++ b/docs/site/guide/accessories/stock-purchases-documents.md
@@ -1,0 +1,240 @@
+---
+title: Stock, purchases, and documents
+description: Manage accessory quantities, individual items, purchases, images, and documents.
+audience: user
+status: stable
+reviewedVersion: 0.1.17.6
+lastReviewed: 2026-08-16
+---
+
+# Stock, purchases, and documents
+
+RailKeeper can count interchangeable accessory units, track physical items individually, or move
+units from counted stock into individual tracking when needed. Purchases and documents belong to
+the same article but have their own immediate save actions. This chapter describes the stable
+behavior of RailKeeper v0.1.17.6.
+
+Admin and Editor users can manage these resources. Viewer and Planner users can inspect them, but a
+Planner's reservation authority does not include stock, purchase, item, or document changes. Save
+the article record once before creating any related resource.
+
+## Choose an inventory strategy
+
+The strategy is stored with the article through the main **Save** action. It controls which stock
+commands and records are available:
+
+| Strategy | Counted stock | Individual items | Purchase booked to stock |
+| --- | --- | --- | --- |
+| **Quantity** | Adjust and transfer quantities by storage location. | Not available. | Adds the purchase quantity to the selected location and writes a Purchase movement. |
+| **Individual** | No quantity adjustment or transfer. | Create and maintain one record per physical item. | Creates one stored item per purchased unit, with condition Unknown. It creates no counted stock movement. |
+| **Quantity, individual later** | Adjust and transfer quantities. | Convert one available unit at a time into an individual item. | Adds counted stock like Quantity. Purchased units can be individualized later. |
+
+Choose **Quantity** for interchangeable material, **Individual** when every unit needs its own
+identity or condition, and the hybrid strategy when packages begin as quantities but selected units
+later need lifecycle tracking.
+
+Changing strategy can be blocked by existing stock and allocations. Quantity values, quantity
+reservations, or quantity installations prevent a change to individual-only tracking. Existing
+items and their reservation, installation, or condition history prevent removing individual
+tracking. A rejected change writes nothing.
+
+**Minimum stock** is a non-negative whole-number planning value. It is saved with the article and
+does not itself create, reserve, or order stock.
+
+## Read stock and availability
+
+The **Stock** tab lists the counted quantity for every referenced storage location. The total is the
+sum of those rows. Individual items appear in a separate table and are not added to this counted
+total.
+
+Counted stock is owned physical quantity. **Available** quantity is lower when active quantity
+reservations exist. RailKeeper therefore prevents an adjustment, transfer, or individualization
+from reducing a location below its actively reserved quantity. Installed counted units have
+already been removed from stored quantity.
+
+The stock journal is newest first and contains these stable movement types:
+
+| Movement | Quantity and source |
+| --- | --- |
+| Purchase | Positive purchased quantity at the destination, linked to the purchase. Quantity and hybrid strategies only. |
+| Adjustment | The signed manual delta at one location. |
+| Transfer out | Negative quantity at the source, linked to the same transfer as Transfer in. |
+| Transfer in | Positive quantity at the destination. |
+| Individualization | `-1` at the source, linked to the newly created item. |
+| Installation | Negative installed quantity at the source for quantity-based installation. |
+| Removal | Positive returned quantity at the destination when a quantity installation is removed back to stock. |
+
+The journal shows date, movement type, signed quantity, and note. A transfer writes two rows in one
+transaction. Reservation creation and cancellation do not write stock movements because they
+change availability, not owned quantity.
+
+## Adjust quantity stock
+
+Use **Adjust stock** for a physical correction that is not a purchase or transfer:
+
+1. Select an active storage location.
+2. Enter a non-zero whole-number delta. A positive value adds units; a negative value removes
+   units.
+3. Select **Book** and review the confirmation containing the signed quantity and article name.
+4. Confirm to write the new location quantity, one Adjustment journal row, and the audit event in a
+   single transaction.
+
+The action is available for Quantity and hybrid articles only. RailKeeper rejects an inactive
+location, zero, a non-whole value, or a reduction below active reservations. Canceling the
+confirmation writes nothing. After success, all article resources are reloaded.
+
+Use purchases for incoming goods whose supplier or invoice should be recorded. A manual positive
+adjustment creates no purchase record. There is no note field on the stable adjustment command.
+
+## Transfer stock between locations
+
+Select different active source and destination locations, enter a positive whole quantity, and
+optionally add a note. **Transfer** opens a confirmation. Confirming atomically:
+
+- subtracts the quantity from the source without touching reserved units;
+- adds it to the destination;
+- writes linked Transfer out and Transfer in journal rows with the same optional note; and
+- reloads the article resources.
+
+The transfer fails without changing either location when the source lacks enough available
+quantity, both locations are equal, a location or its ancestor is archived, or any required value
+is missing. The command exists only for Quantity and hybrid articles.
+
+## Manage individual items
+
+Individual and hybrid articles show the item table. For an Individual article, **Create item** adds
+a new physical record without changing counted stock. For a hybrid article,
+**Individualize** consumes exactly one available counted unit from the selected location and creates
+the item in the same transaction. It also writes an Individualization movement of `-1`.
+
+| Item field | Stable rule |
+| --- | --- |
+| Inventory number | Optional item identity. When supplied, it must be unique without regard to case across accessory items. It is separate from the article inventory number. |
+| Serial number | Optional manufacturer serial number. |
+| Condition | Ready, Maintenance due, Defective, or Unknown. Default is Ready for manual entry. |
+| Lifecycle | Stored, Maintenance, or Retired. Default is Stored. Reserved and Installed are controlled by allocation commands and cannot be chosen here. |
+| Storage location | Required active location in the stable form. A hybrid item is taken from this same location. |
+| Purchase date | Optional calendar date in `YYYY-MM-DD` storage format. |
+| Purchase price | Optional non-negative number, entered in 0.01 steps. |
+| Warranty until | Optional calendar date. |
+| Notes | Optional local text. |
+
+**Save item** always opens a confirmation. For a hybrid article, insufficient available quantity
+cancels the whole individualization, including the new item. Empty inventory and serial numbers are
+allowed, but a duplicate non-empty inventory number is rejected.
+
+Use the edit icon to load an existing item into the same form. Saving the edit also requires
+confirmation and changes only that item. An item whose lifecycle is Reserved or Installed has no
+edit action in this table. Change it through the matching reservation or installation workflow so
+that lifecycle, location, and history remain consistent.
+
+## Record purchases
+
+The purchase list is a stable, newest-first history. Stable v0.1.17.6 provides an add action but no
+purchase edit or delete action.
+
+| Purchase field | Stable rule |
+| --- | --- |
+| Purchase date | Required valid date, defaulting to today. |
+| Supplier | Optional text. |
+| Quantity | Required positive whole number. |
+| Unit price | Optional value. A numeric value produces the displayed quantity-times-unit-price preview. |
+| Currency | The stable form uses EUR. The stored API value, when present, is a three-letter uppercase code. |
+| Invoice number | Optional text. |
+| Warranty until | Optional valid date. |
+| Book to stock | When clear, only the purchase record is created. When selected, an active destination is required and stock is created in the same transaction. |
+| Storage location | Required only for Book to stock. |
+| Notes | Optional text; copied to the Purchase movement for counted stock. |
+
+Selecting **Book purchase** writes immediately without a confirmation. The effect depends on the
+article strategy:
+
+| Strategy and option | Atomic result |
+| --- | --- |
+| Any strategy, Book to stock off | One purchase record; no stock, item, or movement change. |
+| Quantity, Book to stock on | One purchase, the full quantity added at the location, and one linked Purchase movement. |
+| Hybrid, Book to stock on | Same as Quantity. Individualize selected units later. |
+| Individual, Book to stock on | One purchase and one Stored item per unit. Each item inherits purchase date, unit price, warranty, location, and purchase link; condition starts Unknown. No quantity movement is written. |
+
+Purchase creation and optional stock booking run in one database transaction. If any part fails,
+neither the purchase nor its stock/items is stored. After success, the form resets and RailKeeper
+reloads the related resources.
+
+## Manage images and documents
+
+The document area lists the original file name and category. Every user with accessory read access
+can download a document. Admin and Editor users can upload, choose the primary image, and delete.
+
+| Operation | Confirmation and effect |
+| --- | --- |
+| Upload | No confirmation. Select a file, category, and optional description. The first uploaded Image becomes primary when no primary image exists. Resources reload after success. |
+| Make primary image | No confirmation. Available on a non-primary Image. It clears the previous primary flag and sets this image in one transaction, then reloads. |
+| Download | No write and no confirmation. Images may display inline; other types download as attachments. |
+| Delete | Destructive confirmation. It removes the document metadata, then deletes the stored blob only when no other record references it, and reloads. Deleting the primary image does not automatically promote another image. |
+
+The categories are Invoice, Delivery note, Manual, Data sheet, Floor plan, Image, and Other. Only an
+Image can be primary.
+
+Accepted upload extensions are `.pdf`, `.jpg`, `.jpeg`, `.png`, `.webp`, `.zip`, `.txt`, `.csv`,
+`.json`, and `.xml`, and detected content must match the extension. JSON, CSV, and XML receive
+additional structural checks. Empty files, unsafe names, executable or script types, HTML, MIME
+mismatches, and files above the configured attachment limit are rejected. The default limit is
+25 MB through `RAILKEEPER_MAX_ATTACHMENT_MB`. Uploaded blobs stay inside RailKeeper's local data
+model and downloads require an authorized application request.
+
+Images selected in article-data search use a separate URL import. RailKeeper accepts only public
+HTTP or HTTPS addresses, rejects localhost and private or internal addresses before connecting and
+on redirects, allows at most five redirects, uses a ten-second request limit, and accepts only
+detected JPEG, PNG, or WebP content within the same size limit. The idempotency key prevents the
+same queued image from being stored twice for the article.
+
+Accessory articles, counted stock, movements, items, purchases, document metadata, and stored file
+blobs are included in the application backup. Keep current validated backups before destructive
+document or inventory cleanup.
+
+## Protect data during immediate writes
+
+Stock commands, item saves, purchase creation, document upload, primary-image changes, and document
+deletion persist independently of the main article **Save** action. Their confirmations protect the
+command shown above, not unsaved article fields elsewhere in the dialog.
+
+After each successful sub-action, RailKeeper requests stock, journal, items, purchases, documents,
+reservations, installations, history, locations, vehicles, and layout resources again. Those reads
+can partially fail after the write has already committed. In that case:
+
+1. Treat the command as potentially successful. Do not submit it again from stale data.
+2. Read the resource error shown by the editor. RailKeeper marks resources stale and disables
+   further stock, document, reservation, and installation writes.
+3. Select **Retry** until a complete reload succeeds.
+4. Verify the stock row, item, purchase, document, and journal before deciding whether another write
+   is needed.
+
+The same rule matters after document deletion: metadata deletion commits before cleanup of an
+unreferenced blob. An error during cleanup can therefore follow an already removed list entry.
+Reload before attempting to delete again.
+
+## Resolve stock and document errors
+
+| Situation | Next step |
+| --- | --- |
+| Adjustment or transfer reports insufficient stock | Check active reservations at the source. Use only the free quantity. |
+| Location is missing or rejected | Select an active location whose parent chain is also active. Storage-location administration is separate from this article dialog. |
+| Individualization fails | Confirm that the article is hybrid and the selected location has at least one unreserved counted unit. |
+| Item inventory number conflicts | Use a different item number or edit the existing item. Letter case does not create a distinct number. |
+| Reserved or installed item cannot be edited | Complete or cancel its allocation through the reservation or installation controls. |
+| Purchase is rejected | Check purchase date, positive whole quantity, warranty date, and destination when booking to stock. |
+| File type is unsupported | Use an accepted extension with matching real content; renaming a file is not sufficient. |
+| File is too large | Reduce it below the configured attachment limit or ask the operator to review the limit. |
+| Remote image is rejected | Use a public HTTP(S) JPEG, PNG, or WebP URL that does not redirect to a private address. |
+| Write succeeded but refresh failed | Do not repeat it. Retry the resource load and verify the journal or resource list first. |
+
+## Related pages
+
+- [Accessories overview](./)
+- [Article records and technical data](./article-records)
+- [Reservations, installations, and usage](./allocations-history)
+- [Administration and operations](/administration/)
+
+## Documented RailKeeper version
+
+This page documents stable RailKeeper **v0.1.17.6** and was last reviewed on 2026-08-16.

--- a/docs/site/guide/accessories/stock-purchases-documents.md
+++ b/docs/site/guide/accessories/stock-purchases-documents.md
@@ -234,7 +234,6 @@ Reload before attempting to delete again.
 - [Accessories overview](./)
 - [Article records and technical data](./article-records)
 - [Reservations, installations, and usage](./allocations-history)
-- [Administration and operations](/administration/)
 
 ## Documented RailKeeper version
 

--- a/docs/site/guide/index.md
+++ b/docs/site/guide/index.md
@@ -39,3 +39,7 @@ speed curve, CV values and exchange, decoder-file previews, and safe persistence
 [Article search, web documents, and spare parts](/guide/vehicles/search-and-spares) explains how to
 verify external suggestions, save selected article data and images, import documents, and maintain
 spare parts without overlooking partial writes.
+
+[Accessories](/guide/accessories/) covers the separate accessory article inventory, technical
+product data, counted and individual stock, purchases, documents, reservations, installations, and
+usage history.

--- a/docs/site/guide/overview/index.md
+++ b/docs/site/guide/overview/index.md
@@ -194,6 +194,7 @@ shared with other browsers or saved as account-wide dashboard settings.
 ## Related pages
 
 - [User Guide overview](/guide/)
+- [Accessories overview](/guide/accessories/)
 - [Vehicle maintenance and condition](/guide/vehicles/maintenance)
 - [First setup and sign-in](/guide/getting-started/)
 - [Administration overview](/administration/)

--- a/docs/site/guide/vehicles/search-and-spares.md
+++ b/docs/site/guide/vehicles/search-and-spares.md
@@ -287,6 +287,8 @@ have been stored.
 ## Related pages
 
 - [User Guide overview](/guide/)
+- [Accessories overview](/guide/accessories/), for accessory articles and stock kept separately
+  from vehicle-specific spare-part records
 - [Vehicle inventory and basic data](/guide/vehicles/)
 - [Vehicle images and attachments](/guide/vehicles/media)
 - [Vehicle maintenance and condition](/guide/vehicles/maintenance)

--- a/docs/superpowers/plans/2026-08-16-railkeeper-accessories-guide.md
+++ b/docs/superpowers/plans/2026-08-16-railkeeper-accessories-guide.md
@@ -1,0 +1,1057 @@
+# RailKeeper Accessories Guide Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `aegis:executing-plans` to implement this plan
+> task by task. Keep all Git mutations with the coordinating agent.
+
+**Goal:** Publish a complete four-page English and German user-guide section for the stable
+RailKeeper accessories workspace.
+
+**Architecture:** Reuse the existing `accessories` coverage owner and VitePress user-guide
+structure. Add one bilingual overview pair as the coverage destination plus three mirrored
+subpage pairs for records, stock, and allocations. Keep every behavior claim pinned to tag
+`v0.1.17.6` and link only to already published documentation owners.
+
+**Tech Stack:** Markdown, JSON, TypeScript VitePress configuration, Node.js documentation tests,
+VitePress 2.0.0-alpha.19, Git, GitHub Actions, GitHub Pages.
+
+**Baseline/Authority Refs:**
+
+- `AGENTS.md`;
+- `docs/superpowers/specs/2026-08-16-railkeeper-accessories-guide-design.md`;
+- `docs/superpowers/plans/2026-08-15-railkeeper-documentation-foundation.md`;
+- `docs/coverage.json`;
+- tag `v0.1.17.6` and the stable source files named under each task;
+- existing English/German guide pages and `docs/.vitepress/config.mts`.
+
+**Compatibility Boundary:** Documentation only. Do not change runtime behavior, frontend or
+backend source, API contracts, schemas, migrations, dependencies, screenshots, generated output,
+or coverage ownership outside the existing `accessories` topic. Later `main` behavior is excluded.
+
+**TDD Route:**
+
+- Mode: off
+- Decision: skipped
+- Strict authority: not applicable
+- Test posture: post-change documentation regression and stable-source audit
+- Reason: the approved change creates documentation and navigation, not executable product logic
+- Verification: intentional coverage failure, focused validation, full documentation check,
+  semantic parity review, source-fidelity review, pull-request checks, and live-page checks
+
+**Verification:** `node scripts/validate-docs.mjs`, `npm.cmd run check`, `git diff --check`, focused
+metadata/link/line-length scans, stable-tag source audit, pull-request checks, and post-merge HTTP
+checks for every English and German page.
+
+## Plan basis and readiness
+
+**Aegis Visibility:** Planning is useful because eight new stable pages must remain semantically
+paired while describing permissions, stock arithmetic, immediate writes, and recovery without
+leaking unpublished layout or later-development behavior.
+
+**BaselineUsageDraft:**
+
+- Required baseline refs: approved design, documentation foundation, coverage contract,
+  `v0.1.17.6`, current VitePress configuration
+- Delivered context refs: repository `AGENTS.md` and current worktree state
+- Acknowledged before plan refs: all required refs above
+- Cited in plan refs: all required refs above
+- Missing refs: none
+- Decision: continue
+
+**Requirement Ready Check:**
+
+- Requirement source refs: approved accessories-guide design
+- Goals and scope refs: design Objective, Scope, Non-goals, Information architecture
+- User/scenario refs: overview, article record, stock/document, and allocation lifecycles
+- Requirement item refs: roles, trust/persistence, errors, coverage, navigation, verification
+- Acceptance/verification criteria refs: design Verification and Expected outcome
+- Open blocker questions: none
+- Decision: ready
+
+**Change Necessity:**
+
+- User-visible need: complete bilingual accessories documentation that users can navigate
+- No-change/non-code option: insufficient because the stable workflows are absent from the site
+- Why code change is necessary: no product-code change is necessary
+- Minimum change boundary: Markdown pages, coverage JSON, VitePress sidebar, and published links
+- Decision: docs/config-only
+
+**Existence Check:**
+
+- Proposed new surface: four English and four German pages under `guide/accessories`
+- Existing owner/reuse candidate: existing `accessories` topic and VitePress user-guide section
+- Why existing surface is insufficient: its configured destination pair does not exist
+- Creation proof: approved four-page information architecture and current `planned` coverage state
+- Entropy/retirement impact: one bounded topic group, no duplicate runtime or documentation owner
+- Decision: add-with-proof
+
+**Architecture Integrity Lens:**
+
+- Invariant: one coverage owner for all stable accessories user workflows
+- Canonical owner/contract: `accessories` in `docs/coverage.json`
+- Responsibility overlap: vehicle article search stays with `vehicle-search-spares`; layout design
+  stays `not-published`; master-data administration remains planned
+- Higher-level simplification: use one overview hub instead of one oversized page or UI-tab pages
+- Retirement/falsifier: no temporary fallback or duplicate page path is introduced
+- Verdict: proceed
+
+**Plan Pressure Test:**
+
+- Owner/contract/retirement: one existing owner, no retirement track required
+- Architecture integrity/higher-level path: four task-oriented pages fit the approved structure
+- Verification scope: stable source, bilingual parity, coverage, build, PR, and live deployment
+- Task executability: each page pair and navigation slice has exact files, headings, and checks
+- Pressure result: proceed
+
+**Complexity Budget:**
+
+- Artifact class: maintained user documentation
+- Target files/artifacts: eight new pages, coverage JSON, VitePress config, four existing pages
+- Current pressure: accessories behavior is broad and unsuitable for one page
+- Projected post-change pressure: four focused pages with mirrored sections
+- Budget result: within-budget
+- Planned governance: keep each page task-focused and avoid repeating full field/lifecycle tables
+
+**Plan-Time Complexity Check:**
+
+- Target files: new accessory pages plus narrow navigation and related-link owners
+- Existing size/shape signals: existing vehicle chapters are long but focused; config is centralized
+- Owner fit: new content belongs under the existing `accessories` topic
+- Add-in-place risk: one-page design would be overlong; broad edits to unrelated pages would drift
+- Better file boundary: overview, records, stock/documents, and allocations/history page pairs
+- Recommendation: add owner files and keep existing-file edits wiring-only
+
+## Execution Readiness View
+
+- Intent Lock: document every stable user-facing accessories workflow in English and German
+- Scope Fence: documentation and navigation only, no product or API changes
+- Baseline Lock: behavior claims must resolve to tag `v0.1.17.6`
+- Approved Behavior: four-page task-oriented structure and role/safety model from the design
+- Owner/Contract Constraints: promote only `accessories`; preserve all other coverage owners
+- Compatibility Boundary: do not publish layout operation, planned administration, or later `main`
+- Retirement Boundary: no old path, adapter, fallback, or temporary compatibility layer
+- Task Batches: overview, records, stock/documents, allocations/history, navigation, closeout
+- Test Obligations: intentional gate failure, pair parity, coverage validation, VitePress build
+- Review Gates: source fidelity, language parity, permissions, persistence, partial writes, recovery
+- Drift/Rewind Rules: stop and return to the design if stable behavior requires another owner or
+  the four-page boundary no longer fits
+- Evidence Required Before Completion: clean diff, full docs check, reviewed head SHA, green PR
+  checks, merged PR, and successful live English/German routes
+- Advisory Boundary: method-pack execution guidance only, not authoritative completion
+
+## Global constraints
+
+- Work only in `.worktrees/docs-user-guide-accessories` on
+  `dev/docs-user-guide-accessories`. Do not modify or push local `main`.
+- Preserve the user's untracked files in the main checkout.
+- Use stable release `v0.1.17.6` and review date `2026-08-16` on every new page.
+- Keep English and German pages in the same semantic section order.
+- Use UI labels from the matching stable locale. Preserve identifiers and enum values only where
+  they help users interpret stored behavior.
+- State whether every operation changes a dialog draft, writes immediately, or only reads data.
+- State confirmations, partial-write behavior, refresh behavior, and recovery precisely.
+- External search values and URLs are suggestions, not authoritative product data.
+- Do not document the layout workspace as published. Allocation targets may be named only where
+  the stable accessories dialog exposes them.
+- Link only to published pages. Do not activate planned master-data, Settings, backup, layout, or
+  administration destinations.
+- Preserve LF, UTF-8, approximately 100 to 120 character lines, and established documentation
+  style. Do not use em dashes or unfinished-content markers.
+- Do not commit `docs/node_modules`, `docs/.vitepress/dist`, caches, or other generated output.
+- Make one scoped commit after each coherent task passes its verification.
+- Merge only after the exact reviewed head has all required GitHub checks green.
+
+## File map
+
+| File | Responsibility |
+| --- | --- |
+| `docs/coverage.json` | Promote the existing accessories topic. |
+| `docs/site/guide/accessories/index.md` | English overview and catalogue workflow. |
+| `docs/site/de/guide/accessories/index.md` | German overview counterpart. |
+| `docs/site/guide/accessories/article-records.md` | English record and technical-data workflow. |
+| `docs/site/de/guide/accessories/article-records.md` | German record counterpart. |
+| `docs/site/guide/accessories/stock-purchases-documents.md` | English inventory and document workflow. |
+| `docs/site/de/guide/accessories/stock-purchases-documents.md` | German inventory counterpart. |
+| `docs/site/guide/accessories/allocations-history.md` | English reservation and installation workflow. |
+| `docs/site/de/guide/accessories/allocations-history.md` | German allocation counterpart. |
+| `docs/.vitepress/config.mts` | Add mirrored Accessories/Zubehör sidebar groups. |
+| `docs/site/guide/index.md` | Add the English guide transition. |
+| `docs/site/de/guide/index.md` | Add the German guide transition. |
+| `docs/site/guide/overview/index.md` | Add the published accessories related link. |
+| `docs/site/de/guide/overview/index.md` | Add the German related link. |
+| `docs/site/guide/vehicles/search-and-spares.md` | Clarify the accessory-search boundary. |
+| `docs/site/de/guide/vehicles/search-and-spares.md` | German boundary clarification. |
+
+---
+
+### Task 1: Publish the coverage destination and accessories overview
+
+**Files:**
+
+- Modify: `docs/coverage.json`
+- Create: `docs/site/guide/accessories/index.md`
+- Create: `docs/site/de/guide/accessories/index.md`
+- Reference: approved design and stable overview sources
+
+**Why:** Users need a reliable entry point that explains the article catalogue before opening
+write-heavy detail workflows.
+
+**Change Necessity:** The destination pair does not exist. The minimum boundary is the existing
+coverage status plus its exact English/German overview paths.
+
+**Impact/Compatibility:** No ownership changes. `accessories` becomes `documented` only after both
+configured paths exist and pass validation.
+
+**Verification:** Intentional `node scripts/validate-docs.mjs` failure before page creation, then a
+successful focused validation, `git diff --check`, and clean task-owned status before commit.
+
+**Stable sources:**
+
+- `frontend/src/features/accessories/AccessoriesView.tsx`;
+- `ArticleMetrics.tsx`, `ArticleToolbar.tsx`, `ArticleTable.tsx`, `ArticleCardGrid.tsx`,
+  `ArticleCompactList.tsx`, `ArticleActions.tsx`;
+- `articleTableColumns.ts`, `articleViewMode.ts`, `useArticleOverview.ts`;
+- `backend/internal/application/accessory_overview.go`;
+- stable overview tests, route access, and `accessories.*` translations.
+
+- [ ] **Step 1: Audit the stable overview before writing claims**
+
+Run from the worktree root:
+
+```powershell
+git show v0.1.17.6:frontend/src/features/accessories/AccessoriesView.tsx
+git show v0.1.17.6:frontend/src/features/accessories/ArticleMetrics.tsx
+git show v0.1.17.6:frontend/src/features/accessories/ArticleToolbar.tsx
+git show v0.1.17.6:frontend/src/features/accessories/ArticleTable.tsx
+git show v0.1.17.6:frontend/src/features/accessories/useArticleOverview.ts
+git show v0.1.17.6:backend/internal/application/accessory_overview.go
+```
+
+Confirm these stable facts before prose is added:
+
+- metrics cover article/type counts, available quantity/location count, allocated quantity split
+  into reserved/installed, and non-clickable care hints;
+- article, available, and allocated metric cards apply the stable reset/status filters;
+- server query filters are text, article type, manufacturer, gauge, status, and storage location;
+- `allocated` expands to `reserved` plus `installed`;
+- initial sort is inventory number ascending, and selecting an active sortable column reverses it;
+- table and card preference and visible table columns use browser local storage;
+- image, inventory number, manufacturer, article number, name, type, gauge, stock, and storage are
+  the configurable columns; inventory number and name cannot both be hidden;
+- compact width always uses the mobile list;
+- table selection has no bulk command in `v0.1.17.6`;
+- Viewer is read-only, Planner can later reserve, Editor can write/archive/restore, and only Admin
+  receives permanent delete;
+- an earlier result can remain visible with an error, so users must reload before trusting it.
+
+- [ ] **Step 2: Turn the coverage topic into an intentional failing gate**
+
+Change only the `accessories` topic status:
+
+```json
+"status": "documented"
+```
+
+Run from `docs`:
+
+```powershell
+node scripts/validate-docs.mjs
+```
+
+Expected: failure names both missing `guide/accessories/index.md` paths. Any ownership, schema, or
+unrelated failure is unexpected and must be resolved before continuing.
+
+- [ ] **Step 3: Create the English overview page**
+
+Use this exact frontmatter and heading order:
+
+```markdown
+---
+title: Accessories overview
+description: Find, filter, inspect, and safely manage accessory articles.
+audience: user
+status: stable
+reviewedVersion: 0.1.17.6
+lastReviewed: 2026-08-16
+---
+
+# Accessories overview
+
+## Access rights and workspace model
+
+## Read the overview metrics
+
+## Search and filter articles
+
+## Choose columns, view, and sorting
+
+## Select, open, and manage an article
+
+## Resolve loading, empty, and error states
+
+## Continue with an article workflow
+
+## Related pages
+
+## Documented RailKeeper version
+```
+
+Include every confirmed overview fact from Step 1. Explain all stable filters and status values,
+every configurable column, local-browser persistence, compact behavior, per-row actions, archive
+and restore, Admin-only permanent deletion, and the inert selection boundary. Do not duplicate the
+field, stock, or allocation instructions from later pages.
+
+- [ ] **Step 4: Create the German semantic counterpart**
+
+Use matching structure and this frontmatter:
+
+```markdown
+---
+title: Zubehörübersicht
+description: Zubehörartikel finden, filtern, prüfen und sicher verwalten.
+audience: user
+status: stable
+reviewedVersion: 0.1.17.6
+lastReviewed: 2026-08-16
+---
+
+# Zubehörübersicht
+```
+
+Translate the stable UI meaning, not the English sentence shape. Use the same tables, warnings,
+role boundaries, persistence statements, error states, and related destinations.
+
+- [ ] **Step 5: Verify and commit Task 1**
+
+Run:
+
+```powershell
+cd docs
+node scripts/validate-docs.mjs
+cd ..
+git diff --check
+git status --short
+```
+
+Expected: validation succeeds, whitespace check is clean, and only the three Task 1 files plus the
+already committed design/plan history belong to the branch. Commit only Task 1 files:
+
+```powershell
+git add docs/coverage.json docs/site/guide/accessories/index.md `
+  docs/site/de/guide/accessories/index.md
+git commit -m "docs: add accessories overview guide"
+```
+
+---
+
+### Task 2: Document article records and technical data
+
+**Files:**
+
+- Create: `docs/site/guide/accessories/article-records.md`
+- Create: `docs/site/de/guide/accessories/article-records.md`
+
+**Why:** Users need one complete path for product identity, validation, type-specific data, search,
+duplicate handling, and lifecycle actions before they change stock.
+
+**Change Necessity:** The approved overview is intentionally a hub. The focused pair prevents core
+record rules from being buried inside stock or allocation instructions.
+
+**Impact/Compatibility:** This pair stays under the existing accessories owner. It may name
+configured master data but must not document its planned administration page.
+
+**Verification:** Focused documentation validation, mirrored heading scan, `git diff --check`, and
+stable-source readback for every field, role, confirmation, and lifecycle claim.
+
+**Stable sources:**
+
+- `ArticleEditorDialog.tsx`, `ArticleCoreTab.tsx`, `ArticleSubjectTab.tsx`;
+- `articleEditorModel.ts`, `articleEditorAutomation.ts`, `articleTypes.ts`, `articleSubtypes.ts`,
+  `articleTypeFields.ts`;
+- `accessoryArticleSearch.ts`, `useAccessoryArticleSearchController.ts`;
+- shared barcode/article-search dialogs and stable translations;
+- `useArticleEditorController.ts`, application/accessory validation, duplicate, archive, restore,
+  and deletion services plus route-access tests.
+
+- [ ] **Step 1: Audit stable record behavior and field contracts**
+
+Read the files above from tag `v0.1.17.6` with `git show`. Build the page only after confirming:
+
+- required fields are manufacturer, name, subtype, stock unit, and valid positive package quantity;
+- minimum stock is a non-negative whole number;
+- article type, subtype, gauges, and stock units are configured master data with historical-value
+  preservation where stable code permits it;
+- common optional fields include article number, EAN, manufacturer status, scale, description,
+  URLs, alternative numbers, keywords, compatibility notes, and internal notes;
+- inventory strategies are quantity, individual, and quantity-later-individual;
+- the exact stable article types and their supported type-specific fields/options come from
+  `articleTypeFields.ts` and the stable master-data entries;
+- scale and keywords are auto-managed only until the user manually changes them;
+- changing article type can discard subtype and incompatible technical values and requires the
+  stable confirmation;
+- create mode cannot persist stock or related resources before the article exists;
+- duplicate check uses manufacturer/article number and requires deliberate confirmation to create
+  a candidate duplicate;
+- external accessory search and barcode results are untrusted draft suggestions;
+- close with dirty article or subdraft state requires confirmation;
+- archive/restore require Editor; permanent delete requires Admin and can be blocked by references.
+
+- [ ] **Step 2: Create the English records page**
+
+Use this frontmatter and heading order:
+
+```markdown
+---
+title: Article records and technical data
+description: Create accessory records, maintain their identity, and verify technical data.
+audience: user
+status: stable
+reviewedVersion: 0.1.17.6
+lastReviewed: 2026-08-16
+---
+
+# Article records and technical data
+
+## Access rights and persistence
+
+## Create an article
+
+## Common field reference
+
+## Choose article type and technical data
+
+## Use barcode and article-data search
+
+## Review duplicate candidates
+
+## Edit without losing data
+
+## Archive, restore, or delete an article
+
+## Resolve validation and resource errors
+
+## Related pages
+
+## Documented RailKeeper version
+```
+
+Use concise tables for common fields, manufacturer status, inventory strategy, article types, and
+type-specific field groups. State draft versus immediate persistence for every action. Cover the
+exact confirmations, validation errors, historical inactive choices, stale resources, retry
+actions, unsaved-close behavior, and permanent-delete consequences.
+
+- [ ] **Step 3: Create the German semantic counterpart**
+
+Use matching structure and this frontmatter:
+
+```markdown
+---
+title: Artikelstammdaten und Fachangaben
+description: Zubehörartikel anlegen, ihre Identität pflegen und Fachangaben prüfen.
+audience: user
+status: stable
+reviewedVersion: 0.1.17.6
+lastReviewed: 2026-08-16
+---
+
+# Artikelstammdaten und Fachangaben
+```
+
+Use the stable German UI labels and preserve every validation, trust, permission, confirmation,
+and persistence statement from the English page.
+
+- [ ] **Step 4: Verify and commit Task 2**
+
+Run validation and the whitespace check, then compare the English/German heading sequences:
+
+```powershell
+cd docs
+node scripts/validate-docs.mjs
+cd ..
+rg -n "^## " docs/site/guide/accessories/article-records.md
+rg -n "^## " docs/site/de/guide/accessories/article-records.md
+git diff --check
+```
+
+Expected: validation succeeds and both pages have the same section count and semantic order.
+Commit only the pair:
+
+```powershell
+git add docs/site/guide/accessories/article-records.md `
+  docs/site/de/guide/accessories/article-records.md
+git commit -m "docs: explain accessory article records"
+```
+
+---
+
+### Task 3: Document stock, purchases, assets, and documents
+
+**Files:**
+
+- Create: `docs/site/guide/accessories/stock-purchases-documents.md`
+- Create: `docs/site/de/guide/accessories/stock-purchases-documents.md`
+
+**Why:** Stock mutations have materially different effects for counted units and individual
+assets. Users need those effects, confirmations, and recovery rules in one focused chapter.
+
+**Change Necessity:** The stock and document lifecycle is too detailed for the overview and shares
+one resource-refresh boundary in the stable editor.
+
+**Impact/Compatibility:** Describe storage locations only as resources consumed by the published
+accessories UI. Do not present backend-only storage-location CRUD as a visible workflow.
+
+**Verification:** Focused documentation validation, mirrored heading scan, `git diff --check`, and
+stable-source readback for inventory arithmetic, transactions, files, refreshes, and backup.
+
+**Stable sources:**
+
+- `ArticleStockTab.tsx`, `AccessoryStockPanel.tsx`, `AccessoryAssetForm.tsx`;
+- `ArticlePurchaseDocumentsTab.tsx` and its tests;
+- `articleEditorResources.ts`, `useArticleEditorController.ts`;
+- accessory inventory, purchase, and document application services and handlers;
+- remote accessory image import, upload security, stable translations, tests, and backup code.
+
+- [ ] **Step 1: Audit stock and document state transitions**
+
+Confirm from tag `v0.1.17.6`:
+
+- quantity supports adjustments and transfers; individual supports assets; hybrid supports both
+  counted stock and individualization;
+- positive and negative adjustments use an active location and reject zero;
+- transfer requires different active source/target locations and positive available quantity;
+- every accepted adjustment, transfer, individualization, purchase booking, installation, and
+  removal creates the exact stable stock movement entries;
+- reserved or installed assets cannot be edited from the asset table;
+- asset fields and allowed non-reserved/non-installed lifecycle values match stable code;
+- purchase fields, quantity/date rules, `bookToStock`, and required location behavior are exact;
+- purchase creation plus stock booking has the transaction/partial-write behavior proven by the
+  stable service, not inferred from separate UI requests;
+- document categories, primary-image rules, accepted operations, URL import behavior, and
+  immediate persistence are exact;
+- public URL, redirect, private-address, file type, size, empty-file, and path-confinement rules
+  match the stable handlers;
+- successful sub-actions refresh all related resources; failed refresh marks resources stale and
+  disables further writes until retry succeeds;
+- stable backup inclusion is stated only after reading the backup implementation/tests.
+
+- [ ] **Step 2: Create the English stock page**
+
+Use this frontmatter and heading order:
+
+```markdown
+---
+title: Stock, purchases, and documents
+description: Manage accessory quantities, individual items, purchases, images, and documents.
+audience: user
+status: stable
+reviewedVersion: 0.1.17.6
+lastReviewed: 2026-08-16
+---
+
+# Stock, purchases, and documents
+
+## Choose an inventory strategy
+
+## Read stock and availability
+
+## Adjust quantity stock
+
+## Transfer stock between locations
+
+## Manage individual items
+
+## Record purchases
+
+## Manage images and documents
+
+## Protect data during immediate writes
+
+## Resolve stock and document errors
+
+## Related pages
+
+## Documented RailKeeper version
+```
+
+Include a strategy matrix for quantity, individual, and hybrid. Include complete field/operation
+tables for assets, purchases, documents, and stock movements. For every button state whether a
+confirmation occurs, which record changes, whether a refresh follows, and how to recover if the
+write succeeded but resource reload failed.
+
+- [ ] **Step 3: Create the German semantic counterpart**
+
+Use matching structure and this frontmatter:
+
+```markdown
+---
+title: Bestand, Käufe und Dokumente
+description: Zubehörmengen, Einzelstücke, Käufe, Bilder und Dokumente verwalten.
+audience: user
+status: stable
+reviewedVersion: 0.1.17.6
+lastReviewed: 2026-08-16
+---
+
+# Bestand, Käufe und Dokumente
+```
+
+Preserve every arithmetic, lifecycle, confirmation, transaction, security, refresh, and recovery
+statement. Use `Einzelstücke` consistently for individually tracked assets.
+
+- [ ] **Step 4: Verify and commit Task 3**
+
+Run:
+
+```powershell
+cd docs
+node scripts/validate-docs.mjs
+cd ..
+rg -n "^## " docs/site/guide/accessories/stock-purchases-documents.md
+rg -n "^## " docs/site/de/guide/accessories/stock-purchases-documents.md
+git diff --check
+```
+
+Expected: validation succeeds, the section order is mirrored, and no generated artifact is
+tracked. Commit only the pair:
+
+```powershell
+git add docs/site/guide/accessories/stock-purchases-documents.md `
+  docs/site/de/guide/accessories/stock-purchases-documents.md
+git commit -m "docs: explain accessory stock and documents"
+```
+
+---
+
+### Task 4: Document reservations, installations, and history
+
+**Files:**
+
+- Create: `docs/site/guide/accessories/allocations-history.md`
+- Create: `docs/site/de/guide/accessories/allocations-history.md`
+
+**Why:** Allocation commands change stock, asset lifecycle, reservation state, installation state,
+and history. The page must make those coupled effects predictable.
+
+**Change Necessity:** This lifecycle has its own Planner/Editor boundary and cannot be reduced to a
+stock-page footnote without hiding target and recovery rules.
+
+**Impact/Compatibility:** Vehicle, layout, and layout-unit targets may be named because the stable
+dialog exposes them. Layout creation or editing remains explicitly unpublished.
+
+**Verification:** Focused documentation validation, mirrored heading scan, `git diff --check`, and
+stable-source readback for every permission, target, state transition, and usage event.
+
+**Stable sources:**
+
+- `AccessoryReservationsPanel.tsx`, `AccessoryInstallationsPanel.tsx`;
+- `AccessoryTargetFields.tsx`, `AccessoryTechnicalFields.tsx`;
+- `ArticleUsageHistoryTab.tsx`, `ArticleStockTab.tsx`;
+- `useArticleEditorController.ts` permissions/resource refresh;
+- `backend/internal/application/accessory_allocations.go` and tests;
+- allocation handlers, route access, stable types, and translations.
+
+- [ ] **Step 1: Audit allocation invariants and effects**
+
+Confirm from tag `v0.1.17.6`:
+
+- target union is exactly vehicle, layout, or layout unit;
+- technical placement fields are placement, digital address, decoder output, connection, and
+  wiring notes;
+- Planner can create/cancel reservations but cannot install or manage general stock;
+- reservation requires product, target, source location, positive quantity, and an eligible asset
+  when individual tracking requires one;
+- only active reservations can be cancelled;
+- installation can consume an active reservation or use the stable direct path;
+- a selected reservation constrains target, location, asset, and quantity exactly as the UI does;
+- installation condition defaults and all stable condition values are exact;
+- condition update and removal each require their stable confirmation;
+- removal disposition is stored, maintenance, defective, or retired; stored requires a location;
+- quantity stock and asset lifecycle effects are exact for reservation, cancellation, installation,
+  condition change, and removal;
+- usage event types and chronology are reservation, installation, condition change, and removal;
+- allocation summary meanings for owned, stored, reserved, installed, available, and missing match
+  stable service calculations;
+- stale-resource and failed-refresh recovery matches the controller.
+
+- [ ] **Step 2: Create the English allocation page**
+
+Use this frontmatter and heading order:
+
+```markdown
+---
+title: Reservations, installations, and usage
+description: Reserve accessory stock, record installations, and understand usage history.
+audience: user
+status: stable
+reviewedVersion: 0.1.17.6
+lastReviewed: 2026-08-16
+---
+
+# Reservations, installations, and usage
+
+## Roles and allocation targets
+
+## Read the allocation summary
+
+## Reserve stock
+
+## Cancel a reservation
+
+## Record an installation
+
+## Update installation condition
+
+## Remove an installation
+
+## Read usage history
+
+## Keep stock and lifecycle state consistent
+
+## Resolve allocation errors
+
+## Related pages
+
+## Documented RailKeeper version
+```
+
+Use effect tables that separately state quantity-stock, asset, reservation, installation, and
+history changes. Explain every target and technical-placement field without documenting how to
+operate the layout workspace. Include all role, confirmation, stale-state, partial-result, and
+recovery rules.
+
+- [ ] **Step 3: Create the German semantic counterpart**
+
+Use matching structure and this frontmatter:
+
+```markdown
+---
+title: Reservierungen, Einbauten und Verwendung
+description: Zubehör reservieren, Einbauten erfassen und die Verwendungshistorie verstehen.
+audience: user
+status: stable
+reviewedVersion: 0.1.17.6
+lastReviewed: 2026-08-16
+---
+
+# Reservierungen, Einbauten und Verwendung
+```
+
+Keep `Reservierung`, `Einbau`, `Ausbau`, `Verbleib`, and `Verwendungshistorie` consistent with the
+stable UI. Preserve the same effect matrices and warnings.
+
+- [ ] **Step 4: Verify and commit Task 4**
+
+Run validation, heading comparison, and whitespace checks as in Tasks 2 and 3. Expected: all pass.
+Commit only the allocation pair:
+
+```powershell
+git add docs/site/guide/accessories/allocations-history.md `
+  docs/site/de/guide/accessories/allocations-history.md
+git commit -m "docs: explain accessory allocations"
+```
+
+---
+
+### Task 5: Connect navigation and published cross-links
+
+**Files:**
+
+- Modify: `docs/.vitepress/config.mts`
+- Modify: `docs/site/guide/index.md`
+- Modify: `docs/site/de/guide/index.md`
+- Modify: `docs/site/guide/overview/index.md`
+- Modify: `docs/site/de/guide/overview/index.md`
+- Modify: `docs/site/guide/vehicles/search-and-spares.md`
+- Modify: `docs/site/de/guide/vehicles/search-and-spares.md`
+- Modify: all eight new accessory pages for final related links
+
+**Why:** Published content must be discoverable from the site hierarchy and existing owner
+boundaries without exposing planned destinations.
+
+**Change Necessity:** The pages build without sidebar and landing entries but would remain easy to
+miss, contradicting the approved wiki-navigation goal.
+
+**Impact/Compatibility:** Wiring only. Existing vehicle routes, order, titles, and metadata remain
+unchanged except for narrow related-page additions.
+
+**Verification:** Full `npm.cmd run check`, route scan for all eight pages, `git diff --check`, and
+review of every new link against an existing published Markdown destination.
+
+- [ ] **Step 1: Add mirrored sidebar groups**
+
+After the existing User Guide vehicle group, add an English **Accessories** group with links in this
+order:
+
+```text
+/guide/accessories/
+/guide/accessories/article-records
+/guide/accessories/stock-purchases-documents
+/guide/accessories/allocations-history
+```
+
+Add the German **Zubehör** group in the same position and order under `/de/guide/accessories/...`.
+Use the approved page titles as sidebar labels.
+
+- [ ] **Step 2: Add landing and boundary transitions**
+
+Add one concise workflow paragraph to each User Guide landing page after the vehicle search/spares
+paragraph. Add the Accessories overview to the related-page lists of the Overview chapter and the
+vehicle search/spares chapter. The vehicle link must clarify that vehicle spare parts and accessory
+articles are separate inventories.
+
+- [ ] **Step 3: Finalize related links on all accessory pages**
+
+Every accessory page links to:
+
+- User Guide overview;
+- Accessories overview;
+- the other three accessory pages where it is not the current page.
+
+The overview may additionally link to Overview metrics. The records page may link to vehicle
+article search only to explain the boundary. Do not link to planned Settings, master-data,
+backup/restore, layouts, or administration pages.
+
+- [ ] **Step 4: Verify navigation and commit Task 5**
+
+Run:
+
+```powershell
+cd docs
+npm.cmd run check
+cd ..
+git diff --check
+rg -n "/(de/)?guide/accessories" docs/.vitepress/config.mts docs/site
+git status --short
+```
+
+Expected: 19 tests pass, coverage validation succeeds, VitePress builds every new route, and all
+English/German navigation paths appear. Commit only Task 5 wiring files:
+
+```powershell
+git add docs/.vitepress/config.mts docs/site/guide/index.md docs/site/de/guide/index.md `
+  docs/site/guide/overview/index.md docs/site/de/guide/overview/index.md `
+  docs/site/guide/vehicles/search-and-spares.md `
+  docs/site/de/guide/vehicles/search-and-spares.md docs/site/guide/accessories `
+  docs/site/de/guide/accessories
+git commit -m "docs: link accessories user guide"
+```
+
+---
+
+### Task 6: Prove source fidelity, parity, and publication readiness
+
+**Files:**
+
+- Review: all task-owned files
+- Modify only when a verified finding requires correction
+
+**Why:** A polished guide is unsafe if it misstates permissions, stock effects, persistence, or
+stable-version behavior.
+
+**Change Necessity:** Review edits are allowed only for evidence-backed documentation defects and
+must remain inside the approved file boundary.
+
+**Impact/Compatibility:** No scope expansion. Any discovery that belongs to another coverage owner
+returns to design review instead of being absorbed.
+
+**Verification:** Complete stable-source audit, bilingual/hygiene scans, fresh full documentation
+check, focused review, exact-head PR checks, merge workflows, and eight live HTTP checks.
+
+- [ ] **Step 1: Run the complete stable-source audit**
+
+Check each claim against `v0.1.17.6`, not the worktree source. Use `git show` and `git grep` over:
+
+```text
+frontend/src/features/accessories/**
+frontend/src/shared/apiLayoutsAccessories.ts
+frontend/src/shared/i18n/en.ts
+frontend/src/shared/i18n/de.ts
+backend/internal/api/accessory*_handlers.go
+backend/internal/api/routes.go
+backend/internal/application/accessor*.go
+backend/internal/domain/accessory*.go
+backend migrations, backup implementation/tests, and stable OpenAPI paths
+```
+
+Build a review checklist covering: metrics, search fields, filters, sort, view persistence, columns,
+roles, fields, master-data behavior, type automation, search trust, duplicates, draft persistence,
+archive/delete, inventory strategies, arithmetic, movements, assets, purchases, documents, URL/file
+safety, targets, reservations, installations, conditions, removal, history, backup, refresh, and
+recovery. Correct every unsupported or incomplete statement.
+
+- [ ] **Step 2: Run bilingual and hygiene scans**
+
+Run from the worktree root:
+
+```powershell
+rg -n "TBD|TODO|FIXME|coming soon|placeholder" docs/site/guide/accessories `
+  docs/site/de/guide/accessories
+rg -n "^## " docs/site/guide/accessories docs/site/de/guide/accessories
+rg -n "reviewedVersion:|lastReviewed:|status:|audience:" `
+  docs/site/guide/accessories docs/site/de/guide/accessories
+git diff --check origin/main...HEAD
+```
+
+Expected: no unfinished markers; paired pages have matching semantic heading counts; all metadata
+uses user/stable/0.1.17.6/2026-08-16; whitespace is clean.
+
+Check line lengths and correct prose lines over 120 characters unless a Markdown table or
+unbreakable link makes the line clearer:
+
+```powershell
+$files = Get-ChildItem docs/site/guide/accessories,docs/site/de/guide/accessories -Filter *.md
+foreach ($file in $files) {
+  $lines = Get-Content $file.FullName
+  for ($index = 0; $index -lt $lines.Count; $index++) {
+    if ($lines[$index].Length -gt 120) {
+      "{0}:{1}:{2}" -f $file.FullName, ($index + 1), $lines[$index].Length
+    }
+  }
+}
+```
+
+- [ ] **Step 3: Run full documentation verification**
+
+Run fresh:
+
+```powershell
+cd docs
+npm.cmd run check
+cd ..
+git diff --check origin/main...HEAD
+git status --short --branch
+```
+
+Expected: 19 tests pass, coverage validation succeeds, VitePress production build succeeds, diff
+check is clean, and the worktree contains no uncommitted task changes.
+
+- [ ] **Step 4: Request focused review and resolve findings**
+
+Use `aegis:requesting-code-review` for a read-only review of `origin/main...HEAD`. Review questions:
+
+1. Does every behavioral claim match `v0.1.17.6` rather than later `main`?
+2. Are English and German semantically equivalent?
+3. Are Viewer, Planner, Editor, Admin, and Messe boundaries exact?
+4. Are search results, drafts, immediate writes, refreshes, and backup states separated?
+5. Are quantity, hybrid, and individual inventory effects exact?
+6. Are document URL/file protections and path confinement accurate?
+7. Are reservation, installation, removal, asset, and history transitions exact?
+8. Are partial-write and failed-refresh recovery instructions safe?
+9. Are layout and planned-administration boundaries preserved?
+
+Correct valid findings, rerun the focused checks, and obtain a clean re-review. Commit corrections
+as one scoped commit:
+
+```powershell
+git add docs/coverage.json docs/.vitepress/config.mts `
+  docs/site/guide/accessories docs/site/de/guide/accessories `
+  docs/site/guide/index.md docs/site/de/guide/index.md `
+  docs/site/guide/overview/index.md docs/site/de/guide/overview/index.md `
+  docs/site/guide/vehicles/search-and-spares.md `
+  docs/site/de/guide/vehicles/search-and-spares.md
+git commit -m "docs: refine accessories user guide"
+```
+
+If no files changed, do not create an empty commit.
+
+- [ ] **Step 5: Push, open the PR, and verify the reviewed head**
+
+Run:
+
+```powershell
+git push -u origin dev/docs-user-guide-accessories
+gh pr create --base main --head dev/docs-user-guide-accessories `
+  --title "docs: add bilingual accessories guide" `
+  --body "Publishes the complete stable v0.1.17.6 accessories guide in English and German."
+gh pr checks --watch
+```
+
+Record the exact head SHA with `git rev-parse HEAD`. Do not merge if a check is failing, pending, or
+was run against another SHA.
+
+- [ ] **Step 6: Merge only when green and verify publication**
+
+After all required PR checks pass for the reviewed head:
+
+```powershell
+gh pr merge --merge
+```
+
+Wait for merge-triggered CI, CodeQL, Trivy, Documentation Pages, and Docker Image workflows. Verify
+their conclusions against the merge commit:
+
+```powershell
+$mergeSha = gh pr view --json mergeCommit --jq '.mergeCommit.oid'
+gh run list --commit $mergeSha --limit 20 `
+  --json databaseId,workflowName,status,conclusion,url
+```
+
+Verify all eight live routes return HTTP 200 and contain `v0.1.17.6`:
+
+```text
+https://ichwars.github.io/RailKeeper/guide/accessories/
+https://ichwars.github.io/RailKeeper/guide/accessories/article-records
+https://ichwars.github.io/RailKeeper/guide/accessories/stock-purchases-documents
+https://ichwars.github.io/RailKeeper/guide/accessories/allocations-history
+https://ichwars.github.io/RailKeeper/de/guide/accessories/
+https://ichwars.github.io/RailKeeper/de/guide/accessories/article-records
+https://ichwars.github.io/RailKeeper/de/guide/accessories/stock-purchases-documents
+https://ichwars.github.io/RailKeeper/de/guide/accessories/allocations-history
+```
+
+Use this exact read-only check after Documentation Pages succeeds:
+
+```powershell
+$urls = @(
+  'https://ichwars.github.io/RailKeeper/guide/accessories/',
+  'https://ichwars.github.io/RailKeeper/guide/accessories/article-records',
+  'https://ichwars.github.io/RailKeeper/guide/accessories/stock-purchases-documents',
+  'https://ichwars.github.io/RailKeeper/guide/accessories/allocations-history',
+  'https://ichwars.github.io/RailKeeper/de/guide/accessories/',
+  'https://ichwars.github.io/RailKeeper/de/guide/accessories/article-records',
+  'https://ichwars.github.io/RailKeeper/de/guide/accessories/stock-purchases-documents',
+  'https://ichwars.github.io/RailKeeper/de/guide/accessories/allocations-history'
+)
+foreach ($url in $urls) {
+  $response = Invoke-WebRequest -UseBasicParsing $url
+  if ($response.StatusCode -ne 200 -or $response.Content -notmatch 'v0\.1\.17\.6') {
+    throw "Live verification failed: $url"
+  }
+  "OK $($response.StatusCode) $url"
+}
+```
+
+Preserve the completed worktree for traceability unless the user later requests cleanup. Local
+`main` remains untouched.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Later `main` behavior leaks into stable docs | Resolve every claim against `v0.1.17.6`. |
+| One language omits a safety rule | Mirror headings, tables, warnings, and review each pair. |
+| Counted and individual stock are conflated | Lead with a three-strategy matrix and effect tables. |
+| Planner permissions are overstated | Verify both route access and editor permission derivation. |
+| Backend-only storage-location operations look user-facing | Document locations as consumed resources only. |
+| Layout work appears published | Name stable targets while explicitly excluding layout operation. |
+| Immediate write is mistaken for dialog draft | State persistence and refresh after every action. |
+| Partial success causes duplicate retry | Describe reload, reconcile, then retry only missing work. |
+| Generated docs output enters Git | Inspect status and stage explicit task-owned paths only. |
+| PR merges a stale review | Record head SHA and require checks on that exact head. |
+
+## Retirement and rollback
+
+No runtime path, adapter, compatibility layer, or old documentation owner is introduced. Rollback
+is a normal revert of the documentation commits. Reverting must restore `accessories` to `planned`,
+remove all eight pages and sidebar/landing links together, and leave other coverage owners intact.
+
+## Expected completion evidence
+
+- `accessories` is `documented` with its existing overview paths;
+- all four English/German page pairs exist with stable metadata and mirrored content;
+- navigation and published cross-links reach every page;
+- every stable claim has a `v0.1.17.6` source owner;
+- local documentation checks pass from a clean task worktree;
+- focused review has no unresolved findings;
+- the exact reviewed PR head has all required checks green;
+- the PR is merged and all eight live pages return HTTP 200;
+- local `main` and user-owned untracked files remain unchanged.

--- a/docs/superpowers/specs/2026-08-16-railkeeper-accessories-guide-design.md
+++ b/docs/superpowers/specs/2026-08-16-railkeeper-accessories-guide-design.md
@@ -1,0 +1,313 @@
+# RailKeeper Accessories Guide Design
+
+Date: 2026-08-16
+
+Status: Approved in conversation
+Documented release: `v0.1.17.6`
+
+## Objective
+
+Publish a complete English and German user-guide section for the stable accessories workspace.
+The section guides collectors, clubs, planners, and workshop users through the complete lifecycle
+of an accessory article:
+
+1. find and inspect articles in the accessories overview;
+2. create or maintain the article record and its technical data;
+3. choose the correct stock strategy and manage storage, purchases, and documents;
+4. reserve or install stock at a valid target;
+5. review usage history, archive obsolete articles, or delete them with the correct authority.
+
+The section explains every stable user-facing action in this scope. It separates product identity,
+quantity stock, individually tracked assets, reservations, installations, and historical records so
+that users can predict the effect of each write before confirming it.
+
+## Scope
+
+The section owns these stable user workflows:
+
+- accessories overview metrics, search, filters, sorting, selection, and responsive view modes;
+- article read, create, edit, duplicate review, archive, restore, and permanent deletion;
+- accessory article types, subtypes, common fields, type-specific technical data, and custom fields;
+- accessory barcode and external article-data search;
+- quantity-based and individually tracked inventory strategies;
+- stock by storage location, adjustments, transfers, movements, and minimum-stock state;
+- purchases and optional booking of a purchase into stock;
+- individual accessory assets and their lifecycle;
+- accessory images and documents, including URL import, metadata, download, and deletion;
+- reservations, cancellation, installations, condition changes, removal, and disposition;
+- allocation summaries and usage history;
+- permissions, confirmation steps, stale-resource handling, partial writes, backup, and recovery.
+
+## Non-goals
+
+The section does not explain:
+
+- vehicle records, vehicle article lookup, vehicle attachments, or vehicle spare parts;
+- administration of master-data entries or inventory-number schemes;
+- the unpublished layout workspace or how to design layouts and layout units;
+- deployment-level attachment limits, reverse proxy configuration, or environment variables;
+- external catalog data as authoritative truth;
+- cloud synchronization, public sharing, marketplace behavior, or later development features.
+
+Existing allocation targets may be named where the accessories workflow exposes them. The guide
+does not turn that reference into documentation of the unpublished layout workspace.
+
+## Source and compatibility boundary
+
+Behavior claims come from the stable `v0.1.17.6` tag, not from later `main` development. Primary
+source owners include:
+
+- `frontend/src/features/accessories/AccessoriesView.tsx`;
+- `frontend/src/features/accessories/ArticleEditorDialog.tsx`;
+- the `ArticleCoreTab`, `ArticleStockTab`, `ArticlePurchaseDocumentsTab`, `ArticleSubjectTab`, and
+  `ArticleUsageHistoryTab` components;
+- accessories overview, editor, search, automation, table, card, and responsive helpers;
+- stock, purchase, document, reservation, installation, and asset panels;
+- `frontend/src/shared/apiLayoutsAccessories.ts` and the stable API adapter;
+- accessories translations in `frontend/src/shared/i18n/en.ts` and `de.ts`;
+- `backend/internal/application/accessories*.go` and related inventory, purchase, document, and
+  allocation services;
+- `backend/internal/api/accessory*_handlers.go` and stable route access rules;
+- stable domain types, migrations, OpenAPI operations, tests, and backup scope.
+
+Later article-search refinements or accessories changes on `main` must not be described unless they
+are already present in `v0.1.17.6`.
+
+## Information architecture
+
+Create a mirrored four-page section:
+
+- overview and catalogue: `guide/accessories/index.md` and `de/guide/accessories/index.md`;
+- records and technical data: `guide/accessories/article-records.md` and
+  `de/guide/accessories/article-records.md`;
+- stock, purchases, and documents: `guide/accessories/stock-purchases-documents.md` and
+  `de/guide/accessories/stock-purchases-documents.md`;
+- reservations, installations, and history: `guide/accessories/allocations-history.md` and
+  `de/guide/accessories/allocations-history.md`.
+
+Suggested titles:
+
+- **Accessories overview** / **Zubehörübersicht**;
+- **Article records and technical data** / **Artikelstammdaten und Fachangaben**;
+- **Stock, purchases, and documents** / **Bestand, Käufe und Dokumente**;
+- **Reservations, installations, and usage** / **Reservierungen, Einbauten und Verwendung**.
+
+Every page uses the established user-guide frontmatter contract, names stable version
+`v0.1.17.6`, uses matching English and German section order, and states the review date as
+2026-08-16.
+
+## Page 1: Accessories overview
+
+The overview page introduces the workspace and explains:
+
+- the operational meaning of its metrics and status filters;
+- which fields the server search and browser filters inspect;
+- how active, archived, low-stock, allocated, and other stable states combine;
+- table, card, and compact mobile views;
+- stable columns, sorting, and the table selection state, including that `v0.1.17.6` exposes no
+  bulk command for the selected accessories;
+- opening an article in read-only or edit mode;
+- loading, empty, no-result, and stale/error states;
+- role-specific read-only messages and the transition to each detailed page.
+
+The page acts as the coverage destination and the hub for the three focused subpages. It does not
+repeat their field-by-field or transaction details.
+
+## Page 2: Article records and technical data
+
+The records page documents:
+
+- required and optional common article fields;
+- article number, EAN, manufacturer status, URLs, alternative numbers, keywords, compatibility,
+  notes, package quantity, stock unit, minimum stock, and inventory strategy;
+- configured article types and subtypes, including historical inactive values;
+- type-specific stable technical fields and custom subject fields;
+- automatic scale and keyword suggestions and when manual edits stop automatic management;
+- accessory barcode search and external article-data search as untrusted suggestions;
+- which selected search values remain draft state until the article is saved;
+- duplicate checking, candidate review, and deliberate duplicate confirmation;
+- loss warnings when changing the article type would discard subtype or technical values;
+- unsaved-change close confirmation and tab-level validation errors;
+- archive, restore, and permanent Admin deletion, including references that can block deletion.
+
+The field reference is grouped by user purpose rather than by component filename. Stable static
+choices, configured master data, numeric rules, and normalization behavior are stated precisely.
+
+## Page 3: Stock, purchases, and documents
+
+The stock page starts with the critical inventory-strategy distinction:
+
+| Strategy | Meaning |
+| --- | --- |
+| Quantity | Interchangeable units are booked as counts by storage location. |
+| Individual | Physical items are represented as identifiable assets with their own lifecycle. |
+
+The page then explains:
+
+- initial stock behavior during article creation;
+- stock totals, availability, reservations, installations, and minimum-stock warnings;
+- positive and negative stock adjustments and their confirmations;
+- transfers between active storage locations and movement history;
+- individualization of quantity stock where the stable UI permits it;
+- creation and editing of individual assets, including inventory identity and lifecycle limits;
+- purchase fields, optional immediate stock booking, and purchase history;
+- accessory images and other documents, categories, primary-image behavior, metadata, download,
+  URL import, and deletion;
+- public-URL, redirect, file-type, size, empty-file, and storage-safety rules;
+- sequential or multi-step writes, refresh behavior, and recovery after partial failure.
+
+Storage locations are explained only as resources used by stable accessories workflows. CRUD
+operations with no published user interface are not presented as visible user actions.
+
+## Page 4: Reservations, installations, and usage
+
+The allocation page explains:
+
+- target kinds exposed by stable `v0.1.17.6` and the boundary around unpublished layouts;
+- quantity and individual-asset allocation rules;
+- availability checks and valid storage-location or asset choices;
+- Planner reservation rights and the difference from Editor installation rights;
+- creating and cancelling an active reservation;
+- installing with or without a reservation where permitted;
+- how a reservation constrains target, location, asset, and quantity choices;
+- recording installation condition and notes;
+- changing condition, removing an installation, and booking the resulting disposition;
+- active and removed installation states;
+- allocation summary, reservation state, and usage-history chronology;
+- confirmations, validation errors, stale resources, and recovery after a failed refresh.
+
+The page makes clear when a stock count, asset lifecycle, reservation, installation, or history row
+changes. It does not imply that a layout target makes the layout editor a published feature.
+
+## Roles and permissions
+
+The section uses one explicit role matrix:
+
+| Capability | Viewer | Planner | Editor | Admin |
+| --- | --- | --- | --- | --- |
+| Read articles, stock, documents, and history | Yes | Yes | Yes | Yes |
+| Create or cancel reservations | No | Yes | Yes | Yes |
+| Create or edit articles and technical data | No | No | Yes | Yes |
+| Manage stock, purchases, assets, and documents | No | No | Yes | Yes |
+| Create, update, or remove installations | No | No | Yes | Yes |
+| Archive or restore an article | No | No | Yes | Yes |
+| Permanently delete an article | No | No | No | Yes |
+
+The stable UI and server route checks are both audited. Where visible controls and server authority
+differ, the guide treats the server rule as authoritative and names the stable UI limitation.
+Messe does not receive the general accessories workflow through its role alone.
+
+## Trust, persistence, and safety model
+
+External barcode and article-search results are suggestions. Users must verify manufacturer,
+article identity, URLs, technical data, and images before applying them.
+
+The section distinguishes these states:
+
+| State | Persistence |
+| --- | --- |
+| Search result | External suggestion, not stored |
+| Edited article or technical field | Dialog draft until the article save succeeds |
+| Stock, purchase, asset, document, reservation, or installation action | Separate immediate server write |
+| Usage history | Stored consequence of completed lifecycle actions |
+
+Closing a dirty dialog, changing article type, confirming a duplicate, adjusting stock, cancelling
+a reservation, recording an installation, removing an installation, archiving, restoring, and
+deleting are documented with their actual stable confirmation behavior. A later failed request
+must never be described as rolling back an earlier successful request unless the stable service
+uses one transaction that proves that behavior.
+
+## Empty, partial, and error states
+
+The pages cover at least:
+
+- no articles, no search result, no filter match, and article-loading failure;
+- missing or inactive master data;
+- required common fields and invalid numeric or type-specific values;
+- duplicate candidates and deliberate duplicate creation;
+- unsaved changes and type-change data loss;
+- stale article resources and retry behavior;
+- incompatible inventory-strategy operations;
+- insufficient quantity, unavailable assets, inactive storage locations, and invalid transfers;
+- purchase booking failure and stock/history reconciliation;
+- rejected document URLs or files and partial remote imports;
+- invalid allocation targets, conflicting reservations, and unavailable reserved resources;
+- failed condition change or removal and the need to reload before retrying;
+- archive, restore, or deletion blocked by active or historical references;
+- role-forbidden writes.
+
+Stable German-only errors visible in the English locale are identified as localization limitations,
+not translated into behavior that the UI does not provide.
+
+## Storage and backup
+
+Saved accessory products, technical attributes, quantity stock, movements, purchases, individual
+assets, stored documents, reservations, installations, and usage history belong to local
+RailKeeper application data. Their precise inclusion in backup and restore is verified against the
+stable backup implementation before publication.
+
+Transient search results and unsaved dialog drafts are not backup data. The guide recommends a
+current validated backup before large inventory corrections, bulk lifecycle changes, or permanent
+deletion. External URLs remain external dependencies even when their metadata is stored locally.
+
+## Navigation and cross-links
+
+Add an **Accessories** / **Zubehör** group to both user-guide sidebars after the vehicle group. The
+group links to the overview and its three subpages.
+
+Add the accessories overview to both User Guide landing pages. Add related-page links among the
+four accessories pages and from relevant already published pages. Link only to existing published
+owners, including:
+
+- User Guide overview;
+- Overview, metrics, and data quality;
+- vehicle inventory and core records;
+- article search, web documents, and spare parts where the boundary needs clarification.
+
+Do not create active links to planned master-data, Settings, backup/restore, layout, or general
+administration pages.
+
+## Coverage contract
+
+Change only the `accessories` topic from `planned` to `documented`. Preserve its established
+coverage destination and ownership:
+
+- frontend route `/accessories`;
+- translations below `accessories`;
+- API prefixes below `/api/v1/accessory`;
+- `/api/v1/storage-locations`.
+
+The primary English and German coverage paths remain the overview pair. The additional three page
+pairs are children of that documented topic.
+
+If the stable source inventory exposes a user-facing accessories API outside the existing prefix
+mapping, update the owner map only when the mapping is required for accurate validation and remains
+inside the `accessories` topic. Do not absorb unrelated layout or administration owners.
+
+## Verification and review
+
+Verification includes:
+
+1. a stable-tag audit for overview behavior, fields, types, defaults, validation, search, roles,
+   stock strategies, movements, purchases, assets, documents, allocations, history, deletion, and
+   backup;
+2. matching English and German frontmatter, page structure, tables, warnings, and cross-links;
+3. an intentional missing-page validation failure after changing the coverage status;
+4. route, navigation, unfinished-marker, internal-link, line-length, and whitespace scans;
+5. `npm.cmd run check` from `docs`, including unit tests, coverage validation, and the VitePress
+   production build;
+6. independent read-only review of source fidelity, parity, role boundaries, external-data trust,
+   immediate versus draft persistence, stock arithmetic, lifecycle effects, partial writes, and
+   recovery guidance;
+7. correction and focused re-review of every valid finding;
+8. a pull request from the isolated branch only;
+9. merge only when all required checks pass for the reviewed head;
+10. post-merge verification of GitHub Pages and both language trees.
+
+## Expected outcome
+
+Users can locate an accessory article, understand its product and technical identity, choose the
+right stock strategy, maintain purchases and documents, and allocate real stock without confusing
+counts, individual assets, reservations, installations, or history. They know which actions are
+draft-only, which write immediately, which role is required, and how to recover when an operation
+or later refresh fails.


### PR DESCRIPTION
## What changed

- publishes the complete accessories user guide in English and German
- covers article records, stock, purchases, documents, allocations, and usage history
- connects the new pages to navigation, landing pages, related links, and coverage tracking

## Why

The growing RailKeeper feature set needs a complete, versioned user reference that keeps stable
workflows discoverable in both supported documentation languages.

## Impact

Users and operators can now follow all accessory workflows documented against stable v0.1.17.6.
Development documentation remains aligned with `main` and outside this stable user-guide scope.

## Validation

- `npm.cmd run check`
- 19 documentation tests passed
- coverage validation passed
- VitePress production build passed
- independent documentation review completed without findings
