### PR TITLE
docs: add bilingual exhibition guide

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -65,6 +65,14 @@ export default defineConfig({
                 { text: "Reservierungen, Einbauten und Verwendung", link: "/de/guide/accessories/allocations-history" },
               ],
             },
+            {
+              text: "Messe",
+              items: [
+                { text: "Messearbeitsbereich", link: "/de/guide/exhibition/" },
+                { text: "Listen und Sperren", link: "/de/guide/exhibition/lists-and-locking" },
+                { text: "Einträge und Drucken", link: "/de/guide/exhibition/entries-and-printing" },
+              ],
+            },
           ],
           "/de/administration/": [
             {
@@ -147,6 +155,14 @@ export default defineConfig({
             { text: "Article records and technical data", link: "/guide/accessories/article-records" },
             { text: "Stock, purchases, and documents", link: "/guide/accessories/stock-purchases-documents" },
             { text: "Reservations, installations, and usage", link: "/guide/accessories/allocations-history" },
+          ],
+        },
+        {
+          text: "Exhibition",
+          items: [
+            { text: "Exhibition workspace", link: "/guide/exhibition/" },
+            { text: "Lists and locking", link: "/guide/exhibition/lists-and-locking" },
+            { text: "Entries and printing", link: "/guide/exhibition/entries-and-printing" },
           ],
         },
       ],

--- a/docs/coverage.json
+++ b/docs/coverage.json
@@ -60,7 +60,7 @@
     {
       "id": "exhibition",
       "audience": "user",
-      "status": "planned",
+      "status": "documented",
       "englishPath": "guide/exhibition/index.md",
       "germanPath": "de/guide/exhibition/index.md"
     },

--- a/docs/site/de/guide/exhibition/entries-and-printing.md
+++ b/docs/site/de/guide/exhibition/entries-and-printing.md
@@ -1,0 +1,237 @@
+---
+title: Einträge und Drucken
+description: Messeloks erfassen, Adresskonflikte lösen und die Betriebsliste drucken.
+audience: user
+status: stable
+reviewedVersion: 0.1.17.6
+lastReviewed: 2026-08-16
+---
+
+# Einträge und Drucken
+
+Ein Messelisteneintrag beschreibt eine Lokomotive so, wie sie während der ausgewählten
+Veranstaltung benötigt wird. Der Eintrag verbindet Besitzer und Modellidentität mit Betriebstagen,
+digitalen oder analogen Steuerungsdaten, einem Bild, Funktionstasten und Notizen.
+
+## Eintragsrechte und Speicherung
+
+Messe und Admin können Einträge anlegen und bearbeiten, solange die ausgewählte Liste offen ist.
+Nur Admin sieht am Eintrag die Aktion **Löschen**. Eine gesperrte Liste weist alle drei Änderungen
+zurück, auch das Löschen durch Admin.
+
+Der Eintragsdialog ist ein gemeinsamer Entwurf mit den drei Reitern **Allgemein**,
+**Bilder upload** und **Funktionstasten**. Änderungen in jedem Reiter bleiben Formularzustand im
+Browser, bis **Speichern** erfolgreich war. Das Speichern übermittelt den vollständigen Eintrag,
+schließt den Dialog und lädt die Einträge der ausgewählten Liste neu. **Abbrechen** oder die
+Schließen-Schaltfläche verwirft die aktuellen Dialogänderungen ohne eigene Warnung.
+
+Gespeicherte Einträge, eingebettete Bilddaten und Funktionseinstellungen sind lokale
+RailKeeper-Anwendungsdaten und gehören zum App-Backup. Ungespeicherte Formularänderungen und
+Druckoptionen gehören nicht dazu.
+
+## Eintrag anlegen oder bearbeiten
+
+Wähle eine offene Liste und verwende das Bedienelement zum Anlegen im Eintragsbereich.
+**Eintrag erfassen** öffnet sich im Reiter **Allgemein**. Fülle die beiden Pflichtfelder aus:
+
+| Feld | Regel |
+| --- | --- |
+| Besitzer | Pflichtfeld. Der Server entfernt führende und nachgestellte Leerzeichen. |
+| Lok Bezeichnung | Pflichtfeld. Der Server entfernt führende und nachgestellte Leerzeichen. |
+
+Mit **Bearbeiten** in einer vorhandenen Zeile öffnet sich **Eintrag bearbeiten** mit den aktuellen
+Werten. v0.1.17.6 bietet in diesem Dialog keine Fahrzeugauswahl und kein sichtbares Feld für eine
+Fahrzeugverknüpfung. Der Eintrag bleibt ein Messedatensatz, auch wenn seine Beschreibung einem
+Fahrzeug im allgemeinen Bestand ähnelt.
+
+Wähle **Speichern** erst, nachdem du alle drei Reiter geprüft hast. Während des Speicherns oder bei
+einem erkannten DCC- oder SX-Adresskonflikt ist die Schaltfläche deaktiviert. Wurde die Liste nach
+dem Öffnen des Dialogs gesperrt, weist der Server den Vorgang ebenfalls zurück.
+
+## Allgemeine und Steuerungsdaten ausfüllen
+
+Der Reiter **Allgemein** enthält drei Bereiche.
+
+### Basisdaten
+
+| Feld | Eingabe und Bedeutung |
+| --- | --- |
+| Besitzer | Erforderlicher Freitext für die verantwortliche Person oder den Verein. |
+| Lok Bezeichnung | Erforderlicher Freitext als hauptsächliche Modellidentität. |
+| Hersteller | Auswahl aus aktiven Hersteller-Stammdaten, wenn das Konto sie lesen darf. |
+| Baureihe | Optionaler Freitext. |
+| Gattung | Auswahl aus aktiven Fahrzeug-Gattungen, wenn verfügbar. |
+| Epoche | Auswahl aus aktiven Epochen, wenn verfügbar. |
+| Bahnverwaltung | Auswahl aus aktiven Bahnverwaltungen, wenn verfügbar. |
+
+Admin kann diese allgemeinen Stammdatenauswahlen laden. Ein Messekonto mit zusätzlicher Rolle
+Viewer, Editor oder Planner kann sie ebenfalls laden. Reines Messe erhält in diesen vier
+Auswahllisten nur **Keine Auswahl**. Die Auswahllisten nehmen keinen beliebigen Freitext an. Kann
+ein gespeicherter Wert nicht geladen werden, zeigt das Bedienelement möglicherweise
+**Keine Auswahl**, obwohl der Eintragsentwurf seinen bisherigen Wert noch enthält. Wähle nicht
+gezielt **Keine Auswahl** und speichere, wenn diese Klassifikation erhalten bleiben muss. Prüfe sie
+zuerst mit Admin oder einem Messekonto mit bestandsberechtigter Zusatzrolle.
+
+### Steuerung
+
+| Feld | Eingabe und Bedeutung |
+| --- | --- |
+| Decoder-Typ | Optionaler Freitext. |
+| Adapter / Schnittstelle | Keine Auswahl, NEM 651, NEM 652, PluX16, PluX22, MTC21, Next18, 8-polig oder 21-polig. |
+| Adresse DCC | Optionaler Freitext, der mit anderen geladenen Einträgen dieser Liste verglichen wird. |
+| Adresse SX | Optionaler Freitext, der getrennt mit anderen geladenen Einträgen verglichen wird. |
+| Analog | Schalter für die Verfügbarkeit des Analogbetriebs. |
+
+Tabelle und Report verbinden DCC und SX unter **Adresse**, zeigen Analog als Ja oder Nein und führen
+Decoder-Typ und Schnittstelle getrennt auf. Leere Werte erscheinen als Strich.
+
+**Baureihe** wird mit dem Eintrag gespeichert, erscheint in v0.1.17.6 jedoch weder in Tabelle und
+Listenansicht noch im gedruckten Report. Öffne **Eintrag bearbeiten**, um den Wert zu prüfen.
+
+### Nr. / Beschriftung / Merkmale
+
+Das Textfeld **Notizen** speichert freie Betriebsinformationen. Der Server entfernt beim Speichern
+an allen Textfeldern führende und nachgestellte Leerzeichen, erhält aber den Inhalt dazwischen.
+
+## Messetage auswählen
+
+Die Tagesauswahl bietet **Alle Tage** und **Tag 1** bis **Tag 4**.
+
+- **Alle Tage** ersetzt eine vorhandene Einzelauswahl.
+- Die Auswahl eines nummerierten Tages bei aktivem **Alle Tage** begrenzt den Eintrag auf diesen
+  Tag.
+- Weitere nummerierte Tage ergeben eine Mehrfachauswahl.
+- Kein nummerierter Tag oder alle vier nummerierten Tage werden beim Speichern zu **Alle Tage**.
+- Gespeicherte Einzeltage werden in die Reihenfolge Tag 1, Tag 2, Tag 3, Tag 4 gebracht.
+
+Der ausgewählte Umfang erscheint unter dem Besitzer in Tabellen und Reports. Der Druck filtert
+nicht nach einem Tag. Er enthält alle Reporteinträge und zeigt deren jeweiligen Tagesumfang.
+
+## DCC- und SX-Adresskonflikte lösen
+
+RailKeeper vergleicht jede nicht leere DCC- und SX-Angabe mit dem entsprechenden Wert der anderen
+aktuell geladenen Einträge der ausgewählten Liste. Führende und nachgestellte Leerzeichen sowie
+Groß- und Kleinschreibung werden beim Vergleich ignoriert. Der gerade bearbeitete Eintrag bleibt
+außen vor.
+
+Ein Konflikt erzeugt eine Feldwarnung wie **DCC-Adresse bereits bei BR 218 vergeben.** oder
+**SX-Adresse bereits bei BR 218 vergeben.** Die Hauptaktion **Speichern** ist deaktiviert; der
+Speicherpfad meldet **Diese Adresse ist in der ausgewählten Liste bereits vergeben.** Ändere die
+Adresse oder korrigiere den anderen Eintrag.
+
+Dies ist eine Browserprüfung über die bereits geladenen Einträge. Der stabile Server erzwingt keine
+eindeutigen Adressen. Arbeiten mehrere Personen gleichzeitig, lade die Liste unmittelbar vor einer
+neuen Adressvergabe neu und prüfe anschließend die gedruckte Liste auf Konflikte.
+
+## Bild hinzufügen oder entfernen
+
+Der Reiter **Bilder upload** speichert eine Bildquelle pro Eintrag.
+
+| Aktion | Stabiles Verhalten |
+| --- | --- |
+| Bildlink eingeben | Der Browser zeigt die angegebene Quelle als Vorschau und speichert sie später mit dem Eintrag. |
+| **Bild hochladen** | Akzeptiert PNG, JPEG oder WebP und liest die Datei als eingebettete Daten in den Entwurf. |
+| Quelle ersetzen | Ein anderer Link oder eine andere Datei ersetzt die Quelle im Entwurf. |
+| **Bild entfernen** | Leert die Quelle im Entwurf. Dauerhaft wird dies erst nach erfolgreichem Speichern des Eintrags. |
+
+RailKeeper lädt oder validiert einen externen Link nicht vor dem Speichern. Der Browser ruft die
+externe Ressource ab, wenn er Vorschau, Tabelle, Detailansicht oder Report darstellt. Prüfe Quelle,
+Verfügbarkeit und Datenschutz vor der Verwendung. Ein defekter Link liefert keine nutzbare
+Vorschau. Korrigiere oder entferne ihn und speichere erneut.
+
+Kann der Browser eine ausgewählte lokale Bilddatei nicht lesen, wird die Quelle im Entwurf nicht
+ersetzt. Wähle eine lesbare unterstützte Datei und prüfe die Vorschau vor **Speichern**.
+
+## Funktionstasten F0 bis F31 konfigurieren
+
+Der Reiter **Funktionstasten** enthält F0 bis F31. Jede Zeile kann Folgendes aufnehmen:
+
+- einen optionalen Funktionsnamen;
+- ein optionales Funktionssymbol;
+- einen Typ: `standard`, `licht`, `sound`, `kupplung`, `rauch` oder `sonderfunktion`.
+
+Bei einem neuen Eintrag beginnt F0 mit **Fahrlicht**, Typ `licht` und Lichtsymbol. Alle anderen
+Tasten beginnen unkonfiguriert mit Typ `standard`. Eine Zeile gilt als belegt, sobald sie einen
+Namen, ein Symbol oder einen vom Standard abweichenden Typ besitzt. Die Zusammenfassung zählt
+belegte Zeilen sowie die Typen `sound` und `licht`.
+
+Die Auswahl eines Symbols übernimmt dessen Bezeichnung als Funktionsnamen, wenn die Auswahl eine
+Bezeichnung liefert. Prüfe den Namen nach der Symbolauswahl. Beim **Speichern** legt RailKeeper nur
+belegte Funktionen als strukturierte Daten ab. Tabelle, Detailansicht und Report zeigen nur diese
+Funktionen.
+
+v0.1.17.6 kann außerdem frühere Klartextwerte lesen, die durch Kommas, Semikolons oder Zeilen
+getrennt sind und jeweils mit einer Taste wie `F1 Sound` beginnen. Das Öffnen und Speichern eines
+solchen Eintrags schreibt die aktuell konfigurierte strukturierte Darstellung.
+
+## Einträge lesen, sortieren und löschen
+
+Die Eintragstabelle beginnt mit **Besitzer** aufsteigend und bietet diese sortierbaren
+Überschriften:
+
+- **Besitzer**;
+- **Lok Bezeichnung**;
+- **Steuerung**, sortiert nach der DCC-Adresse;
+- **Funktionstasten**, sortiert nach der gespeicherten Funktionsdarstellung.
+
+Die Bildspalte ist nicht sortierbar. Die Lokzelle verbindet Lok Bezeichnung, Bahnverwaltung,
+Hersteller, Gattung, Epoche und Notizen, soweit Werte vorhanden sind. Die Steuerungszelle zeigt
+Adresse, Analogzustand, Decoder und Schnittstelle.
+
+Admin kann bei einem Eintrag einer offenen Liste **Löschen** wählen und bestätigen:
+
+> Eintrag "BR 218" wirklich löschen?
+
+Das Löschen ist sofort und dauerhaft. Danach lädt RailKeeper Einträge und Anzahl neu. Ein
+allgemeiner Fahrzeugdatensatz wird nicht gelöscht. Messe erhält das Löschbedienelement nicht. Eine
+gesperrte Liste weist die Serveranfrage auch für Admin zurück.
+
+## Report ansehen und drucken
+
+**Ansehen** öffnet eine schreibgeschützte Tabelle für eine Liste. Sie zeigt Bild, Besitzer und Tage,
+Lokdaten, Steuerungsdaten und belegte Funktionstasten. **Drucken** in diesem Dialog führt weiter zu
+**Report drucken**.
+
+Alternativ stehen **Drucken** in einer Listenzeile und **Liste drucken** über der ausgewählten
+Eintragstabelle zur Verfügung. Gehört die Aktion zu einer anderen Liste, lädt RailKeeper zuerst
+deren Einträge. Die Aktion der ausgewählten Liste verwendet die aktuell angezeigten Einträge.
+
+Lasse in **Report drucken** die Option **Mit Bildern drucken** aktiviert oder deaktiviere sie, um
+die Bildspalte wegzulassen. Der erzeugte Report verwendet A4 im Querformat und enthält:
+
+- RailKeeper-Zeichen, Listenbezeichnung, Datum und Eintragsanzahl;
+- optional das Bild;
+- Besitzer und Tagesumfang;
+- Lokidentität sowie vorhandene Angaben zu Hersteller, Gattung und Epoche;
+- Adressen, Analogzustand, Decoder und Schnittstelle;
+- belegte Funktionstasten und Symbole;
+- Notizen.
+
+Mit **Drucken** öffnet sich der Druckdialog des Browsers. Papierauswahl, Ränder, Skalierung,
+Druckerverfügbarkeit, Abbruch und endgültige Ausgabe bleiben Entscheidungen von Browser und
+Betriebssystem. Eine leere Liste erzeugt eine Reportzeile mit **Keine Einträge.**
+
+## Eintrags- und Druckfehler beheben
+
+| Situation | Stabiles Ergebnis und Wiederherstellung |
+| --- | --- |
+| Besitzer oder Lok Bezeichnung fehlt | Browser oder Server weist Speichern ab. Fülle beide Pflichtfelder aus. |
+| Doppelte DCC- oder SX-Adresse | Speichern bleibt deaktiviert. Lade neu, finde den anderen Eintrag und korrigiere eine Adresse. |
+| Liste wurde gesperrt | Speichern oder Löschen wird abgewiesen. Lade den Status; Admin muss vor der Korrektur entsperren. |
+| Stammdatenauswahlen zeigen nur **Keine Auswahl** | Das Konto darf allgemeine Bestandsstammdaten nicht lesen. Lösche gespeicherte Auswahlwerte nicht. |
+| Bild hat keine Vorschau | Prüfe den Link oder wähle vor dem Speichern eine lesbare PNG-, JPEG- oder WebP-Datei. |
+| Speichern gelingt, aber der Refresh scheitert | Öffne den Arbeitsbereich neu und prüfe den Eintrag vor dem Wiederholen. |
+| Detail oder Report öffnet nicht | Lade Liste und Einträge neu und wiederhole danach die Leseaktion. |
+| Browser-Druckdialog wird ohne Ausgabe geschlossen | Öffne **Report drucken** erneut; RailKeeper-Daten wurden nicht geändert. |
+
+## Verwandte Seiten
+
+- [Messearbeitsbereich](./)
+- [Listen und Sperren](./lists-and-locking)
+- [Übersicht des Benutzerhandbuchs](/de/guide/)
+- [Fahrzeugbestand und Grunddaten](/de/guide/vehicles/)
+
+## Dokumentierte RailKeeper-Version
+
+Diese Seite beschreibt RailKeeper v0.1.17.6. Der Entwicklungsstand auf `main` kann abweichen und
+gehört nicht zu diesem Benutzerablauf.

--- a/docs/site/de/guide/exhibition/index.md
+++ b/docs/site/de/guide/exhibition/index.md
@@ -1,0 +1,133 @@
+---
+title: Messearbeitsbereich
+description: Messelisten sicher vorbereiten, pflegen, prüfen und drucken.
+audience: user
+status: stable
+reviewedVersion: 0.1.17.6
+lastReviewed: 2026-08-16
+---
+
+# Messearbeitsbereich
+
+Der Arbeitsbereich **Messeliste** bündelt die für eine Messe oder einen Fahrtag benötigten Angaben
+in einer Betriebsansicht. Jede Liste besitzt ein Datum, den Zustand offen oder gesperrt und eigene
+Lokomotiveinträge. Das Betriebspersonal kann eine offene Liste pflegen, ohne den allgemeinen
+Fahrzeugbestand zu öffnen.
+
+Dieses Kapitel dokumentiert RailKeeper v0.1.17.6. Benutzer- und Stammdatenverwaltung,
+Backup-Bedienung sowie der Anlagen-Arbeitsbereich gehören nicht zu diesem Kapitel.
+
+## Zugriffsrechte und Trennung
+
+RailKeeper stellt den Arbeitsbereich zwei Rollen mit unterschiedlichen Aufgaben bereit:
+
+| Rolle | Stabiler Zugriff |
+| --- | --- |
+| Messe | Öffnet den getrennten Messearbeitsbereich. Die Rolle kann Listen lesen und drucken sowie Einträge pflegen, solange die Liste offen ist. |
+| Admin | Öffnet den Arbeitsbereich und kann zusätzlich Listen anlegen, bearbeiten, sperren, entsperren und löschen. Admin kann auch Einträge einer offenen Liste löschen. |
+
+Editor, Viewer und Planner öffnen den Messearbeitsbereich allein nicht. Wird eine dieser Rollen mit
+Messe kombiniert, kann das Eintragsformular zusätzlich allgemeine Stammdatenauswahlen des
+Fahrzeugbestands laden. Ein reines Messekonto bleibt von diesen Auswahlen getrennt, kann jedoch die
+im Dialog vorhandenen Messefelder verwenden. Funktionssymbole stehen Messe weiterhin zur
+Verfügung.
+
+Der Server prüft dieselbe Trennung. Admin wird für jede geschützte Messeanfrage akzeptiert, Messe
+für das Lesen von Listen sowie das Anlegen und Bearbeiten von Einträgen. Ein ausgeblendetes oder
+deaktiviertes Bedienelement ist daher nicht der einzige Schutz gegen unerlaubte Schreibvorgänge.
+
+## Listen und Einträge verstehen
+
+Die Seite enthält zwei zusammengehörige Tabellen:
+
+| Bereich | Aufgabe |
+| --- | --- |
+| Listen | Zeigt **Bezeichnung**, **Datum**, Anzahl der **Einträge**, **Status** und verfügbare Aktionen. |
+| Einträge | Zeigt Bild, Besitzer und Betriebstage, Lokdaten, Steuerungsdaten, belegte Funktionstasten und Aktionen der ausgewählten Liste. |
+
+Die Auswahl einer Listenzeile lädt deren Einträge in die benachbarte Tabelle. Nach der ersten
+Listenanfrage wählt RailKeeper die erste gelieferte Liste aus, falls noch keine Auswahl besteht.
+Die stabile Speicherreihenfolge beginnt mit dem neuesten Datum und danach der Bezeichnung; auch der
+Browser startet mit **Datum** absteigend.
+
+Wähle eine sortierbare Listenüberschrift, um nach Bezeichnung, Datum, Eintragsanzahl oder Status zu
+sortieren. Ein erneuter Klick auf die aktive Überschrift kehrt die Reihenfolge um. Die
+Eintragssortierung beginnt mit **Besitzer** aufsteigend. Die genauen Spalten und Regeln beschreibt
+[Einträge und Drucken](./entries-and-printing).
+
+## Dem Messeablauf folgen
+
+Diese Reihenfolge hält den Betrieb nachvollziehbar:
+
+1. Ein Admin legt eine Liste mit Bezeichnung und Datum an.
+2. Messe oder Admin wählt die offene Liste aus.
+3. Das Betriebspersonal ergänzt Einträge und pflegt Besitzer, Lok-, Betriebs-, Bild- und
+   Funktionsdaten.
+4. Adresskonflikte werden vor dem Speichern eines Eintrags gelöst.
+5. Mit **Ansehen** oder **Liste drucken** werden die aktuellen Einträge geprüft.
+6. Ein Admin sperrt die Liste, sobald keine Einträge mehr geändert werden sollen.
+7. Die gesperrte Liste bleibt les- und druckbar. Für eine gezielte Korrektur kann ein Admin sie
+   wieder entsperren.
+
+Listen- und Eintragsaktionen sind getrennte Server-Schreibvorgänge. Das Schließen eines Dialogs
+ohne Absenden speichert dessen Formular nicht. Nach einem erfolgreichen Listenvorgang lädt
+RailKeeper die Listentabelle neu. Nach einem erfolgreichen Eintragsvorgang lädt es die Einträge der
+ausgewählten Liste neu und aktualisiert die angezeigte Anzahl.
+
+## Mit einer offenen oder gesperrten Liste arbeiten
+
+Die Spalte **Status** zeigt **offen** oder **gesperrt**.
+
+| Vorgang | Offene Liste | Gesperrte Liste |
+| --- | --- | --- |
+| Auswählen und lesen | Ja | Ja |
+| Vollständige Liste ansehen | Ja | Ja |
+| Drucken | Ja | Ja |
+| Eintrag anlegen oder bearbeiten | Ja | Nein |
+| Eintrag als Admin löschen | Ja | Nein |
+| Listenfelder als Admin bearbeiten | Ja | Ja |
+| Als Admin sperren oder entsperren | Sperren | Entsperren |
+| Liste als Admin löschen | Ja | Ja |
+
+Die Bedienelemente zum Anlegen und Bearbeiten von Einträgen sind bei einer gesperrten Liste
+deaktiviert. Der Server weist Eintragsänderungen ebenfalls zurück, wenn die Liste erst nach dem
+Laden der Seite gesperrt wurde. Entsperre die Liste vor einer Korrektur; ein deaktiviertes
+Bedienelement bedeutet nicht, dass Daten fehlen.
+
+Jede Liste bietet **Ansehen** und **Drucken**. Admin sieht zusätzlich **Bearbeiten**, **Sperren**
+oder **Entsperren** sowie **Löschen**. Der Eintragsbereich bietet außerdem **Liste drucken** und bei
+einer offenen Auswahl das Bedienelement zum Anlegen eines Eintrags.
+
+## Lade-, Leer- und Fehlerzustände lesen
+
+| Zustand | Bedeutung und nächster Schritt |
+| --- | --- |
+| **Wird geladen...** | Die Listenanfrage läuft noch. Warte, bevor du eine Liste auswählst. |
+| **Noch keine Messeliste angelegt.** | Es ist keine Liste vorhanden. Ein Admin muss die erste Liste anlegen. |
+| **Bitte eine Liste auswählen.** / **Keine Liste ausgewählt.** | Wähle eine Zeile der Listentabelle, bevor du Einträge bearbeitest. |
+| **Noch keine Einträge in dieser Liste.** | Die ausgewählte Liste ist leer. Lege einen Eintrag an, solange sie offen ist. |
+| Meldung oberhalb der Tabellen | Eine Listen-, Eintrags-, Symbol- oder Stammdatenanfrage ist fehlgeschlagen. Lies die Meldung, bevor du fortfährst. |
+
+Einige Folgeanfragen entfernen zuvor angezeigte Daten nicht, bevor sie einen Fehler melden. Schlägt
+das Neuladen einer Liste oder ihrer Einträge fehl, lade den Arbeitsbereich neu. Prüfe anschließend
+Auswahl, Status, Eintragsanzahl und gespeicherte Einträge, bevor du einen Schreibvorgang wiederholst.
+So wird ein möglicherweise bereits erfolgreicher Vorgang nach einem fehlgeschlagenen Refresh nicht
+versehentlich doppelt ausgeführt.
+
+## Mit einem gezielten Ablauf fortfahren
+
+- [Listen und Sperren](./lists-and-locking) erklärt Vorbereitung, Sperrwirkung und Löschen durch
+  Admin.
+- [Einträge und Drucken](./entries-and-printing) erklärt alle Eintragsfelder, Adresskonflikte,
+  Bilder, Funktionstasten, Ansicht und Reportdruck.
+
+## Verwandte Seiten
+
+- [Übersicht des Benutzerhandbuchs](/de/guide/)
+- [Fahrzeugbestand und Grunddaten](/de/guide/vehicles/)
+- [Zubehörübersicht](/de/guide/accessories/)
+
+## Dokumentierte RailKeeper-Version
+
+Diese Seite beschreibt RailKeeper v0.1.17.6. Der Entwicklungsstand auf `main` kann abweichen und
+gehört nicht zu diesem Benutzerablauf.

--- a/docs/site/de/guide/exhibition/index.md
+++ b/docs/site/de/guide/exhibition/index.md
@@ -124,8 +124,9 @@ versehentlich doppelt ausgeführt.
 ## Verwandte Seiten
 
 - [Übersicht des Benutzerhandbuchs](/de/guide/)
+- [Listen und Sperren](./lists-and-locking)
+- [Einträge und Drucken](./entries-and-printing)
 - [Fahrzeugbestand und Grunddaten](/de/guide/vehicles/)
-- [Zubehörübersicht](/de/guide/accessories/)
 
 ## Dokumentierte RailKeeper-Version
 

--- a/docs/site/de/guide/exhibition/index.md
+++ b/docs/site/de/guide/exhibition/index.md
@@ -70,9 +70,10 @@ Diese Reihenfolge hält den Betrieb nachvollziehbar:
    wieder entsperren.
 
 Listen- und Eintragsaktionen sind getrennte Server-Schreibvorgänge. Das Schließen eines Dialogs
-ohne Absenden speichert dessen Formular nicht. Nach einem erfolgreichen Listenvorgang lädt
-RailKeeper die Listentabelle neu. Nach einem erfolgreichen Eintragsvorgang lädt es die Einträge der
-ausgewählten Liste neu und aktualisiert die angezeigte Anzahl.
+ohne Absenden speichert dessen Formular nicht. Nach dem Anlegen, Bearbeiten oder Löschen einer
+Liste lädt RailKeeper die Listentabelle neu; Sperren und Entsperren aktualisieren die betroffene
+Zeile direkt. Nach einem erfolgreichen Eintragsvorgang lädt es die Einträge der ausgewählten Liste
+neu und aktualisiert die angezeigte Anzahl.
 
 ## Mit einer offenen oder gesperrten Liste arbeiten
 

--- a/docs/site/de/guide/exhibition/lists-and-locking.md
+++ b/docs/site/de/guide/exhibition/lists-and-locking.md
@@ -1,0 +1,136 @@
+---
+title: Listen und Sperren
+description: Messelisten anlegen, sperren, entsperren und sicher löschen.
+audience: user
+status: stable
+reviewedVersion: 0.1.17.6
+lastReviewed: 2026-08-16
+---
+
+# Listen und Sperren
+
+Eine Messeliste bündelt die Lokomotiveinträge für eine benannte Messe oder einen Fahrtag. Admin
+bereitet Listen vor und steuert sie; Messe konzentriert sich auf die Betriebseinträge einer offenen
+Liste.
+
+## Rollen für Betrieb und Verwaltung
+
+| Aktion | Messe | Admin |
+| --- | --- | --- |
+| Listen auflisten, auswählen, ansehen und drucken | Ja | Ja |
+| Liste anlegen oder bearbeiten | Nein | Ja |
+| Liste sperren oder entsperren | Nein | Ja |
+| Liste löschen | Nein | Ja |
+| Einträge einer offenen Liste pflegen | Ja | Ja |
+| Eintrag einer offenen Liste löschen | Nein | Ja |
+
+Admin erhält direkten Zugriff auf den Messearbeitsbereich und benötigt keine zusätzliche Rolle
+Messe. Editor, Viewer und Planner öffnen den Arbeitsbereich allein nicht und erteilen keine
+Listenverwaltung.
+
+## Liste anlegen
+
+Wähle **Neue Liste** und fülle den Dialog **Messeliste anlegen** aus:
+
+| Feld | Regel |
+| --- | --- |
+| Bezeichnung | Pflichtfeld. RailKeeper entfernt beim Speichern führende und nachgestellte Leerzeichen. |
+| Datum | Pflichtfeld. Ein neuer Dialog beginnt mit dem vom Browser erzeugten UTC-Kalendertag. Prüfe ihn nahe der lokalen Mitternacht. |
+
+Wähle **Speichern**. Eine erfolgreiche Anfrage legt eine offene Liste an, wählt sie aus, schließt
+den Dialog und lädt die Listentabelle neu. Das Anlegen ist ein sofortiger Server-Schreibvorgang;
+bis zum Erfolg sind die Dialogwerte nur lokaler Formularzustand.
+
+Ist eines der Pflichtfelder leer, verhindert der Browser die normale Übermittlung. Der Server weist
+auch Werte zurück, die nach dem Entfernen äußerer Leerzeichen leer sind. In v0.1.17.6 prüft der
+Server beim Datum, dass der Wert nicht leer ist; das Datumsfeld liefert den normalen Kalenderwert.
+
+## Listen auswählen, sortieren und prüfen
+
+Wähle eine Zeile, um sie zur aktiven Liste zu machen. Die Eintragstabelle lädt anschließend die
+Einträge dieser Liste. Die ausgewählte Zeile bleibt hervorgehoben.
+
+Die Listentabelle beginnt mit **Datum** absteigend. Diese Überschriften sortieren im Browser:
+
+- **Bezeichnung**;
+- **Datum**;
+- **Einträge**;
+- **Status**.
+
+Die Auswahl einer anderen Überschrift beginnt aufsteigend. Die aktive aufsteigende Sortierung wird
+beim nächsten Klick absteigend und beim darauffolgenden wieder aufsteigend.
+
+**Ansehen** lädt die aktuellen Einträge und öffnet eine schreibgeschützte Tabelle. Die Aktion steht
+Messe und Admin für offene und gesperrte Listen zur Verfügung. **Drucken** verwendet denselben
+Leseweg und öffnet die unter [Einträge und Drucken](./entries-and-printing) beschriebenen
+Reportoptionen.
+
+## Bezeichnung oder Datum bearbeiten
+
+Admin wählt **Bearbeiten** in der gewünschten Zeile. **Messeliste bearbeiten** öffnet sich mit der
+gespeicherten Bezeichnung und dem Datum. Ändere eines oder beide Felder und wähle **Speichern**.
+
+Das Bearbeiten einer Liste ändert weder ihre Einträge noch ihren Sperrzustand. Es ist bei offenen
+und gesperrten Listen erlaubt. Nach einem erfolgreichen Schreibvorgang bleibt die gespeicherte
+Liste ausgewählt und RailKeeper lädt alle Listen neu. Schlägt das Speichern fehl, bleibt der Dialog
+offen und die Meldung oberhalb des Arbeitsbereichs zeigt den Fehler. Korrigiere die Werte oder lade
+neu, bevor du es erneut versuchst.
+
+## Liste sperren oder entsperren
+
+Wähle **Sperren**, sobald keine Einträge mehr geändert werden sollen. RailKeeper schreibt den neuen
+Zustand sofort und ersetzt **offen** in der Tabelle durch **gesperrt**. Es erscheint kein
+Bestätigungsdialog.
+
+Die Sperre hat diese genaue Grenze:
+
+- Auswahl, Lesen, **Ansehen** und **Drucken** funktionieren weiter;
+- Bezeichnung und Datum können weiterhin von Admin bearbeitet werden;
+- die Liste kann weiterhin von Admin gelöscht werden;
+- Anlegen, Bearbeiten und Löschen von Einträgen werden abgewiesen;
+- deaktivierte Bedienelemente und Servervalidierung erzwingen gemeinsam die Eintragssperre.
+
+Wähle **Entsperren**, um die Eintragspflege wieder zuzulassen. Auch das Entsperren erfolgt sofort
+und ohne Bestätigung. Schlägt eine Sperranfrage fehl oder ist der angezeigte Zustand unklar, lade
+den Arbeitsbereich neu und lies die Spalte **Status**, bevor du einen Eintrag änderst.
+
+## Liste löschen
+
+Admin wählt **Löschen** und bestätigt:
+
+> Messeliste "{name}" wirklich löschen?
+
+Das Löschen ist dauerhaft. Mit der Liste werden über die Datenbankbeziehung auch alle zugehörigen
+Messelisteneinträge entfernt. Allgemeine Fahrzeugdatensätze werden nicht gelöscht. Exportiere vor
+dem Löschen einer gefüllten Liste ein aktuelles validiertes App-Backup, falls eine Wiederherstellung
+nötig werden könnte.
+
+Nach erfolgreichem Löschen entfernt RailKeeper die Auswahl, wenn sie auf diese Liste zeigte, und
+lädt die verbleibenden Listen neu. Brich die Bestätigung ab, um die Liste unverändert zu lassen.
+
+## Listenfehler beheben
+
+| Situation | Stabiles Ergebnis und Wiederherstellung |
+| --- | --- |
+| Leere Bezeichnung oder leeres Datum | Speichern wird abgewiesen. Fülle beide Pflichtfelder aus. |
+| Liste existiert nicht mehr | Der Server meldet nicht gefunden. Lade den Arbeitsbereich neu und wähle eine vorhandene Liste. |
+| Fehlende Admin-Berechtigung | Anlegen, Bearbeiten, Sperren, Entsperren und Löschen sind verboten. Verwende ein berechtigtes Adminkonto. |
+| Speichern schlägt fehl | Der Dialog bleibt offen und eine Meldung erscheint. Prüfe Werte und Speicherzustand vor dem Wiederholen. |
+| Sperren oder Entsperren wirkt unverändert | Lade vor der Eintragspflege neu; der Serverzustand ist maßgeblich. |
+| Löschergebnis ist unklar | Lade neu und prüfe, ob die Liste noch vorhanden ist, bevor du erneut **Löschen** wählst. |
+| Eintragsvorgang meldet eine gesperrte Liste | Lade den Status neu. Nur Admin kann die Liste gezielt entsperren. |
+
+Erfolgreiches Anlegen, Bearbeiten, Sperren, Entsperren und Löschen wird im RailKeeper-Audit-Log
+erfasst. Die Bedienung des Audit-Logs gehört zur Administration und wird auf dieser Benutzerseite
+nicht erklärt.
+
+## Verwandte Seiten
+
+- [Messearbeitsbereich](./)
+- [Einträge und Drucken](./entries-and-printing)
+- [Übersicht des Benutzerhandbuchs](/de/guide/)
+
+## Dokumentierte RailKeeper-Version
+
+Diese Seite beschreibt RailKeeper v0.1.17.6. Der Entwicklungsstand auf `main` kann abweichen und
+gehört nicht zu diesem Benutzerablauf.

--- a/docs/site/de/guide/exhibition/lists-and-locking.md
+++ b/docs/site/de/guide/exhibition/lists-and-locking.md
@@ -98,7 +98,7 @@ den Arbeitsbereich neu und lies die Spalte **Status**, bevor du einen Eintrag ä
 
 Admin wählt **Löschen** und bestätigt:
 
-> Messeliste "{name}" wirklich löschen?
+> Messeliste "Dortmund 2026" wirklich löschen?
 
 Das Löschen ist dauerhaft. Mit der Liste werden über die Datenbankbeziehung auch alle zugehörigen
 Messelisteneinträge entfernt. Allgemeine Fahrzeugdatensätze werden nicht gelöscht. Exportiere vor

--- a/docs/site/de/guide/index.md
+++ b/docs/site/de/guide/index.md
@@ -45,3 +45,6 @@ Ersatzteile pflegst, ohne teilweise Schreibvorgänge zu übersehen.
 [Zubehör](/de/guide/accessories/) beschreibt den getrennten Zubehör-Artikelbestand, technische
 Produktdaten, Mengen- und Einzelbestand, Käufe, Dokumente, Reservierungen, Einbauten und
 Verwendungshistorie.
+
+[Messearbeitsbereich](/de/guide/exhibition/) erklärt, wie du Listen vorbereitest, Betriebseinträge
+pflegst, Sperren verwendest, DCC- und SX-Adresskonflikte löst und den Veranstaltungsreport druckst.

--- a/docs/site/de/guide/vehicles/index.md
+++ b/docs/site/de/guide/vehicles/index.md
@@ -312,6 +312,7 @@ Datei physisch zu entfernen.
 - [Fahrzeugwartung und Zustand](/de/guide/vehicles/maintenance)
 - [Decoder, Funktionen und CV-Daten](/de/guide/vehicles/decoder-cv)
 - [Artikelsuche, Web-Dokumente und Ersatzteile](/de/guide/vehicles/search-and-spares)
+- [Messearbeitsbereich](/de/guide/exhibition/)
 - [Ersteinrichtung und Anmeldung](/de/guide/getting-started/)
 - [Übersicht, Kennzahlen und Datenqualität](/de/guide/overview/)
 - [Übersicht der Administration](/de/administration/)

--- a/docs/site/guide/exhibition/entries-and-printing.md
+++ b/docs/site/guide/exhibition/entries-and-printing.md
@@ -1,0 +1,226 @@
+---
+title: Entries and printing
+description: Record exhibition locomotives, resolve address conflicts, and print the operating list.
+audience: user
+status: stable
+reviewedVersion: 0.1.17.6
+lastReviewed: 2026-08-16
+---
+
+# Entries and printing
+
+An exhibition entry describes one locomotive as it is needed during the selected event. The entry
+combines owner and model identity with operating days, digital or analog control data, one image,
+function keys, and notes.
+
+## Entry rights and persistence
+
+Messe and Admin can create and edit entries while the selected list is open. Only Admin sees the
+entry **Delete** action. A locked list rejects all three mutations, including an Admin deletion.
+
+The entry dialog is one draft with three tabs: **General**, **Image upload**, and **Function keys**.
+Changes on any tab remain browser form state until **Save** succeeds. Saving sends the complete
+entry, closes the dialog, and reloads the selected list's entries. **Cancel** or the close button
+discards the current dialog changes without a separate warning.
+
+Saved entries, inline image data, and function settings are local RailKeeper application data and
+belong to the app backup. Unsaved form changes and print options do not.
+
+## Create or edit an entry
+
+Select an open list and use the add-entry control in the entry panel. **Create entry** opens on the
+**General** tab. Complete the two required fields:
+
+| Field | Rule |
+| --- | --- |
+| Owner | Required. Leading and trailing whitespace is removed on the server. |
+| Locomotive name | Required. Leading and trailing whitespace is removed on the server. |
+
+Use **Edit** on an existing row to open **Edit entry** with its current values. Stable v0.1.17.6
+does not expose a vehicle picker or a visible vehicle-link field in this dialog. The entry remains
+an exhibition record even when its description resembles a vehicle in general inventory.
+
+Select **Save** only after checking all three tabs. The button is disabled while saving or while a
+duplicate DCC or SX address is detected. A list that became locked after the dialog opened is still
+rejected by the server.
+
+## Complete general and control data
+
+The **General** tab contains three groups.
+
+### Basic data
+
+| Field | Input and meaning |
+| --- | --- |
+| Owner | Required free text for the person or club responsible for the locomotive. |
+| Locomotive name | Required free text shown as the main model identity. |
+| Manufacturer | Selection from active manufacturer master data when the account may read it. |
+| Class | Optional free text. |
+| Type | Selection from active vehicle-type master data when available. |
+| Epoch | Selection from active epoch master data when available. |
+| Railway company | Selection from active railway-company master data when available. |
+
+Admin can load these general master-data choices. A Messe account combined with Viewer, Editor, or
+Planner can also load them. Pure Messe receives only **No selection** in those four selectors. The
+selectors do not accept arbitrary text. When a stored choice cannot be loaded, the control can show
+**No selection** even though the entry draft still carries its previous value. Do not deliberately
+choose **No selection** and save if that stored classification must be retained; use Admin or a
+Messe account with an inventory-capable role to verify it first.
+
+### Control
+
+| Field | Input and meaning |
+| --- | --- |
+| Decoder type | Optional free text. |
+| Adapter / interface | No selection, NEM 651, NEM 652, PluX16, PluX22, MTC21, Next18, 8-polig, or 21-polig. |
+| DCC address | Optional free text checked against other loaded entries in this list. |
+| SX address | Optional free text checked separately against other loaded entries. |
+| Analog | Switch indicating that analog operation is available. |
+
+The table and report combine DCC and SX into **Address**, show analog as Yes or No, and list decoder
+type and interface separately. Empty values appear as a dash.
+
+**Class** is saved with the entry but is not shown in the stable table, read-only list view, or
+printed report. Reopen **Edit entry** when that value must be checked.
+
+### No. / lettering / features
+
+The **Notes** text area stores free-form operating information. The server removes leading and
+trailing whitespace from all text fields when saving but preserves their internal content.
+
+## Select exhibition days
+
+The day selector offers **All days** and **Day 1** through **Day 4**.
+
+- Select **All days** to replace any individual selection.
+- Selecting one numbered day while **All days** is active changes the entry to that day only.
+- Select more numbered days to build a multi-day scope.
+- No numbered day or all four numbered days normalize to **All days** when saved.
+- Stored numbered days are normalized to the order Day 1, Day 2, Day 3, Day 4.
+
+The selected scope appears below the owner in tables and reports. Printing does not filter entries
+to one day; it prints every entry in the report and displays each entry's scope.
+
+## Resolve DCC and SX address conflicts
+
+RailKeeper compares each non-empty DCC and SX value with the corresponding values of other entries
+currently loaded for the selected list. Comparison ignores leading and trailing whitespace and
+letter case. The entry being edited is excluded.
+
+A conflict produces a field warning such as **DCC address already used by BR 218.** or
+**SX address already used by BR 218.** The main **Save** action is disabled, and attempting the save
+path reports **This address is already used in the selected list.** Change the address or correct
+the other entry before saving.
+
+This is a browser check over the entries already loaded by the page; the stable server does not
+enforce address uniqueness. When several operators work at once, reload the list immediately before
+adding another address and review the printed list for conflicts.
+
+## Add or remove the image
+
+The **Image upload** tab stores one image source per entry.
+
+| Action | Stable behavior |
+| --- | --- |
+| Enter an image link | The browser previews and later stores the entered source string with the entry. |
+| **Upload image** | Accepts PNG, JPEG, or WebP and reads the selected file into the entry draft as inline data. |
+| Replace source | Entering another link or uploading another file replaces the draft source. |
+| **Remove image** | Clears the draft source. It is permanent only after the entry save succeeds. |
+
+RailKeeper does not download or validate an external link before storing it. The browser requests
+that external resource when it renders the preview, table, detail view, or report. Verify the
+source and consider its availability and privacy before using it. A broken link produces no usable
+preview; correct or remove it and save the entry again.
+
+If the browser cannot read a selected local image, the draft source is not replaced. Choose a
+supported readable file and verify the preview before selecting **Save**.
+
+## Configure function keys F0 through F31
+
+The **Function keys** tab contains F0 through F31. Each row can hold:
+
+- an optional function name;
+- an optional function symbol;
+- one type: `standard`, `licht`, `sound`, `kupplung`, `rauch`, or `sonderfunktion`.
+
+For a new entry, F0 starts as **Fahrlicht**, type `licht`, with the light symbol. Other keys start
+unconfigured with type `standard`. A row becomes configured when it has a name, a symbol, or a type
+different from its default. The summary counts configured, `sound`, and `licht` rows.
+
+Selecting a symbol applies the symbol label as the function name when the picker supplies one.
+Review the name after choosing a symbol. On **Save**, RailKeeper stores only configured functions as
+structured data. The table, detail view, and report show only those functions.
+
+Stable v0.1.17.6 can also read earlier plain-text values separated by commas, semicolons, or lines
+when each item starts with a key such as `F1 Sound`. Opening and saving such an entry writes the
+currently configured structured representation.
+
+## Read, sort, and delete entries
+
+The entry table starts with **Owner** ascending and offers these sortable headings:
+
+- **Owner**;
+- **Locomotive name**;
+- **Control**, sorted by DCC address;
+- **Function keys**, sorted by the stored function representation.
+
+The image column is not sortable. The locomotive cell combines locomotive name, railway company,
+manufacturer, type, epoch, and notes when present. The control cell shows address, analog state,
+decoder, and interface.
+
+Admin can select **Delete** on an entry in an open list and confirm:
+
+> Really delete entry "BR 218"?
+
+The delete is immediate and permanent, then RailKeeper reloads the entries and count. It does not
+delete a general vehicle. Messe does not receive the delete control. A locked list rejects the
+server request even for Admin.
+
+## View and print the report
+
+**View** opens a read-only table for one list. It shows image, owner and days, locomotive data,
+control data, and configured function keys. **Print** from that dialog continues to **Print report**.
+
+You can also use **Print** on a list row or **Print list** above the selected entry table. If the
+action belongs to another list, RailKeeper loads that list's entries first. The selected-list action
+uses the entries currently displayed.
+
+In **Print report**, keep **Print with images** selected or clear it to omit the image column. The
+generated report uses A4 landscape and contains:
+
+- RailKeeper mark, list designation, date, and entry count;
+- optional image;
+- owner and day scope;
+- locomotive identity and available manufacturer, type, and epoch;
+- addresses, analog state, decoder, and interface;
+- configured function keys and symbols;
+- notes.
+
+Select **Print** to open the browser's print dialog. Paper selection, margins, scaling, printer
+availability, cancellation, and the final output remain browser and operating-system decisions.
+An empty list produces a report row reading **No entries.**
+
+## Resolve entry and print errors
+
+| Situation | Stable result and recovery |
+| --- | --- |
+| Missing owner or locomotive name | Browser or server rejects the save. Complete both required fields. |
+| Duplicate DCC or SX value | Save stays disabled. Reload, identify the other entry, and correct one address. |
+| List became locked | Save or delete is rejected. Reload the status; Admin must unlock before a correction. |
+| Master-data selectors contain only **No selection** | The account cannot read general inventory master data. Avoid clearing stored choices. |
+| Image has no preview | Verify the link or choose a readable PNG, JPEG, or WebP before saving. |
+| Save succeeds but reload fails | Reopen the workspace and inspect the stored entry before retrying. |
+| Detail or report does not open | Reload the list and entries, then retry the read-only action. |
+| Browser print dialog closes without output | Reopen **Print report**; no RailKeeper data was changed. |
+
+## Related pages
+
+- [Exhibition workspace](./)
+- [Lists and locking](./lists-and-locking)
+- [User Guide overview](/guide/)
+- [Vehicle inventory and core records](/guide/vehicles/)
+
+## Documented RailKeeper version
+
+This page describes stable RailKeeper v0.1.17.6. Development behavior on `main` may differ and is
+not part of this user workflow.

--- a/docs/site/guide/exhibition/index.md
+++ b/docs/site/guide/exhibition/index.md
@@ -115,8 +115,9 @@ already have succeeded before the refresh failed.
 ## Related pages
 
 - [User Guide overview](/guide/)
+- [Lists and locking](./lists-and-locking)
+- [Entries and printing](./entries-and-printing)
 - [Vehicle inventory and core records](/guide/vehicles/)
-- [Accessories overview](/guide/accessories/)
 
 ## Documented RailKeeper version
 

--- a/docs/site/guide/exhibition/index.md
+++ b/docs/site/guide/exhibition/index.md
@@ -65,8 +65,9 @@ Use this sequence for predictable operation:
    deliberate correction.
 
 List actions and entry actions are separate server writes. Closing a dialog without submitting it
-does not save its form. After a successful list write, RailKeeper reloads the list table. After a
-successful entry write, it reloads the selected list's entries and updates the displayed count.
+does not save its form. After creating, editing, or deleting a list, RailKeeper reloads the list
+table; locking or unlocking updates the affected row directly. After a successful entry write, it
+reloads the selected list's entries and updates the displayed count.
 
 ## Work with an open or locked list
 

--- a/docs/site/guide/exhibition/index.md
+++ b/docs/site/guide/exhibition/index.md
@@ -1,0 +1,124 @@
+---
+title: Exhibition workspace
+description: Prepare, maintain, review, and print exhibition lists safely.
+audience: user
+status: stable
+reviewedVersion: 0.1.17.6
+lastReviewed: 2026-08-16
+---
+
+# Exhibition workspace
+
+The **Exhibition list** workspace keeps the information needed for an exhibition or running day in
+one operational view. Each list has a date, an open or locked state, and its own locomotive
+entries. Operators can maintain an open list without entering the general vehicle inventory.
+
+This chapter documents stable RailKeeper v0.1.17.6. It does not explain user administration,
+master-data administration, backup operation, or the layout workspace.
+
+## Access rights and isolation
+
+RailKeeper exposes the workspace to two roles with different purposes:
+
+| Role | Stable access |
+| --- | --- |
+| Messe | Opens the isolated exhibition workspace. It can read and print lists and maintain entries while a list is open. |
+| Admin | Opens the workspace and additionally creates, edits, locks, unlocks, and deletes lists. Admin can also delete entries from an open list. |
+
+Editor, Viewer, and Planner do not open the exhibition workspace on their own. When one of these
+roles is combined with Messe, the entry form can also load general inventory master-data choices.
+A pure Messe account remains isolated from those choices, but it can still use the exhibition
+fields provided by the dialog. Function symbols remain available to Messe.
+
+The server checks the same distinction. Admin is accepted for every protected exhibition request;
+Messe is accepted for reading lists and for creating or editing entries. An unavailable control is
+therefore not the only protection against an unauthorized write.
+
+## Understand lists and entries
+
+The page contains two related tables:
+
+| Area | Purpose |
+| --- | --- |
+| Lists | Shows **Designation**, **Date**, number of **Entries**, **Status**, and available actions. |
+| Entries | Shows the image, owner and operating days, locomotive data, control data, configured function keys, and actions for the selected list. |
+
+Selecting a list row loads its entries in the adjacent table. After the initial list request,
+RailKeeper selects the first returned list when no selection exists. Stable storage order is newest
+date first and then designation; the browser also starts with **Date** descending.
+
+Select a sortable list heading to sort by designation, date, entry count, or status. Select the
+active heading again to reverse it. Entry sorting starts with **Owner** ascending. Its detailed
+columns and rules are covered in [Entries and printing](./entries-and-printing).
+
+## Follow the exhibition workflow
+
+Use this sequence for predictable operation:
+
+1. An Admin creates a list with a designation and date.
+2. Messe or Admin selects the open list.
+3. Operators add entries and complete owner, locomotive, operating, image, and function data.
+4. Address conflicts are resolved before an entry is saved.
+5. Operators use **View** or **Print list** to review the current entries.
+6. An Admin locks the list when entry maintenance should stop.
+7. The locked list remains available for viewing and printing. An Admin can unlock it for a
+   deliberate correction.
+
+List actions and entry actions are separate server writes. Closing a dialog without submitting it
+does not save its form. After a successful list write, RailKeeper reloads the list table. After a
+successful entry write, it reloads the selected list's entries and updates the displayed count.
+
+## Work with an open or locked list
+
+The **Status** column shows **open** or **locked**.
+
+| Operation | Open list | Locked list |
+| --- | --- | --- |
+| Select and read | Yes | Yes |
+| View complete list | Yes | Yes |
+| Print | Yes | Yes |
+| Create or edit an entry | Yes | No |
+| Delete an entry as Admin | Yes | No |
+| Edit list fields as Admin | Yes | Yes |
+| Lock or unlock as Admin | Lock | Unlock |
+| Delete list as Admin | Yes | Yes |
+
+The entry add and edit controls are disabled for a locked list. The server also rejects entry
+changes if the list became locked after the page loaded. Unlock the list before correcting an
+entry; do not interpret a disabled control as missing data.
+
+Every list provides **View** and **Print** actions. Admin additionally sees **Edit**, **Lock** or
+**Unlock**, and **Delete**. The entry panel also provides **Print list** and, for an open selection,
+the add-entry control.
+
+## Read loading, empty, and error states
+
+| State | Meaning and next action |
+| --- | --- |
+| **Loading...** | The list request is still running. Wait before choosing a list. |
+| **No exhibition list created yet.** | No list exists. An Admin must create the first list. |
+| **Please select a list.** / **No list selected.** | Select a row in the list table before working with entries. |
+| **No entries in this list yet.** | The selected list is empty. Add an entry while it is open. |
+| Message above the tables | A list, entry, symbol, or master-data request failed. Read the message before continuing. |
+
+Some follow-up requests do not clear previously displayed data before reporting an error. If a
+list or entry refresh fails, reload the workspace and verify the selected list, its status, entry
+count, and stored entries before retrying a write. This avoids repeating an operation that may
+already have succeeded before the refresh failed.
+
+## Continue with a focused workflow
+
+- [Lists and locking](./lists-and-locking) explains Admin preparation, lock effects, and deletion.
+- [Entries and printing](./entries-and-printing) explains every entry field, address conflicts,
+  images, function keys, viewing, and report printing.
+
+## Related pages
+
+- [User Guide overview](/guide/)
+- [Vehicle inventory and core records](/guide/vehicles/)
+- [Accessories overview](/guide/accessories/)
+
+## Documented RailKeeper version
+
+This page describes stable RailKeeper v0.1.17.6. Development behavior on `main` may differ and is
+not part of this user workflow.

--- a/docs/site/guide/exhibition/lists-and-locking.md
+++ b/docs/site/guide/exhibition/lists-and-locking.md
@@ -94,7 +94,7 @@ If a lock request fails or the displayed state is uncertain, reload the workspac
 
 Admin selects **Delete** and confirms:
 
-> Really delete exhibition list "{name}"?
+> Really delete exhibition list "Dortmund 2026"?
 
 Deletion is permanent. Removing a list also removes all of its exhibition entries through the
 database relationship. It does not delete general vehicle records. Export a current validated app

--- a/docs/site/guide/exhibition/lists-and-locking.md
+++ b/docs/site/guide/exhibition/lists-and-locking.md
@@ -1,0 +1,130 @@
+---
+title: Lists and locking
+description: Create exhibition lists, control their lock state, and remove them safely.
+audience: user
+status: stable
+reviewedVersion: 0.1.17.6
+lastReviewed: 2026-08-16
+---
+
+# Lists and locking
+
+An exhibition list groups the locomotive entries for one named exhibition or running date. Admin
+prepares and controls lists; Messe concentrates on operating entries inside an open list.
+
+## Roles for operation and administration
+
+| Action | Messe | Admin |
+| --- | --- | --- |
+| List, select, view, and print lists | Yes | Yes |
+| Create or edit a list | No | Yes |
+| Lock or unlock a list | No | Yes |
+| Delete a list | No | Yes |
+| Maintain entries in an open list | Yes | Yes |
+| Delete an entry from an open list | No | Yes |
+
+Admin receives direct access to the exhibition workspace. It does not need an additional Messe
+role. Editor, Viewer, and Planner neither expose the workspace nor grant list management by
+themselves.
+
+## Create a list
+
+Select **New list** and complete the **Create exhibition list** dialog:
+
+| Field | Rule |
+| --- | --- |
+| Designation | Required. RailKeeper removes leading and trailing whitespace when saving. |
+| Date | Required. A new dialog starts with the browser-generated UTC calendar date. Verify it near local midnight. |
+
+Select **Save**. A successful request creates an open list, selects it, closes the dialog, and
+reloads the list table. The create operation is an immediate server write; the dialog values are
+only local form state until it succeeds.
+
+If either required field is empty, the browser prevents normal submission. The server also rejects
+blank values after trimming them. In stable v0.1.17.6 the server checks that the date value is not
+empty; the date control supplies the normal calendar value.
+
+## Select, sort, and inspect lists
+
+Select any row to make it the active list. The entry table then loads that list's entries. The
+selected row remains highlighted.
+
+The list table starts with **Date** descending. Select these headings to sort in the browser:
+
+- **Designation**;
+- **Date**;
+- **Entries**;
+- **Status**.
+
+Selecting a different heading starts ascending. Selecting the active ascending heading changes it
+to descending; selecting it once more returns to ascending.
+
+The **View** action loads the list's current entries and opens a read-only table. It is available to
+Messe and Admin for open and locked lists. **Print** follows the same read path and opens the report
+options described in [Entries and printing](./entries-and-printing).
+
+## Edit designation or date
+
+Admin selects **Edit** on the required row. **Edit exhibition list** opens with the stored
+designation and date. Change either field and select **Save**.
+
+Editing a list does not change its entries or lock state. It is allowed while the list is open or
+locked. After a successful write, RailKeeper keeps the saved list selected and reloads all lists.
+If saving fails, the dialog remains open and the message above the workspace reports the error.
+Correct the values or reload before trying again.
+
+## Lock or unlock a list
+
+Select **Lock** when no further entry changes should be accepted. RailKeeper immediately writes the
+new state and replaces **open** with **locked** in the table. There is no confirmation dialog.
+
+A lock has this exact boundary:
+
+- selection, reading, **View**, and **Print** continue to work;
+- list designation and date can still be edited by Admin;
+- a list can still be deleted by Admin;
+- entry creation, entry editing, and entry deletion are rejected;
+- both disabled controls and server validation enforce the entry restriction.
+
+Select **Unlock** to restore entry maintenance. Unlocking is also immediate and has no confirmation.
+If a lock request fails or the displayed state is uncertain, reload the workspace and read the
+**Status** column before changing an entry.
+
+## Delete a list
+
+Admin selects **Delete** and confirms:
+
+> Really delete exhibition list "{name}"?
+
+Deletion is permanent. Removing a list also removes all of its exhibition entries through the
+database relationship. It does not delete general vehicle records. Export a current validated app
+backup before deleting a populated list when recovery may be required.
+
+After a successful delete, RailKeeper clears the selection when it referred to that list and
+reloads the remaining lists. Cancel the confirmation to leave the list unchanged.
+
+## Resolve list errors
+
+| Situation | Stable result and recovery |
+| --- | --- |
+| Empty designation or date | Save is rejected. Complete both required fields. |
+| List no longer exists | The server returns not found. Reload the workspace and select an existing list. |
+| Missing Admin authority | Create, edit, lock, unlock, and delete requests are forbidden. Use an authorized Admin account. |
+| Save request fails | The dialog stays open and a message appears. Verify the values and stored state before retrying. |
+| Lock or unlock appears unchanged | Reload before entry maintenance; the server state is authoritative. |
+| Delete result is uncertain | Reload and verify whether the list still exists before selecting **Delete** again. |
+| Entry operation reports a locked list | Reload the status. Only Admin can deliberately unlock it. |
+
+Successful create, edit, lock, unlock, and delete operations are recorded in RailKeeper's audit
+log. Audit-log operation belongs to administration and is not documented on this user page.
+
+## Related pages
+
+- [Exhibition workspace](./)
+- [Entries and printing](./entries-and-printing)
+- [User Guide overview](/guide/)
+
+## Documented RailKeeper version
+
+This page describes stable RailKeeper v0.1.17.6. Development behavior on `main` may differ and is
+not part of this user workflow.

--- a/docs/site/guide/index.md
+++ b/docs/site/guide/index.md
@@ -43,3 +43,6 @@ spare parts without overlooking partial writes.
 [Accessories](/guide/accessories/) covers the separate accessory article inventory, technical
 product data, counted and individual stock, purchases, documents, reservations, installations, and
 usage history.
+
+[Exhibition workspace](/guide/exhibition/) explains how to prepare lists, maintain operating
+entries, use locks, resolve DCC and SX address conflicts, and print the event report.

--- a/docs/site/guide/vehicles/index.md
+++ b/docs/site/guide/vehicles/index.md
@@ -303,6 +303,7 @@ important records; the application does not promise physical cleanup of every re
 - [Vehicle maintenance and condition](/guide/vehicles/maintenance)
 - [Decoder, functions, and CV data](/guide/vehicles/decoder-cv)
 - [Article search, web documents, and spare parts](/guide/vehicles/search-and-spares)
+- [Exhibition workspace](/guide/exhibition/)
 - [First setup and sign-in](/guide/getting-started/)
 - [Overview, metrics, and data quality](/guide/overview/)
 - [Administration overview](/administration/)

--- a/docs/superpowers/plans/2026-08-16-railkeeper-exhibition-guide.md
+++ b/docs/superpowers/plans/2026-08-16-railkeeper-exhibition-guide.md
@@ -1,0 +1,863 @@
+# RailKeeper Exhibition Guide Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `aegis:executing-plans` to implement this plan
+> task by task. Keep all Git mutations with the coordinating agent.
+
+**Goal:** Publish a complete three-page English and German user-guide section for the stable
+RailKeeper exhibition workspace.
+
+**Architecture:** Reuse the existing `exhibition` coverage owner and VitePress user-guide
+structure. Add one bilingual overview pair as the coverage destination plus two mirrored subpage
+pairs for list administration and entry operation. Keep every behavior claim pinned to tag
+`v0.1.17.6` and link only to already published documentation owners.
+
+**Tech Stack:** Markdown, JSON, TypeScript VitePress configuration, Node.js documentation tests,
+VitePress 2.0.0-alpha.19, Git, GitHub Actions, GitHub Pages.
+
+**Baseline/Authority Refs:**
+
+- `AGENTS.md`;
+- `docs/superpowers/specs/2026-08-16-railkeeper-exhibition-guide-design.md`;
+- `docs/superpowers/plans/2026-08-15-railkeeper-documentation-foundation.md`;
+- `docs/coverage.json`;
+- tag `v0.1.17.6` and the stable source files named under each task;
+- existing English/German guide pages and `docs/.vitepress/config.mts`.
+
+**Compatibility Boundary:** Documentation only. Do not change runtime behavior, frontend or
+backend source, API contracts, schemas, migrations, dependencies, screenshots, generated output,
+or coverage ownership outside the existing `exhibition` topic. Later `main` behavior is excluded.
+
+**TDD Route:**
+
+- Mode: off
+- Decision: skipped
+- Strict authority: not applicable
+- Test posture: post-change documentation regression and stable-source audit
+- Reason: the approved change creates documentation and navigation, not executable product logic
+- Verification: intentional coverage failure, focused validation, full documentation check,
+  bilingual review, source-fidelity review, pull-request checks, and live-page checks
+
+**Verification:** `node scripts/validate-docs.mjs`, `npm.cmd run check`, `git diff --check`, focused
+metadata/link/line-length scans, stable-tag source audit, pull-request checks, and post-merge HTTP
+checks for every English and German page.
+
+## Plan basis and readiness
+
+**Aegis Visibility:** Planning is useful because six new pages must remain semantically paired
+while describing combined roles, list locks, duplicate addresses, entry persistence, and print
+behavior without leaking planned administration or later-development behavior.
+
+**BaselineUsageDraft:**
+
+- Required baseline refs: approved design, documentation foundation, coverage contract,
+  `v0.1.17.6`, current VitePress configuration
+- Acknowledged before plan refs: all required refs above
+- Cited in plan refs: all required refs above
+- Missing refs: none
+- Decision: continue
+
+**Requirement Ready Check:**
+
+- Requirement source refs: approved exhibition-guide design
+- Goals and scope refs: design Objective, Scope, Non-goals, Information architecture
+- User/scenario refs: Messe operation, Admin list management, entry maintenance, printing
+- Requirement item refs: roles, locks, validation, persistence, errors, navigation, verification
+- Acceptance/verification criteria refs: design Verification and Expected outcome
+- Open blocker questions: none
+- Decision: ready
+
+**Change Necessity:**
+
+- User-visible need: complete bilingual exhibition documentation that users can navigate
+- No-change/non-code option: insufficient because the stable workflows are absent from the site
+- Why code change is necessary: no product-code change is necessary
+- Minimum change boundary: Markdown pages, coverage JSON, VitePress sidebar, and published links
+- Decision: docs/config-only
+
+**Existence Check:**
+
+- Proposed new surface: three English and three German pages under `guide/exhibition`
+- Existing owner/reuse candidate: existing `exhibition` topic and VitePress user-guide section
+- Why existing surface is insufficient: its configured destination pair does not exist
+- Creation proof: approved three-page information architecture and current `planned` coverage state
+- Entropy/retirement impact: one bounded topic group, no duplicate runtime or documentation owner
+- Decision: add-with-proof
+
+**Architecture Integrity Lens:**
+
+- Invariant: one coverage owner for all stable exhibition-list workflows
+- Canonical owner/contract: `exhibition` in `docs/coverage.json`
+- Responsibility overlap: role administration, master-data administration, vehicle editing,
+  backup operation, deployment, and layouts remain with their existing owners
+- Higher-level simplification: use one overview hub instead of one oversized page or role copies
+- Retirement/falsifier: no temporary path, fallback, or duplicate owner is introduced
+- Verdict: proceed
+
+**Plan Pressure Test:**
+
+- Owner/contract/retirement: one existing owner, no retirement track required
+- Architecture integrity/higher-level path: three task-oriented pages fit the approved structure
+- Verification scope: stable source, bilingual parity, coverage, build, PR, and live deployment
+- Task executability: each page pair and navigation slice has exact files, headings, and checks
+- Pressure result: proceed
+
+**Complexity Budget:**
+
+- Artifact class: maintained user documentation
+- Target files/artifacts: six new pages, coverage JSON, VitePress config, four existing pages
+- Current pressure: roles, entry fields, locks, and printing are unsuitable for one page
+- Projected post-change pressure: three focused pages with mirrored sections
+- Budget result: within-budget
+- Planned governance: keep each page task-focused and avoid repeating field and permission tables
+
+**Plan-Time Complexity Check:**
+
+- Target files: new exhibition pages plus narrow navigation and related-link owners
+- Existing size/shape signals: vehicle and accessories chapters are long but focused; config is
+  centralized
+- Owner fit: new content belongs under the existing `exhibition` topic
+- Add-in-place risk: one-page design would obscure role and lock boundaries
+- Better file boundary: overview, list/locking, and entry/printing page pairs
+- Recommendation: add owner files and keep existing-file edits wiring-only
+
+## Execution Readiness View
+
+- Intent Lock: document every stable user-facing exhibition workflow in English and German
+- Scope Fence: documentation and navigation only, no product or API changes
+- Baseline Lock: behavior claims must resolve to tag `v0.1.17.6`
+- Approved Behavior: three-page task-oriented structure and combined-role model from the design
+- Owner/Contract Constraints: promote only `exhibition`; preserve all other coverage owners
+- Compatibility Boundary: do not publish planned administration, layouts, or later `main`
+- Retirement Boundary: no old path, adapter, fallback, or compatibility layer
+- Task Batches: overview, list administration, entry operation, navigation, closeout
+- Test Obligations: intentional gate failure, pair parity, coverage validation, VitePress build
+- Review Gates: source fidelity, language parity, roles, locks, persistence, validation, printing
+- Drift/Rewind Rules: return to the design if stable behavior requires another owner or more pages
+- Evidence Required Before Completion: clean diff, full docs check, reviewed head SHA, green PR
+  checks, merged PR, green merge workflows, and six successful live routes
+- Advisory Boundary: method-pack execution guidance only, not completion authority
+
+## Global constraints
+
+- Work only in `.worktrees/docs-user-guide-exhibition` on
+  `dev/docs-user-guide-exhibition`. Do not modify or push local `main`.
+- Preserve the user's untracked files in the main checkout.
+- Use stable release `v0.1.17.6` and review date `2026-08-16` on every new page.
+- Keep English and German pages in the same semantic section order.
+- Use exact UI labels from the matching stable locale.
+- State whether each operation changes dialog state, writes immediately, or only reads data.
+- Treat Messe as the workspace role and Messe plus Admin as the list-management combination.
+- State confirmations, lock effects, failed-refresh behavior, and recovery precisely.
+- Do not document role assignment, master-data administration, backup operation, deployment, or
+  the layout workspace as published in this chapter.
+- Link only to published pages. Do not activate planned Settings, administration, layout, backup,
+  deployment, or reference destinations.
+- Preserve LF, UTF-8, approximately 100 to 120 character lines, and established documentation
+  style. Do not use em dashes or unfinished-content markers.
+- Do not commit `docs/node_modules`, `docs/.vitepress/dist`, caches, or generated output.
+- Make one scoped commit after each coherent task passes its verification.
+- Merge only after the exact reviewed head has all required GitHub checks green.
+
+## File map
+
+| File | Responsibility |
+| --- | --- |
+| `docs/coverage.json` | Promote the existing exhibition topic. |
+| `docs/site/guide/exhibition/index.md` | English workspace overview and operating sequence. |
+| `docs/site/de/guide/exhibition/index.md` | German overview counterpart. |
+| `docs/site/guide/exhibition/lists-and-locking.md` | English list administration workflow. |
+| `docs/site/de/guide/exhibition/lists-and-locking.md` | German list counterpart. |
+| `docs/site/guide/exhibition/entries-and-printing.md` | English entry and print workflow. |
+| `docs/site/de/guide/exhibition/entries-and-printing.md` | German entry counterpart. |
+| `docs/.vitepress/config.mts` | Add mirrored Exhibition/Messe sidebar groups. |
+| `docs/site/guide/index.md` | Add the English guide transition. |
+| `docs/site/de/guide/index.md` | Add the German guide transition. |
+| `docs/site/guide/vehicles/index.md` | Link the published exhibition workflow at its boundary. |
+| `docs/site/de/guide/vehicles/index.md` | Add the German boundary link. |
+
+---
+
+### Task 1: Publish the coverage destination and exhibition overview
+
+**Files:**
+
+- Modify: `docs/coverage.json`
+- Create: `docs/site/guide/exhibition/index.md`
+- Create: `docs/site/de/guide/exhibition/index.md`
+
+**Why:** Messe users need a reliable entry point that explains the isolated workspace and the
+complete operating sequence before they modify an open list.
+
+**Change Necessity:** The destination pair does not exist. The minimum boundary is the existing
+coverage status plus its exact English/German overview paths.
+
+**Impact/Compatibility:** No ownership changes. `exhibition` becomes `documented` only after both
+configured paths exist and pass validation.
+
+**Verification:** Intentional validation failure before page creation, then successful focused
+validation, `git diff --check`, and a clean task-owned status before commit.
+
+**Stable sources:**
+
+- `frontend/src/app/App.tsx`, `Shell.tsx`, and their role tests;
+- `frontend/src/features/exhibition/ExhibitionView.tsx` and tests;
+- exhibition translations in `frontend/src/shared/i18n/en.ts` and `de.ts`;
+- `backend/internal/api/routes.go` and stable exhibition authorization tests.
+
+- [ ] **Step 1: Capture the implementation start snapshot and audit the stable overview**
+
+Run from the worktree root:
+
+```powershell
+git status --short --branch
+git rev-parse HEAD
+git show v0.1.17.6:frontend/src/app/App.tsx
+git show v0.1.17.6:frontend/src/app/Shell.tsx
+git show v0.1.17.6:frontend/src/features/exhibition/ExhibitionView.tsx
+git grep -n '"exhibition\.' v0.1.17.6 -- frontend/src/shared/i18n/en.ts `
+  frontend/src/shared/i18n/de.ts
+```
+
+Confirm before writing:
+
+- the route and navigation require the Messe role;
+- list management controls additionally require Admin;
+- the list table shows designation, date, entry count, status, and actions;
+- initial list sort is date descending and stable columns can reverse direction;
+- selecting a row controls the adjacent entry table;
+- view and print are available without Admin;
+- entry creation is disabled when no list is selected or the selected list is locked;
+- pure Messe operation remains isolated from general inventory master data;
+- loading, no-list, no-selection, no-entry, and request-error states are visible.
+
+- [ ] **Step 2: Turn the coverage topic into an intentional failing gate**
+
+Change only the `exhibition` topic status:
+
+```json
+"status": "documented"
+```
+
+Run from `docs`:
+
+```powershell
+node scripts/validate-docs.mjs
+```
+
+Expected: failure names both missing `guide/exhibition/index.md` paths. An ownership, schema, or
+unrelated failure is unexpected and must be resolved before continuing.
+
+- [ ] **Step 3: Create the English overview page**
+
+Use this exact frontmatter and heading order:
+
+```markdown
+---
+title: Exhibition workspace
+description: Prepare, maintain, review, and print exhibition lists safely.
+audience: user
+status: stable
+reviewedVersion: 0.1.17.6
+lastReviewed: 2026-08-16
+---
+
+# Exhibition workspace
+
+## Access rights and isolation
+
+## Understand lists and entries
+
+## Follow the exhibition workflow
+
+## Work with an open or locked list
+
+## Read loading, empty, and error states
+
+## Continue with a focused workflow
+
+## Related pages
+
+## Documented RailKeeper version
+```
+
+Include the confirmed role combination, two-panel relationship, sort defaults, action visibility,
+lock boundary, empty states, immediate-write boundary, and transitions to the two subpages. Keep
+field-level and list-admin detail on their focused pages.
+
+- [ ] **Step 4: Create the German semantic counterpart**
+
+Use matching structure and this frontmatter:
+
+```markdown
+---
+title: Messearbeitsbereich
+description: Messelisten sicher vorbereiten, pflegen, prüfen und drucken.
+audience: user
+status: stable
+reviewedVersion: 0.1.17.6
+lastReviewed: 2026-08-16
+---
+
+# Messearbeitsbereich
+```
+
+Use exact German stable labels such as **Messeliste**, **offen**, **gesperrt**, **Ansehen**, and
+**Liste drucken**. Preserve the same role, persistence, error, and recovery statements.
+
+- [ ] **Step 5: Verify and commit Task 1**
+
+Run:
+
+```powershell
+cd docs
+node scripts/validate-docs.mjs
+cd ..
+git diff --check
+git status --short
+```
+
+Expected: validation succeeds and only the three Task 1 files are uncommitted. Commit:
+
+```powershell
+git add docs/coverage.json docs/site/guide/exhibition/index.md `
+  docs/site/de/guide/exhibition/index.md
+git commit -m "docs: add exhibition workspace guide"
+```
+
+---
+
+### Task 2: Document list administration and locking
+
+**Files:**
+
+- Create: `docs/site/guide/exhibition/lists-and-locking.md`
+- Create: `docs/site/de/guide/exhibition/lists-and-locking.md`
+
+**Why:** Combined Messe and Admin accounts need a precise preparation workflow whose lock and
+deletion effects remain predictable for operators.
+
+**Change Necessity:** The overview is intentionally a hub. This focused pair prevents Admin-only
+actions and lock effects from being hidden in the entry instructions.
+
+**Impact/Compatibility:** The pair stays under the exhibition owner. It explains role requirements
+but does not document how roles are assigned.
+
+**Verification:** Focused validation, mirrored heading scan, stable-source readback, whitespace
+check, and one scoped commit.
+
+**Stable sources:**
+
+- list handlers in `ExhibitionView.tsx`;
+- `backend/internal/application/exhibition.go` list methods and tests;
+- `backend/internal/api/exhibition.go`, route definitions, audit tests, and translations;
+- migrations `0018_exhibition_lists.sql` and stable backup coverage.
+
+- [ ] **Step 1: Audit list validation, permissions, and consequences**
+
+Use `git show` and `git grep` on tag `v0.1.17.6` to confirm:
+
+- designation and date are required and normalized by the stable service;
+- new lists default to today's local date in the UI;
+- create, edit, lock, unlock, and list deletion require Admin on the server;
+- normal workspace access still requires Messe in the stable UI;
+- locking preserves reading, viewing, and printing but rejects entry mutations;
+- unlocking restores entry mutation;
+- list deletion uses the exact confirmation and removes its entries through the stable database
+  relationship;
+- successful create, update, lock, unlock, and delete operations write audit records;
+- missing, invalid, locked, forbidden, and reload-failure behavior is described exactly.
+
+- [ ] **Step 2: Create the English list page**
+
+Use this exact structure:
+
+```markdown
+---
+title: Lists and locking
+description: Create exhibition lists, control their lock state, and remove them safely.
+audience: user
+status: stable
+reviewedVersion: 0.1.17.6
+lastReviewed: 2026-08-16
+---
+
+# Lists and locking
+
+## Required role combination
+
+## Create a list
+
+## Select, sort, and inspect lists
+
+## Edit designation or date
+
+## Lock or unlock a list
+
+## Delete a list
+
+## Resolve list errors
+
+## Related pages
+
+## Documented RailKeeper version
+```
+
+State exact actions and confirmations, immediate persistence, cascade consequences, lock effects,
+audit ownership at a user-relevant level, and reload-before-retry guidance.
+
+- [ ] **Step 3: Create the German semantic counterpart**
+
+Use matching headings and this frontmatter:
+
+```markdown
+---
+title: Listen und Sperren
+description: Messelisten anlegen, sperren, entsperren und sicher löschen.
+audience: user
+status: stable
+reviewedVersion: 0.1.17.6
+lastReviewed: 2026-08-16
+---
+
+# Listen und Sperren
+```
+
+Use the exact stable labels **Neue Liste**, **Messeliste anlegen**, **Messeliste bearbeiten**,
+**Sperren**, **Entsperren**, **Löschen**, and **Speichern**.
+
+- [ ] **Step 4: Verify and commit Task 2**
+
+Run:
+
+```powershell
+cd docs
+node scripts/validate-docs.mjs
+cd ..
+rg -n "^## " docs/site/guide/exhibition/lists-and-locking.md
+rg -n "^## " docs/site/de/guide/exhibition/lists-and-locking.md
+git diff --check
+```
+
+Expected: validation succeeds and section order is mirrored. Commit:
+
+```powershell
+git add docs/site/guide/exhibition/lists-and-locking.md `
+  docs/site/de/guide/exhibition/lists-and-locking.md
+git commit -m "docs: explain exhibition list management"
+```
+
+---
+
+### Task 3: Document entries, conflicts, images, functions, and printing
+
+**Files:**
+
+- Create: `docs/site/guide/exhibition/entries-and-printing.md`
+- Create: `docs/site/de/guide/exhibition/entries-and-printing.md`
+
+**Why:** Entry changes combine required identity, operating data, address uniqueness, images,
+function mappings, lock state, and print output. Operators must understand the complete write.
+
+**Change Necessity:** The approved overview cannot carry the field and print reference without
+becoming difficult to use. This is the minimum focused boundary.
+
+**Impact/Compatibility:** No product behavior changes. Master data and function symbols are
+consumed resources only; their administration stays outside this chapter.
+
+**Verification:** Stable-field audit, mirrored page scan, focused validation, whitespace check,
+and one scoped commit.
+
+**Stable sources:**
+
+- entry form, duplicate detection, image helpers, function serialization, view, and print code in
+  `ExhibitionView.tsx`;
+- `FunctionSymbolPicker`, function-symbol helpers, `AppSelect`, and stable API types;
+- `backend/internal/application/exhibition.go` entry methods, scanners, and tests;
+- entry handlers, route access, migrations 0027, 0028, and 0036, translations, and backup tests.
+
+- [ ] **Step 1: Audit every stable entry and print rule**
+
+Confirm from `v0.1.17.6`:
+
+- required fields are owner and locomotive designation;
+- optional general fields are manufacturer, type, class, epoch, railway company, DT state, DCC
+  address, SX address, decoder type, adapter/interface, analog state, day scope, features, notes,
+  and any stable vehicle link behavior;
+- day scope normalizes no selection or all four individual days to `all`;
+- DCC and SX conflicts compare trimmed lowercase values inside the selected list and exclude the
+  edited entry;
+- a conflict blocks saving and names the conflicting locomotive;
+- pure Messe lacks general inventory master-data choices while combined inventory roles can load
+  them; the guide must state the actual free-text/select behavior of `AppSelect`;
+- one image source can be uploaded as a data URL or entered as a link; replacement and removal are
+  dialog changes until **Save** succeeds;
+- functions cover F0 through F31, F0 defaults to light, and only configured functions are stored
+  and displayed;
+- earlier plain-text function values are parsed when stable code supports them;
+- entry create/update require an open list; entry deletion additionally requires Admin and
+  confirmation;
+- initial entry sort is owner ascending; sortable keys are owner, locomotive name, DT state,
+  decoder number, and function keys;
+- detail view and report fetch current list entries before display;
+- report output is A4 landscape and optionally includes images, with browser print handling;
+- save, stale list, lock, image-read, detail-load, and print-load failures have safe recovery text.
+
+- [ ] **Step 2: Create the English entry page**
+
+Use this exact structure:
+
+```markdown
+---
+title: Entries and printing
+description: Record exhibition locomotives, resolve address conflicts, and print the operating list.
+audience: user
+status: stable
+reviewedVersion: 0.1.17.6
+lastReviewed: 2026-08-16
+---
+
+# Entries and printing
+
+## Entry rights and persistence
+
+## Create or edit an entry
+
+## Complete general and control data
+
+## Select exhibition days
+
+## Resolve DCC and SX address conflicts
+
+## Add or remove the image
+
+## Configure function keys F0 through F31
+
+## Read, sort, and delete entries
+
+## View and print the report
+
+## Resolve entry and print errors
+
+## Related pages
+
+## Documented RailKeeper version
+```
+
+Use field, role, and print-output tables where they improve scanning. State draft versus immediate
+persistence and explain that browser or printer settings can change final output.
+
+- [ ] **Step 3: Create the German semantic counterpart**
+
+Use matching structure and this frontmatter:
+
+```markdown
+---
+title: Einträge und Drucken
+description: Messeloks erfassen, Adresskonflikte lösen und die Betriebsliste drucken.
+audience: user
+status: stable
+reviewedVersion: 0.1.17.6
+lastReviewed: 2026-08-16
+---
+
+# Einträge und Drucken
+```
+
+Use exact stable labels for **Allgemein**, **Bilder upload**, **Funktionstasten**, **DT vorhanden**,
+**Adresse DCC**, **Adresse SX**, **Mit Bildern drucken**, and all save/delete confirmations.
+
+- [ ] **Step 4: Verify and commit Task 3**
+
+Run the focused validator, mirrored heading scan, and `git diff --check`. Expected: all pass and
+only the pair is uncommitted. Commit:
+
+```powershell
+git add docs/site/guide/exhibition/entries-and-printing.md `
+  docs/site/de/guide/exhibition/entries-and-printing.md
+git commit -m "docs: explain exhibition entries and printing"
+```
+
+---
+
+### Task 4: Connect navigation and published cross-links
+
+**Files:**
+
+- Modify: `docs/.vitepress/config.mts`
+- Modify: `docs/site/guide/index.md`
+- Modify: `docs/site/de/guide/index.md`
+- Modify: `docs/site/guide/vehicles/index.md`
+- Modify: `docs/site/de/guide/vehicles/index.md`
+- Modify: all six new exhibition pages for final related links
+
+**Why:** Published content must be discoverable from the site hierarchy and the existing vehicle
+exhibition boundary without exposing planned destinations.
+
+**Change Necessity:** The pages can build without navigation but would remain easy to overlook,
+contradicting the approved wiki goal.
+
+**Impact/Compatibility:** Wiring only. Existing routes, titles, and metadata remain unchanged
+except for narrow related-page additions.
+
+**Verification:** Full documentation check, route scan for all six pages, link review, whitespace
+check, and one scoped commit.
+
+- [ ] **Step 1: Add mirrored sidebar groups after Accessories**
+
+Add English **Exhibition** links in this order:
+
+```text
+/guide/exhibition/
+/guide/exhibition/lists-and-locking
+/guide/exhibition/entries-and-printing
+```
+
+Add German **Messe** links in the same position and order under `/de/guide/exhibition/...`. Use the
+approved page titles as sidebar labels.
+
+- [ ] **Step 2: Add landing and vehicle-boundary transitions**
+
+Add one concise workflow paragraph to each User Guide landing page after Accessories. It must link
+to the new overview and name list preparation, operating entries, locks, address conflicts, and
+printing without duplicating the subpages.
+
+Add the exhibition overview to the related links of both vehicle core pages. The nearby boundary
+text already explains the vehicle **Exhibition** switch; the new link must lead to operational list
+handling without changing that existing behavior claim.
+
+- [ ] **Step 3: Finalize related links on all exhibition pages**
+
+Every exhibition page links to:
+
+- User Guide overview;
+- Exhibition workspace;
+- the other two exhibition pages where it is not the current page.
+
+The overview and entry page may link to Vehicle inventory only to explain the isolation boundary.
+Do not link to planned role administration, master data, backup/restore, Settings, layouts,
+deployment, or reference pages.
+
+- [ ] **Step 4: Verify navigation and commit Task 4**
+
+Run:
+
+```powershell
+cd docs
+npm.cmd run check
+cd ..
+git diff --check
+rg -n "/(de/)?guide/exhibition" docs/.vitepress/config.mts docs/site
+git status --short
+```
+
+Expected: 19 tests pass, coverage validation succeeds, VitePress builds every route, and all
+English/German paths appear. Commit only Task 4 files:
+
+```powershell
+git add docs/.vitepress/config.mts docs/site/guide/index.md docs/site/de/guide/index.md `
+  docs/site/guide/vehicles/index.md docs/site/de/guide/vehicles/index.md `
+  docs/site/guide/exhibition docs/site/de/guide/exhibition
+git commit -m "docs: publish exhibition user guide"
+```
+
+---
+
+### Task 5: Prove source fidelity, parity, and publication readiness
+
+**Files:**
+
+- Review: all task-owned files
+- Modify only when a verified finding requires correction
+
+**Why:** A polished guide is unsafe if it misstates combined roles, lock effects, required fields,
+address conflicts, persistence, deletion, or print behavior.
+
+**Change Necessity:** Review edits are allowed only for evidence-backed documentation defects and
+must remain inside the approved file boundary.
+
+**Impact/Compatibility:** No scope expansion. Any discovery owned by another coverage topic returns
+to design review instead of being absorbed.
+
+**Verification:** Complete stable-source audit, bilingual and hygiene scans, fresh documentation
+check, focused independent review, exact-head PR checks, merge workflows, and six live HTTP checks.
+
+- [ ] **Step 1: Run the complete stable-source audit**
+
+Check each claim against `v0.1.17.6` using `git show` and `git grep` over:
+
+```text
+frontend/src/app/App.tsx
+frontend/src/app/Shell.tsx
+frontend/src/features/exhibition/ExhibitionView.tsx
+frontend/src/features/exhibition/ExhibitionView.test.tsx
+frontend/src/shared/api.ts and related adapters/types
+frontend/src/shared/i18n/en.ts
+frontend/src/shared/i18n/de.ts
+frontend/src/shared/ui/AppSelect.tsx
+frontend/src/shared/functionSymbols.tsx
+backend/internal/api/exhibition.go
+backend/internal/api/routes.go
+backend/internal/application/exhibition.go
+backend/internal/application/exhibition_test.go
+backend migrations 0018, 0027, 0028, 0029, and 0036
+backend backup implementation/tests and stable OpenAPI paths
+```
+
+Audit route access, roles, list fields, defaults, sorting, lock behavior, deletion, audit events,
+entry fields, day normalization, master-data isolation, duplicate comparison, images, functions,
+view, printing, persistence, backup, partial refresh, and recovery. Correct every unsupported or
+incomplete statement.
+
+- [ ] **Step 2: Run bilingual and hygiene scans**
+
+Run:
+
+```powershell
+rg -n -i "\b(todo|tbd|placeholder|coming soon|incomplete)\b|noch zu dokumentieren|platzhalter" `
+  docs/site/guide/exhibition docs/site/de/guide/exhibition
+rg -n "^## " docs/site/guide/exhibition docs/site/de/guide/exhibition
+rg -n "reviewedVersion:|lastReviewed:|status:|audience:" `
+  docs/site/guide/exhibition docs/site/de/guide/exhibition
+git diff --check origin/main...HEAD
+```
+
+Expected: no unfinished markers; paired pages have matching semantic heading counts; all metadata
+uses user/stable/0.1.17.6/2026-08-16; whitespace is clean.
+
+Check non-table prose lines over 120 characters and wrap them:
+
+```powershell
+$files = Get-ChildItem docs/site/guide/exhibition,docs/site/de/guide/exhibition -Filter *.md
+foreach ($file in $files) {
+  $lineNumber = 0
+  Get-Content -LiteralPath $file.FullName | ForEach-Object {
+    $lineNumber++
+    if ($_.Length -gt 120 -and -not $_.StartsWith('|')) {
+      "{0}:{1}:{2}" -f $file.FullName,$lineNumber,$_.Length
+    }
+  }
+}
+```
+
+- [ ] **Step 3: Run full documentation verification**
+
+Run fresh:
+
+```powershell
+cd docs
+npm.cmd run check
+cd ..
+git diff --check origin/main...HEAD
+git status --short --branch
+```
+
+Expected: 19 tests pass, coverage validation succeeds, VitePress production build succeeds, diff
+check is clean, and the task worktree contains no uncommitted changes.
+
+- [ ] **Step 4: Request focused review and resolve findings**
+
+Use `aegis:requesting-code-review` for a read-only review of `origin/main...HEAD`. Require answers:
+
+1. Does every behavior claim match `v0.1.17.6` rather than later `main`?
+2. Are English and German semantically equivalent and UI labels exact?
+3. Is Messe versus Messe plus Admin authority exact in UI and server routes?
+4. Are list locks applied to create, update, and delete entry operations correctly?
+5. Are required fields, day normalization, and duplicate address comparisons exact?
+6. Are image and function edits correctly described as form state until entry save?
+7. Are list and entry writes, refresh failures, and retry guidance safe?
+8. Are view and print data, image option, layout, and browser-print behavior exact?
+9. Are planned-administration, vehicle, backup, and layout boundaries preserved?
+
+Correct valid findings, rerun focused checks, and obtain a clean re-review. Commit corrections only
+when files changed:
+
+```powershell
+git add docs/coverage.json docs/.vitepress/config.mts `
+  docs/site/guide/exhibition docs/site/de/guide/exhibition `
+  docs/site/guide/index.md docs/site/de/guide/index.md `
+  docs/site/guide/vehicles/index.md docs/site/de/guide/vehicles/index.md
+git commit -m "docs: refine exhibition user guide"
+```
+
+- [ ] **Step 5: Push, open the PR, and verify the reviewed head**
+
+Run:
+
+```powershell
+git push -u origin dev/docs-user-guide-exhibition
+gh pr create --base main --head dev/docs-user-guide-exhibition `
+  --title "docs: add bilingual exhibition guide" `
+  --body "Publishes the complete stable v0.1.17.6 exhibition guide in English and German."
+gh pr checks --watch
+```
+
+Record `git rev-parse HEAD`. Do not merge if a check is failing, pending, or ran against another
+SHA.
+
+- [ ] **Step 6: Merge only when green and verify publication**
+
+After all required checks pass for the reviewed head:
+
+```powershell
+gh pr merge --merge
+$mergeSha = gh pr view --json mergeCommit --jq '.mergeCommit.oid'
+gh run list --commit $mergeSha --limit 20 `
+  --json databaseId,workflowName,status,conclusion,url
+```
+
+Wait for merge-triggered CI, CodeQL, Trivy, Documentation Pages, and Docker Image. All must finish
+successfully. After Documentation Pages succeeds, verify these routes return HTTP 200 and contain
+`v0.1.17.6`:
+
+```text
+https://ichwars.github.io/RailKeeper/guide/exhibition/
+https://ichwars.github.io/RailKeeper/guide/exhibition/lists-and-locking
+https://ichwars.github.io/RailKeeper/guide/exhibition/entries-and-printing
+https://ichwars.github.io/RailKeeper/de/guide/exhibition/
+https://ichwars.github.io/RailKeeper/de/guide/exhibition/lists-and-locking
+https://ichwars.github.io/RailKeeper/de/guide/exhibition/entries-and-printing
+```
+
+Preserve the completed worktree for traceability unless the user later requests cleanup. Local
+`main` and its user-owned untracked files remain untouched.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Later `main` behavior leaks into stable docs | Resolve every claim against `v0.1.17.6`. |
+| Admin alone is described as workspace-capable | State the stable Messe route requirement and combined role. |
+| Locked lists appear partially writable | Audit all entry mutations in UI and application service. |
+| Pure Messe appears to access general inventory | Explain the isolated master-data boundary exactly. |
+| Duplicate warnings are described as advisory | Verify and state their save-blocking behavior. |
+| Image or function edits appear immediately stored | Separate form state from successful entry save. |
+| Browser print output is overpromised | Document report layout and browser/printer variability. |
+| Planned administration pages become visible | Link only to existing published destinations. |
+| Generated output enters Git | Inspect status and stage explicit task-owned paths only. |
+| PR merges a stale review | Record head SHA and require checks on that exact head. |
+
+## Retirement and rollback
+
+No runtime path, adapter, compatibility layer, or old documentation owner is introduced. Rollback
+is a normal revert of the documentation commits. Reverting must restore `exhibition` to `planned`,
+remove all six pages and sidebar/landing links together, and leave other coverage owners intact.
+
+## Expected completion evidence
+
+- `exhibition` is `documented` with its existing overview paths;
+- all three English/German page pairs exist with stable metadata and mirrored content;
+- navigation and published cross-links reach every page;
+- every stable claim has a `v0.1.17.6` source owner;
+- local documentation checks pass from a clean task worktree;
+- focused review has no unresolved findings;
+- the exact reviewed PR head has all required checks green;
+- the PR is merged and all six live pages return HTTP 200;
+- local `main` and user-owned untracked files remain unchanged.
+
+## Execution Route
+
+- Decision: inline
+- Evidence: the tasks share one documentation owner and several pages are linked by later wiring;
+  current policy does not authorize subagent delegation for this request
+- Fallback: pause at the failing task boundary, preserve the worktree, and report exact evidence
+- User confirmation required: no

--- a/docs/superpowers/plans/2026-08-16-railkeeper-exhibition-guide.md
+++ b/docs/superpowers/plans/2026-08-16-railkeeper-exhibition-guide.md
@@ -481,9 +481,8 @@ and one scoped commit.
 Confirm from `v0.1.17.6`:
 
 - required fields are owner and locomotive designation;
-- optional general fields are manufacturer, type, class, epoch, railway company, DT state, DCC
-  address, SX address, decoder type, adapter/interface, analog state, day scope, features, notes,
-  and any stable vehicle link behavior;
+- optional general fields are manufacturer, type, class, epoch, railway company, DCC address, SX
+  address, decoder type, adapter/interface, analog state, day scope, and notes;
 - day scope normalizes no selection or all four individual days to `all`;
 - DCC and SX conflicts compare trimmed lowercase values inside the selected list and exclude the
   edited entry;
@@ -497,8 +496,8 @@ Confirm from `v0.1.17.6`:
 - earlier plain-text function values are parsed when stable code supports them;
 - entry create/update require an open list; entry deletion additionally requires Admin and
   confirmation;
-- initial entry sort is owner ascending; sortable keys are owner, locomotive name, DT state,
-  decoder number, and function keys;
+- initial entry sort is owner ascending; sortable keys are owner, locomotive name, decoder number,
+  and function keys;
 - detail view and report fetch current list entries before display;
 - report output is A4 landscape and optionally includes images, with browser print handling;
 - save, stale list, lock, image-read, detail-load, and print-load failures have safe recovery text.
@@ -564,8 +563,8 @@ lastReviewed: 2026-08-16
 # Einträge und Drucken
 ```
 
-Use exact stable labels for **Allgemein**, **Bilder upload**, **Funktionstasten**, **DT vorhanden**,
-**Adresse DCC**, **Adresse SX**, **Mit Bildern drucken**, and all save/delete confirmations.
+Use exact stable labels for **Allgemein**, **Bilder upload**, **Funktionstasten**, **Adresse DCC**,
+**Adresse SX**, **Mit Bildern drucken**, and all save/delete confirmations.
 
 - [ ] **Step 4: Verify and commit Task 3**
 

--- a/docs/superpowers/plans/2026-08-16-railkeeper-exhibition-guide.md
+++ b/docs/superpowers/plans/2026-08-16-railkeeper-exhibition-guide.md
@@ -44,7 +44,7 @@ checks for every English and German page.
 ## Plan basis and readiness
 
 **Aegis Visibility:** Planning is useful because six new pages must remain semantically paired
-while describing combined roles, list locks, duplicate addresses, entry persistence, and print
+while describing Messe and Admin roles, list locks, duplicate addresses, entry persistence, and print
 behavior without leaking planned administration or later-development behavior.
 
 **BaselineUsageDraft:**
@@ -125,7 +125,7 @@ behavior without leaking planned administration or later-development behavior.
 - Intent Lock: document every stable user-facing exhibition workflow in English and German
 - Scope Fence: documentation and navigation only, no product or API changes
 - Baseline Lock: behavior claims must resolve to tag `v0.1.17.6`
-- Approved Behavior: three-page task-oriented structure and combined-role model from the design
+- Approved Behavior: three-page task-oriented structure and role model from the corrected design
 - Owner/Contract Constraints: promote only `exhibition`; preserve all other coverage owners
 - Compatibility Boundary: do not publish planned administration, layouts, or later `main`
 - Retirement Boundary: no old path, adapter, fallback, or compatibility layer
@@ -146,7 +146,7 @@ behavior without leaking planned administration or later-development behavior.
 - Keep English and German pages in the same semantic section order.
 - Use exact UI labels from the matching stable locale.
 - State whether each operation changes dialog state, writes immediately, or only reads data.
-- Treat Messe as the workspace role and Messe plus Admin as the list-management combination.
+- Treat Messe as the isolated operating role and Admin as the direct list-management role.
 - State confirmations, lock effects, failed-refresh behavior, and recovery precisely.
 - Do not document role assignment, master-data administration, backup operation, deployment, or
   the layout workspace as published in this chapter.
@@ -280,7 +280,7 @@ lastReviewed: 2026-08-16
 ## Documented RailKeeper version
 ```
 
-Include the confirmed role combination, two-panel relationship, sort defaults, action visibility,
+Include the confirmed Messe/Admin role split, two-panel relationship, sort defaults, action visibility,
 lock boundary, empty states, immediate-write boundary, and transitions to the two subpages. Keep
 field-level and list-admin detail on their focused pages.
 
@@ -333,7 +333,7 @@ git commit -m "docs: add exhibition workspace guide"
 - Create: `docs/site/guide/exhibition/lists-and-locking.md`
 - Create: `docs/site/de/guide/exhibition/lists-and-locking.md`
 
-**Why:** Combined Messe and Admin accounts need a precise preparation workflow whose lock and
+**Why:** Admin accounts need a precise preparation workflow whose lock and
 deletion effects remain predictable for operators.
 
 **Change Necessity:** The overview is intentionally a hub. This focused pair prevents Admin-only
@@ -383,7 +383,7 @@ lastReviewed: 2026-08-16
 
 # Lists and locking
 
-## Required role combination
+## Roles for operation and administration
 
 ## Create a list
 
@@ -669,7 +669,7 @@ git commit -m "docs: publish exhibition user guide"
 - Review: all task-owned files
 - Modify only when a verified finding requires correction
 
-**Why:** A polished guide is unsafe if it misstates combined roles, lock effects, required fields,
+**Why:** A polished guide is unsafe if it misstates roles, lock effects, required fields,
 address conflicts, persistence, deletion, or print behavior.
 
 **Change Necessity:** Review edits are allowed only for evidence-backed documentation defects and
@@ -760,7 +760,7 @@ Use `aegis:requesting-code-review` for a read-only review of `origin/main...HEAD
 
 1. Does every behavior claim match `v0.1.17.6` rather than later `main`?
 2. Are English and German semantically equivalent and UI labels exact?
-3. Is Messe versus Messe plus Admin authority exact in UI and server routes?
+3. Is Messe versus Admin authority exact in UI and server routes?
 4. Are list locks applied to create, update, and delete entry operations correctly?
 5. Are required fields, day normalization, and duplicate address comparisons exact?
 6. Are image and function edits correctly described as form state until entry save?
@@ -826,7 +826,7 @@ Preserve the completed worktree for traceability unless the user later requests 
 | Risk | Mitigation |
 | --- | --- |
 | Later `main` behavior leaks into stable docs | Resolve every claim against `v0.1.17.6`. |
-| Admin alone is described as workspace-capable | State the stable Messe route requirement and combined role. |
+| Admin is incorrectly described as needing Messe | State Admin's stable direct UI and server access. |
 | Locked lists appear partially writable | Audit all entry mutations in UI and application service. |
 | Pure Messe appears to access general inventory | Explain the isolated master-data boundary exactly. |
 | Duplicate warnings are described as advisory | Verify and state their save-blocking behavior. |

--- a/docs/superpowers/plans/2026-08-16-railkeeper-exhibition-guide.md
+++ b/docs/superpowers/plans/2026-08-16-railkeeper-exhibition-guide.md
@@ -357,7 +357,8 @@ check, and one scoped commit.
 Use `git show` and `git grep` on tag `v0.1.17.6` to confirm:
 
 - designation and date are required and normalized by the stable service;
-- new lists default to today's local date in the UI;
+- new lists default to the browser-generated UTC calendar date; users must verify it near local
+  midnight;
 - create, edit, lock, unlock, and list deletion require Admin on the server;
 - normal workspace access still requires Messe in the stable UI;
 - locking preserves reading, viewing, and printing but rejects entry mutations;

--- a/docs/superpowers/specs/2026-08-16-railkeeper-exhibition-guide-design.md
+++ b/docs/superpowers/specs/2026-08-16-railkeeper-exhibition-guide-design.md
@@ -29,7 +29,8 @@ The section owns these stable user workflows:
 - creating, editing, locking, unlocking, and deleting exhibition lists;
 - creating, editing, and deleting exhibition entries;
 - entry owner, locomotive identity, technical, address, day, image, function, and notes fields;
-- optional inventory master-data choices available through combined roles;
+- optional inventory master-data choices available to Admin or through a Messe account combined
+  with an inventory-capable role;
 - DCC and SX address-conflict detection within the selected list;
 - day scopes for all days or selected days one through four;
 - image upload, image links, preview, replacement, and removal;
@@ -125,8 +126,8 @@ The list page documents:
 - server rejection of stale, missing, invalid, unauthorized, or locked resources;
 - refresh and retry guidance after a failed operation.
 
-The text states that an Admin role without Messe does not by itself expose the exhibition route in
-the stable UI. Administrative operation therefore requires a suitable combined role assignment.
+The text states that Admin receives direct access to the exhibition route and all list-management
+controls. Messe receives the isolated operating workspace without Admin-only list management.
 
 ## Page 3: Entries and printing
 
@@ -172,7 +173,7 @@ The page also explains:
 
 The section uses one explicit role matrix:
 
-| Capability | Messe | Messe + Admin |
+| Capability | Messe | Admin |
 | --- | --- | --- |
 | Open the exhibition workspace | Yes | Yes |
 | Read lists and entries | Yes | Yes |
@@ -183,9 +184,9 @@ The section uses one explicit role matrix:
 | Delete entries from an open list | No | Yes |
 | Delete lists | No | Yes |
 
-An account with Admin but without Messe is not described as having normal UI access to the
-workspace. Other combined roles may make general inventory master-data options available inside
-the entry dialog, but they do not replace Messe as the exhibition-workspace role.
+Admin has normal UI and server access to the workspace without an additional Messe role. A Messe
+account combined with Viewer, Editor, or Planner may receive general inventory master-data options
+inside the entry dialog, but those roles do not grant Admin-only list management.
 
 The stable UI and server route checks are both audited. Where visible controls and server authority
 differ, the guide treats the server rule as authoritative and names the stable UI limitation.
@@ -293,5 +294,5 @@ Verification includes:
 Exhibition operators can prepare and use a list without entering the general inventory workspace.
 They know which list they are changing, whether it is open, which operating details belong to each
 locomotive, how address conflicts are prevented, and how to produce a useful printed report.
-Administrators understand that list management requires a Messe-capable account plus Admin and can
-lock or remove lists without obscuring the effect on entry maintenance.
+Administrators understand their direct access and can manage, lock, or remove lists without
+obscuring the effect on entry maintenance.

--- a/docs/superpowers/specs/2026-08-16-railkeeper-exhibition-guide-design.md
+++ b/docs/superpowers/specs/2026-08-16-railkeeper-exhibition-guide-design.md
@@ -1,0 +1,297 @@
+# RailKeeper Exhibition Guide Design
+
+Date: 2026-08-16
+
+Status: Approved in conversation
+Documented release: `v0.1.17.6`
+
+## Objective
+
+Publish a complete English and German user-guide section for RailKeeper's stable exhibition
+workspace. The section guides exhibition operators through the full working sequence:
+
+1. select an exhibition list and understand its state;
+2. add or maintain locomotive entries while the list is open;
+3. detect address conflicts and complete operating details;
+4. review, sort, and print the finished list;
+5. let an authorized administrator prepare, lock, reopen, or remove lists.
+
+The Messe role is the primary audience. Additional Admin capabilities are identified at the point
+where they affect the workflow. The guide explains every stable user-facing action in this scope
+without implying access to the general inventory or to unpublished layout features.
+
+## Scope
+
+The section owns these stable user workflows:
+
+- exhibition workspace access and isolation from general inventory;
+- list selection, status, entry counts, sorting, viewing, and printing;
+- creating, editing, locking, unlocking, and deleting exhibition lists;
+- creating, editing, and deleting exhibition entries;
+- entry owner, locomotive identity, technical, address, day, image, function, and notes fields;
+- optional inventory master-data choices available through combined roles;
+- DCC and SX address-conflict detection within the selected list;
+- day scopes for all days or selected days one through four;
+- image upload, image links, preview, replacement, and removal;
+- function keys F0 through F31, names, types, and symbols;
+- read-only list view and report printing with or without images;
+- open and locked states, confirmation steps, empty states, and request failures;
+- the exact stable interaction of Messe and Admin authority;
+- local persistence and backup ownership of exhibition lists and entries.
+
+## Non-goals
+
+The section does not explain:
+
+- general vehicle inventory, vehicle editing, or vehicle import;
+- administration of manufacturers, epochs, railway companies, types, or function symbols;
+- user creation, role assignment, sessions, or authentication administration;
+- backup and restore operation beyond accurately stating exhibition-data ownership;
+- the unpublished layout workspace;
+- printer installation, operating-system print settings, or deployment configuration;
+- cloud synchronization, public sharing, or later development features.
+
+Already published vehicle or user-guide pages may be linked where they clarify a boundary. Planned
+administration and reference pages are not exposed as active navigation destinations.
+
+## Source and compatibility boundary
+
+Behavior claims come from the stable `v0.1.17.6` tag, not from later `main` development. Primary
+source owners include:
+
+- `frontend/src/features/exhibition/ExhibitionView.tsx` and its stable tests;
+- `frontend/src/styles/exhibition.css` for responsive and print-related presentation behavior;
+- exhibition translations in `frontend/src/shared/i18n/en.ts` and `de.ts`;
+- stable app routing, navigation, role gating, API adapters, selects, date input, and function
+  symbol helpers;
+- `backend/internal/application/exhibition.go` and its tests;
+- `backend/internal/api/exhibition.go`, route definitions, role tests, and audit behavior;
+- exhibition migrations, OpenAPI operations, vehicle exhibition-flag maintenance, and stable backup
+  coverage.
+
+Later exhibition changes on `main` must not be described unless they are already present in
+`v0.1.17.6`.
+
+## Information architecture
+
+Create a mirrored three-page section:
+
+- overview and operating sequence: `guide/exhibition/index.md` and
+  `de/guide/exhibition/index.md`;
+- list administration and locking: `guide/exhibition/lists-and-locking.md` and
+  `de/guide/exhibition/lists-and-locking.md`;
+- entries, validation, and printing: `guide/exhibition/entries-and-printing.md` and
+  `de/guide/exhibition/entries-and-printing.md`.
+
+Suggested titles:
+
+- **Exhibition workspace** / **Messearbeitsbereich**;
+- **Lists and locking** / **Listen und Sperren**;
+- **Entries and printing** / **Einträge und Drucken**.
+
+Every page uses the established user-guide frontmatter contract, names stable version
+`v0.1.17.6`, uses matching English and German section order, and states the review date as
+2026-08-16.
+
+## Page 1: Exhibition workspace
+
+The overview page introduces the workspace and explains:
+
+- why the Messe role opens a dedicated operational area instead of general inventory;
+- the two-panel layout for exhibition lists and entries;
+- list columns for designation, date, entry count, status, and actions;
+- entry columns, selection, stable sorting, and responsive behavior;
+- the complete sequence from list preparation through entry maintenance, locking, and printing;
+- which controls are always available, which require an open list, and which require Admin;
+- loading, no-list, no-selection, no-entry, and request-error states;
+- the relationship between a selected list and the entries shown beside it.
+
+The page acts as the coverage destination and hub for the two focused subpages. It does not repeat
+their field-by-field or administrative details.
+
+## Page 2: Lists and locking
+
+The list page documents:
+
+- the requirement for a Messe-capable account to open the workspace;
+- the additional Admin authority required for list management;
+- list designation and date validation;
+- creation and editing through the stable dialog and **Save** action;
+- sorting by designation, date, entry count, and lock status;
+- read-only list viewing and printing for Messe users;
+- locking an open list and unlocking a locked list;
+- the effect of a lock on entry creation, editing, and deletion;
+- list deletion, its confirmation, and cascading consequences verified against stable behavior;
+- server rejection of stale, missing, invalid, unauthorized, or locked resources;
+- refresh and retry guidance after a failed operation.
+
+The text states that an Admin role without Messe does not by itself expose the exhibition route in
+the stable UI. Administrative operation therefore requires a suitable combined role assignment.
+
+## Page 3: Entries and printing
+
+The entries page documents the stable entry dialog in its three tabs:
+
+### General
+
+- required owner and locomotive designation;
+- manufacturer, type, class, epoch, and railway company;
+- all-days or selected-day scope for days one through four;
+- DT availability, DCC address, SX address, decoder type, adapter or interface, and analog state;
+- number, lettering, features, and notes;
+- exact behavior when optional master-data lists are unavailable to a pure Messe account.
+
+### Image upload
+
+- one image source per entry;
+- local upload or image link;
+- preview, replacement, and removal;
+- the fact that a selected image remains part of the entry form until **Save** succeeds;
+- safe user guidance for external links without presenting remote content as trusted data.
+
+### Function keys
+
+- keys F0 through F31;
+- default F0 light behavior;
+- function name, type, and optional symbol;
+- which configured functions appear in the table, detail view, and print report;
+- stable handling of earlier plain-text function-key data where visible.
+
+The page also explains:
+
+- creating and editing entries only while the selected list is open;
+- deleting entries only with Admin authority and confirmation;
+- DCC and SX duplicate detection within the current list, excluding the entry being edited;
+- case- and whitespace-normalized address comparison;
+- sorting by owner, locomotive designation, DT state, decoder number, and function keys;
+- the read-only detail view;
+- the print dialog, **Print with images** option, A4 landscape report, empty report state, function
+  symbols, and final browser print dialog.
+
+## Roles and permissions
+
+The section uses one explicit role matrix:
+
+| Capability | Messe | Messe + Admin |
+| --- | --- | --- |
+| Open the exhibition workspace | Yes | Yes |
+| Read lists and entries | Yes | Yes |
+| View and print a list | Yes | Yes |
+| Add or edit entries in an open list | Yes | Yes |
+| Create or edit lists | No | Yes |
+| Lock or unlock lists | No | Yes |
+| Delete entries from an open list | No | Yes |
+| Delete lists | No | Yes |
+
+An account with Admin but without Messe is not described as having normal UI access to the
+workspace. Other combined roles may make general inventory master-data options available inside
+the entry dialog, but they do not replace Messe as the exhibition-workspace role.
+
+The stable UI and server route checks are both audited. Where visible controls and server authority
+differ, the guide treats the server rule as authoritative and names the stable UI limitation.
+
+## Locking, validation, and persistence
+
+Lists and entries are separate immediate server writes. The guide distinguishes:
+
+| State | Persistence |
+| --- | --- |
+| List or entry form edits | Dialog state until **Save** succeeds |
+| Saved list fields or lock state | Immediate server write |
+| Saved entry, image data, and function data | Immediate server write |
+| View or print options | Temporary browser state |
+
+Required values, date parsing, day normalization, address conflicts, list locks, and role checks are
+documented from stable behavior. A duplicate address warning prevents saving until the conflict is
+resolved. A lock prevents all entry mutations, including an Admin deletion, until the list is
+unlocked.
+
+The guide does not claim that a later reload failure rolls back a successful earlier write. It
+instructs users to reload the list and verify the stored state before retrying an uncertain action.
+
+## Empty, partial, and error states
+
+The pages cover at least:
+
+- workspace loading and list-loading failure;
+- no lists, no selected list, and no entries;
+- invalid or missing designation, date, owner, or locomotive designation;
+- missing optional master-data choices for isolated Messe accounts;
+- duplicate DCC or SX address;
+- invalid, missing, stale, or locked lists;
+- save, delete, lock, unlock, detail-load, and print-data load failures;
+- a list becoming locked while an entry dialog is open;
+- failed image reading or unavailable external image links;
+- empty function configuration and legacy function text;
+- unauthorized list management or entry deletion;
+- browser print cancellation or printer-specific output differences.
+
+Stable German-only errors visible in the English locale are identified as localization limitations,
+not translated into behavior that the UI does not provide.
+
+## Storage and backup
+
+Saved exhibition lists and entries belong to local RailKeeper application data and are included in
+the stable app backup. Entry images stored directly with an entry and serialized function settings
+follow that entry's persistence. Print options and unsaved dialog changes are not backup data.
+
+The guide recommends a current validated backup before deleting a populated exhibition list or
+performing extensive corrections. It does not duplicate the planned backup-and-restore manual.
+
+## Navigation and cross-links
+
+Add an **Exhibition** / **Messe** group to both user-guide sidebars after Accessories. The group
+links to the overview and its two subpages.
+
+Add the exhibition overview to both User Guide landing pages. Add related-page links among the
+three exhibition pages and from relevant already published pages. Link only to existing published
+owners, including:
+
+- User Guide overview;
+- vehicle inventory and core records where the exhibition boundary needs clarification;
+- Accessories only when distinguishing operational lists from accessory allocations.
+
+Do not create active links to planned Settings, role administration, master-data, backup/restore,
+deployment, layout, or reference pages.
+
+## Coverage contract
+
+Change only the `exhibition` topic from `planned` to `documented`. Preserve its established
+coverage destination and ownership:
+
+- frontend route `/exhibition`;
+- translations below `exhibition`;
+- API prefixes below `/api/v1/exhibition-lists`.
+
+The primary English and German coverage paths remain the overview pair. The two additional page
+pairs are children of that documented topic.
+
+If the stable source inventory exposes a user-facing exhibition API outside the existing prefix
+mapping, update the owner map only when required for accurate validation and when it remains inside
+the `exhibition` topic. Do not absorb user administration, master data, vehicle, or layout owners.
+
+## Verification and review
+
+Verification includes:
+
+1. a stable-tag audit for route access, lists, entries, fields, defaults, validation, sorting,
+   locking, deletion, images, functions, printing, persistence, audit, and backup;
+2. matching English and German frontmatter, page structure, tables, warnings, and cross-links;
+3. an intentional missing-page validation failure after changing the coverage status;
+4. route, navigation, unfinished-marker, internal-link, line-length, and whitespace scans;
+5. `npm.cmd run check` from `docs`, including unit tests, coverage validation, and the VitePress
+   production build;
+6. independent read-only review of stable-source fidelity, bilingual parity, role boundaries,
+   lock behavior, duplicate detection, persistence, printing, and recovery guidance;
+7. correction and focused re-review of every valid finding;
+8. a pull request from the isolated branch only;
+9. merge only when all required checks pass for the reviewed head;
+10. post-merge verification of all six English and German GitHub Pages routes.
+
+## Expected outcome
+
+Exhibition operators can prepare and use a list without entering the general inventory workspace.
+They know which list they are changing, whether it is open, which operating details belong to each
+locomotive, how address conflicts are prevented, and how to produce a useful printed report.
+Administrators understand that list management requires a Messe-capable account plus Admin and can
+lock or remove lists without obscuring the effect on entry maintenance.

--- a/docs/superpowers/specs/2026-08-16-railkeeper-exhibition-guide-design.md
+++ b/docs/superpowers/specs/2026-08-16-railkeeper-exhibition-guide-design.md
@@ -138,7 +138,7 @@ The entries page documents the stable entry dialog in its three tabs:
 - required owner and locomotive designation;
 - manufacturer, type, class, epoch, and railway company;
 - all-days or selected-day scope for days one through four;
-- DT availability, DCC address, SX address, decoder type, adapter or interface, and analog state;
+- DCC address, SX address, decoder type, adapter or interface, and analog state;
 - number, lettering, features, and notes;
 - exact behavior when optional master-data lists are unavailable to a pure Messe account.
 
@@ -164,7 +164,7 @@ The page also explains:
 - deleting entries only with Admin authority and confirmation;
 - DCC and SX duplicate detection within the current list, excluding the entry being edited;
 - case- and whitespace-normalized address comparison;
-- sorting by owner, locomotive designation, DT state, decoder number, and function keys;
+- sorting by owner, locomotive designation, decoder number, and function keys;
 - the read-only detail view;
 - the print dialog, **Print with images** option, A4 landscape report, empty report state, function
   symbols, and final browser print dialog.


### PR DESCRIPTION
## Summary

- publishes a complete three-page Exhibition user guide in English and German
- documents stable v0.1.17.6 roles, list locks, entry fields, address conflicts, images, function keys, and printing
- adds mirrored navigation, cross-links, and coverage ownership

## User impact

Messe operators and administrators can now find the complete stable exhibition workflow from the main user guide and vehicle documentation.

## Validation

- `npm.cmd run check`
- 19/19 documentation tests passed
- coverage validation passed
- VitePress production build passed
- all six generated routes contain the v0.1.17.6 marker
- source-fidelity review against tag `v0.1.17.6`
- `git diff --check origin/main...HEAD`
