### PR TITLE
Prepare v0.1.18 release

### DIFF
--- a/CHANGELOG.de.md
+++ b/CHANGELOG.de.md
@@ -6,6 +6,45 @@ Diese Datei dokumentiert alle wesentlichen Änderungen an RailKeeper.
 
 ## Unveröffentlicht
 
+## [0.1.18] - 2026-08-16
+
+### Hinzugefügt
+
+- Die Fahrzeugübersicht bietet pro Benutzer gespeicherte Spaltenauswahl und -reihenfolge,
+  zusätzliche Bestandsfilter, eine erweiterte Suche sowie kompakte, aufklappbare Mobilkarten.
+- Fahrzeuge erfassen jetzt Erwerb, Kaufpreis und -datum, Lagerung, Zustand und Verpackung. Listen-
+  und Kaufwerte werden für Fahrzeuge und Zubehör getrennt ausgewertet und in der Übersicht
+  nachvollziehbar zusammengefasst.
+- Stammdaten können sicher deaktiviert, reaktiviert und nur dann gelöscht werden, wenn keine
+  fachlichen Referenzen bestehen. Herkunft und Status bleiben in Exporten und Sicherungen erhalten.
+- Die Windows-Standalone-Ausgabe kann verfügbare Versionen anzeigen und das passende ZIP direkt
+  herunterladen. Die Anwendung schützt bestehende Installationen durch dauerhafte Datenpfade,
+  validierte SQLite-Sicherungen und automatische Sicherungskopien vor Migrationen.
+- Das zweisprachige RailKeeper-Handbuch dokumentiert Einrichtung, Übersicht, Fahrzeuge, Wartung,
+  Medien, Decoder/CV, Suche, Zubehör und Ausstellungsbetrieb.
+
+### Geändert
+
+- CSV-Import und -Export umfassen alle skalaren Fahrzeugfelder. Eindeutige deutsche und englische
+  Überschriften, zusätzliche Aliase und die bestehende Änderungsvorschau ermöglichen einen
+  verlustfreien RailKeeper-CSV-Rundlauf.
+- Die Fahrzeugübersicht unterstützt `PluX12`; Aktionsmenüs bleiben in Tabellen- und Mobilansichten
+  sichtbar und tastaturbedienbar.
+
+### Behoben
+
+- Kennzahlen der Übersicht bleiben auf breiten Ansichten in einer gemeinsamen Zeile.
+- Fahrzeug-Kurzmenüs werden nicht mehr an Tabellen- oder Bildschirmrändern verdeckt.
+- Windows-Aktualisierungen trennen Programmpaket und Benutzerdaten, statt Daten im
+  Installationsordner durch entpackte Dateien zu gefährden.
+
+### Sicherheit
+
+- Vor Datenbankmigrationen wird eine konsistente SQLite-Sicherung erstellt; unsichere oder
+  mehrdeutige Windows-Datenpfade blockieren den Start mit einer verständlichen Diagnose.
+- Stammdatenimporte und -änderungen bewahren referenzierte historische Werte und erzwingen die
+  serverseitigen Lebenszyklusregeln.
+
 ## [0.1.17.6] - 2026-08-15
 
 ### Geändert
@@ -188,6 +227,7 @@ Diese Datei dokumentiert alle wesentlichen Änderungen an RailKeeper.
 - Die Vorprüfung der Backup-Wiederherstellung bleibt konservativ, Authentifizierungsdaten bleiben
   aus Exporten ausgeschlossen.
 
+[0.1.18]: https://github.com/ichwars/RailKeeper/compare/v0.1.17.6...v0.1.18
 [0.1.17.6]: https://github.com/ichwars/RailKeeper/compare/v0.1.17.5...v0.1.17.6
 [0.1.17.5]: https://github.com/ichwars/RailKeeper/compare/v0.1.17.4...v0.1.17.5
 [0.1.17.4]: https://github.com/ichwars/RailKeeper/compare/v0.1.17.3...v0.1.17.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,44 @@ All notable changes to RailKeeper are documented in this file.
 
 ## Unreleased
 
+## [0.1.18] - 2026-08-16
+
+### Added
+
+- The vehicle inventory now provides per-user column visibility and ordering, additional inventory
+  filters, expanded search, and compact expandable mobile cards.
+- Vehicles now record acquisition, purchase price and date, storage, condition, and packaging.
+  Vehicle and accessory list and purchase values are evaluated separately and summarized clearly
+  on the overview.
+- Master data can be deactivated, reactivated, and deleted only when no domain references remain.
+  Origin and lifecycle state survive exports and backups.
+- The Windows standalone build can show available versions and download the matching ZIP directly.
+  Persistent data paths, validated SQLite snapshots, and automatic pre-migration backups protect
+  existing installations.
+- The bilingual RailKeeper handbook now documents setup, overview, vehicles, maintenance, media,
+  decoder/CV data, search, accessories, and exhibition operation.
+
+### Changed
+
+- CSV import and export cover every scalar vehicle field. Unambiguous German and English headers,
+  additional aliases, and the existing change preview provide a lossless RailKeeper CSV round trip.
+- The vehicle inventory supports `PluX12`; action menus remain visible and keyboard-accessible in
+  table and mobile views.
+
+### Fixed
+
+- Overview metrics remain on a single row on wide screens.
+- Vehicle quick menus are no longer obscured at table or viewport edges.
+- Windows updates separate the program package from user data instead of risking data stored inside
+  an overwritten installation directory.
+
+### Security
+
+- A consistent SQLite snapshot is created before database migrations; unsafe or ambiguous Windows
+  data paths block startup with an actionable diagnostic.
+- Master-data imports and changes preserve referenced historical values and enforce lifecycle rules
+  on the server.
+
 ## [0.1.17.6] - 2026-08-15
 
 ### Changed
@@ -176,6 +214,7 @@ All notable changes to RailKeeper are documented in this file.
 - Tightened API validation and protected master-data import invariants.
 - Kept backup restore preflight conservative and authentication data excluded from exports.
 
+[0.1.18]: https://github.com/ichwars/RailKeeper/compare/v0.1.17.6...v0.1.18
 [0.1.17.6]: https://github.com/ichwars/RailKeeper/compare/v0.1.17.5...v0.1.17.6
 [0.1.17.5]: https://github.com/ichwars/RailKeeper/compare/v0.1.17.4...v0.1.17.5
 [0.1.17.4]: https://github.com/ichwars/RailKeeper/compare/v0.1.17.3...v0.1.17.4

--- a/README.de.md
+++ b/README.de.md
@@ -149,7 +149,7 @@ SQLite-Datenbank, Uploads und lokale Dateien bleiben im Docker-Volume `railkeepe
 Um statt `latest` ein bestimmtes Release festzulegen, trage Folgendes in `.env` ein:
 
 ```env
-RAILKEEPER_IMAGE=ghcr.io/ichwars/railkeeper:v0.1.17.6
+RAILKEEPER_IMAGE=ghcr.io/ichwars/railkeeper:v0.1.18
 ```
 
 Wenn du bewusst den ausgecheckten Quellstand bauen möchtest, verwende:

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ The SQLite database, uploads and local files stay in the `railkeeper_data` Docke
 To pin a specific release instead of `latest`, set this in `.env`:
 
 ```env
-RAILKEEPER_IMAGE=ghcr.io/ichwars/railkeeper:v0.1.17.6
+RAILKEEPER_IMAGE=ghcr.io/ichwars/railkeeper:v0.1.18
 ```
 
 If you intentionally want to build the checked-out source tree, use:

--- a/backend/cmd/railkeeper/main.go
+++ b/backend/cmd/railkeeper/main.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	version               = "0.1.17.6"
+	version               = "0.1.18"
 	defaultUpdateCheckURL = "https://api.github.com/repos/ichwars/RailKeeper/releases/latest"
 )
 

--- a/docs/releases/v0.1.18.md
+++ b/docs/releases/v0.1.18.md
@@ -1,0 +1,38 @@
+# RailKeeper v0.1.18
+
+## Deutsch
+
+RailKeeper 0.1.18 erweitert den Fahrzeugbestand um konfigurierbare Spalten, präzisere Suche und
+Filter sowie eine kompakte Mobilansicht. Neue Betriebs-, Erwerbs-, Lager- und Zustandsdaten fließen
+gemeinsam mit getrennten Listen- und Kaufwerten für Fahrzeuge und Zubehör in die Übersicht ein.
+
+CSV-Import und -Export decken jetzt alle skalaren Fahrzeugfelder mit eindeutigen Überschriften,
+Alias-Erkennung und Änderungsvorschau ab. Stammdaten erhalten einen sicheren Lebenszyklus für
+Deaktivierung, Reaktivierung und referenzgeschützte Löschung.
+
+Windows-Standalone-Installationen können neue Versionen direkt als ZIP herunterladen. Das Paket
+enthält keine Benutzerdaten. RailKeeper verwendet dauerhafte Datenpfade und erstellt vor
+Datenbankmigrationen konsistente Sicherungskopien, damit ein Überschreiben des Programmordners die
+bestehende Datenbank nicht ersetzt.
+
+Weitere Details stehen im
+[deutschen Änderungsprotokoll](https://github.com/ichwars/RailKeeper/blob/v0.1.18/CHANGELOG.de.md).
+
+## English
+
+RailKeeper 0.1.18 expands vehicle inventory with configurable columns, more precise search and
+filters, and a compact mobile view. New operational, acquisition, storage, and condition data feed
+into the overview together with separate list and purchase values for vehicles and accessories.
+
+CSV import and export now cover all scalar vehicle fields with unambiguous headers, alias detection,
+and a change preview. Master data gains a safe lifecycle for deactivation, reactivation, and
+reference-protected deletion.
+
+Windows standalone installations can download new versions directly as ZIP files. The package
+contains no user data. RailKeeper uses persistent data paths and creates consistent safety copies
+before database migrations so replacing the program directory does not replace the existing
+database.
+
+See the
+[English changelog](https://github.com/ichwars/RailKeeper/blob/v0.1.18/CHANGELOG.md)
+for details.

--- a/docs/scripts/validate-docs.test.mjs
+++ b/docs/scripts/validate-docs.test.mjs
@@ -7,7 +7,7 @@ import { dirname, join } from "node:path";
 import { parseFrontmatter, validateCoverage, validateDocumentTree } from "./validate-docs.mjs";
 
 const versions = {
-  stable: "0.1.17.6",
+  stable: "0.1.18",
   development: "main",
 };
 
@@ -58,14 +58,14 @@ lastReviewed: ${values.lastReviewed}
 
 test("accepts a complete matching language pair", async () => {
   const root = await fixture({
-    "index.md": page("reference", "stable", "0.1.17.6"),
-    "de/index.md": page("reference", "stable", "0.1.17.6"),
+    "index.md": page("reference", "stable", "0.1.18"),
+    "de/index.md": page("reference", "stable", "0.1.18"),
   });
   assert.deepEqual(await validateDocumentTree(root, versions), []);
 });
 
 test("reports a missing German counterpart", async () => {
-  const root = await fixture({ "guide/index.md": page("user", "stable", "0.1.17.6") });
+  const root = await fixture({ "guide/index.md": page("user", "stable", "0.1.18") });
   assert.deepEqual(await validateDocumentTree(root, versions), [
     "guide/index.md: missing counterpart de/guide/index.md",
   ]);
@@ -73,7 +73,7 @@ test("reports a missing German counterpart", async () => {
 
 test("reports a missing English counterpart", async () => {
   const root = await fixture({
-    "de/administration/index.md": page("admin", "stable", "0.1.17.6"),
+    "de/administration/index.md": page("admin", "stable", "0.1.18"),
   });
   assert.deepEqual(await validateDocumentTree(root, versions), [
     "de/administration/index.md: missing counterpart administration/index.md",
@@ -82,7 +82,7 @@ test("reports a missing English counterpart", async () => {
 
 test("reports missing and mismatched metadata", async () => {
   const root = await fixture({
-    "index.md": page("reference", "stable", "0.1.17.6"),
+    "index.md": page("reference", "stable", "0.1.18"),
     "de/index.md": page("developer", "development", "main"),
   });
   const errors = await validateDocumentTree(root, versions);
@@ -97,7 +97,7 @@ test("enforces the canonical version for each status", async () => {
     "de/index.md": page("reference", "stable", "0.1.14"),
   });
   assert((await validateDocumentTree(root, versions)).some((error) =>
-    error.includes("reviewedVersion must be 0.1.17.6"),
+    error.includes("reviewedVersion must be 0.1.18"),
   ));
 });
 

--- a/docs/site/administration/index.md
+++ b/docs/site/administration/index.md
@@ -3,7 +3,7 @@ title: Installation and Administration
 description: Install, configure, secure, and operate RailKeeper.
 audience: admin
 status: stable
-reviewedVersion: 0.1.17.6
+reviewedVersion: 0.1.18
 lastReviewed: 2026-08-16
 ---
 
@@ -13,7 +13,7 @@ This section covers Windows Standalone and Docker installation, runtime configur
 roles, SMTP, backups and restores, updates, TLS, uploads, OCR, printers, operational checks, and
 conservative troubleshooting.
 
-Administration guidance describes the stable v0.1.17.6 runtime and preserves RailKeeper's
+Administration guidance describes the stable v0.1.18 runtime and preserves RailKeeper's
 local-first, self-hosted security model.
 
 ## Safe Windows Standalone updates

--- a/docs/site/de/administration/index.md
+++ b/docs/site/de/administration/index.md
@@ -3,7 +3,7 @@ title: Installation und Administration
 description: RailKeeper installieren, konfigurieren, absichern und betreiben.
 audience: admin
 status: stable
-reviewedVersion: 0.1.17.6
+reviewedVersion: 0.1.18
 lastReviewed: 2026-08-16
 ---
 
@@ -13,7 +13,7 @@ Dieser Bereich behandelt Windows Standalone, Docker, Laufzeitkonfiguration, Benu
 SMTP, Sicherung und Wiederherstellung, Updates, TLS, Uploads, OCR, Drucker,
 Betriebsprüfungen und konservative Fehlerbehebung.
 
-Die Administrationsanleitungen beschreiben die stabile Laufzeit v0.1.17.6 und erhalten das lokale,
+Die Administrationsanleitungen beschreiben die stabile Laufzeit v0.1.18 und erhalten das lokale,
 selbst gehostete Sicherheitsmodell von RailKeeper.
 
 ## Sichere Updates unter Windows

--- a/docs/site/de/guide/accessories/allocations-history.md
+++ b/docs/site/de/guide/accessories/allocations-history.md
@@ -3,7 +3,7 @@ title: Reservierungen, Einbauten und Verwendung
 description: Zubehör reservieren, Einbauten erfassen und die Verwendungshistorie verstehen.
 audience: user
 status: stable
-reviewedVersion: 0.1.17.6
+reviewedVersion: 0.1.18
 lastReviewed: 2026-08-16
 ---
 
@@ -202,4 +202,4 @@ verwendet kein zweiter Befehl einen alten Verfügbarkeits- oder Lebenszyklusstan
 
 ## Dokumentierte RailKeeper-Version
 
-Diese Seite dokumentiert RailKeeper **v0.1.17.6** und wurde zuletzt am 16.08.2026 geprüft.
+Diese Seite dokumentiert RailKeeper **v0.1.18** und wurde zuletzt am 16.08.2026 geprüft.

--- a/docs/site/de/guide/accessories/article-records.md
+++ b/docs/site/de/guide/accessories/article-records.md
@@ -3,7 +3,7 @@ title: Artikelstammdaten und Fachangaben
 description: Zubehörartikel anlegen, ihre Identität pflegen und technische Angaben prüfen.
 audience: user
 status: stable
-reviewedVersion: 0.1.17.6
+reviewedVersion: 0.1.18
 lastReviewed: 2026-08-16
 ---
 
@@ -12,7 +12,7 @@ lastReviewed: 2026-08-16
 Ein Zubehörartikel ist der gemeinsame Produktdatensatz für Bestand, Einkäufe, Dokumente,
 Reservierungen und Einbauten. Legen Sie ihn einmal für einen Hersteller- und Katalogartikel an und
 erfassen Sie anschließend Mengen oder Einzelstücke dazu. Dieses Kapitel beschreibt die
-Artikelidentität und die artabhängigen Fachangaben in RailKeeper v0.1.17.6.
+Artikelidentität und die artabhängigen Fachangaben in RailKeeper v0.1.18.
 
 ## Zugriffsrechte und Speichern
 
@@ -141,7 +141,7 @@ Der Trefferdialog kann Hersteller, Artikelnummer, Name, EAN, Maßstab, Beschreib
 Spurweite übernehmen. Hersteller oder Spurweite sind nur auswählbar, wenn sie einem aktiven
 bekannten Stammdatenwert entsprechen. Eine gewählte Spurweite wird den vorhandenen hinzugefügt.
 Ungültige allgemeine Werte und Produkt-URLs außerhalb von HTTP oder HTTPS werden ignoriert. In
-v0.1.17.6 bietet die Trefferauswahl technische Ergebnisfelder nur für **Gleis** an. Andere
+v0.1.18 bietet die Trefferauswahl technische Ergebnisfelder nur für **Gleis** an. Andere
 Artikelarten können die allgemeinen Treffergruppen, aber keine Fachangaben übernehmen.
 
 Nur Felder mit aktuell leerem Formularwert sind in der Prüfung vorausgewählt. Vorhandene Werte sind
@@ -231,4 +231,4 @@ rückgängig machen. Prüfen Sie vorher eine aktuelle Sicherung.
 
 ## Dokumentierte RailKeeper-Version
 
-Diese Seite dokumentiert RailKeeper **v0.1.17.6** und wurde zuletzt am 16.08.2026 geprüft.
+Diese Seite dokumentiert RailKeeper **v0.1.18** und wurde zuletzt am 16.08.2026 geprüft.

--- a/docs/site/de/guide/accessories/index.md
+++ b/docs/site/de/guide/accessories/index.md
@@ -3,7 +3,7 @@ title: Zubehörübersicht
 description: Zubehörartikel finden, filtern, prüfen und sicher verwalten.
 audience: user
 status: stable
-reviewedVersion: 0.1.17.6
+reviewedVersion: 0.1.18
 lastReviewed: 2026-08-16
 ---
 
@@ -12,7 +12,7 @@ lastReviewed: 2026-08-16
 **Zubehör** ist RailKeepers Katalog- und Bestandsbereich für Gleise, Signale, Decoder, elektrische
 Bauteile, Landschaftsbau, Beleuchtung und weitere Modellbahnartikel. Er verbindet Produktidentität,
 gelagerte und gebundene Mengen, Bilder, Lagerorte und Aktionen im Artikellebenszyklus. Dieses
-Kapitel beschreibt den stabilen RailKeeper-Stand v0.1.17.6.
+Kapitel beschreibt den stabilen RailKeeper-Stand v0.1.18.
 
 Ein Artikel ist der gemeinsame Produktdatensatz. Sein Bestand kann aus austauschbaren Mengen,
 einzeln geführten Stücken oder beidem bestehen. Reservierungen und Einbauten binden einen Teil
@@ -145,7 +145,7 @@ Serversortierung, bieten aber keine eigenen Sortieraktionen.
 
 Kontrollkästchen in der Tabelle wählen eine Zeile oder alle aktuell sichtbaren Zeilen aus. Eine
 Auswahl verschwindet, wenn ein neues Such- oder Filterergebnis den Artikel nicht mehr enthält. Der
-stabile Stand v0.1.17.6 bietet keine Sammelaktion für diese Auswahl. Sie ist nur visueller Zustand
+stabile Stand v0.1.18 bietet keine Sammelaktion für diese Auswahl. Sie ist nur visueller Zustand
 und keine vorgemerkte Archivierung, Auswertung oder Bestandsbuchung.
 
 Öffne über Artikelname, Bild oder **Artikel ansehen** den schreibgeschützten Artikeldialog. Abhängig
@@ -207,5 +207,5 @@ sofortige Bestands- oder Lebenszyklusaktion startest.
 
 ## Dokumentierter RailKeeper-Stand
 
-Diese Seite dokumentiert den stabilen RailKeeper-Stand **v0.1.17.6** und wurde zuletzt am
+Diese Seite dokumentiert den stabilen RailKeeper-Stand **v0.1.18** und wurde zuletzt am
 2026-08-16 geprüft.

--- a/docs/site/de/guide/accessories/stock-purchases-documents.md
+++ b/docs/site/de/guide/accessories/stock-purchases-documents.md
@@ -3,7 +3,7 @@ title: Bestand, Käufe und Dokumente
 description: Zubehörmengen, Einzelstücke, Käufe, Bilder und Dokumente verwalten.
 audience: user
 status: stable
-reviewedVersion: 0.1.17.6
+reviewedVersion: 0.1.18
 lastReviewed: 2026-08-16
 ---
 
@@ -12,7 +12,7 @@ lastReviewed: 2026-08-16
 RailKeeper kann austauschbare Zubehöreinheiten als Menge zählen, physische Stücke einzeln verwalten
 oder Einheiten bei Bedarf aus dem Mengenbestand in die Einzelverwaltung überführen. Käufe und
 Dokumente gehören zum selben Artikel, besitzen aber eigene Sofortaktionen zum Speichern. Dieses
-Kapitel beschreibt das stabile Verhalten von RailKeeper v0.1.17.6.
+Kapitel beschreibt das stabile Verhalten von RailKeeper v0.1.18.
 
 Administratoren und Bearbeiter können diese Ressourcen verwalten. Betrachter und Planer können sie
 ansehen. Das Reservierungsrecht eines Planers umfasst jedoch keine Änderungen an Bestand, Käufen,
@@ -137,7 +137,7 @@ Lebenszyklus, Lagerort und Verlauf konsistent bleiben.
 
 ## Käufe erfassen
 
-Die Kaufliste ist eine stabile, absteigend chronologische Historie. RailKeeper v0.1.17.6 bietet das
+Die Kaufliste ist eine stabile, absteigend chronologische Historie. RailKeeper v0.1.18 bietet das
 Hinzufügen, aber keine Aktion zum Bearbeiten oder Löschen eines Kaufs.
 
 | Kauffeld | Stabile Regel |
@@ -249,4 +249,4 @@ bereits aus der Liste entfernten Eintrag folgen. Laden Sie neu, bevor Sie erneut
 
 ## Dokumentierte RailKeeper-Version
 
-Diese Seite dokumentiert RailKeeper **v0.1.17.6** und wurde zuletzt am 16.08.2026 geprüft.
+Diese Seite dokumentiert RailKeeper **v0.1.18** und wurde zuletzt am 16.08.2026 geprüft.

--- a/docs/site/de/guide/exhibition/entries-and-printing.md
+++ b/docs/site/de/guide/exhibition/entries-and-printing.md
@@ -3,7 +3,7 @@ title: Einträge und Drucken
 description: Messeloks erfassen, Adresskonflikte lösen und die Betriebsliste drucken.
 audience: user
 status: stable
-reviewedVersion: 0.1.17.6
+reviewedVersion: 0.1.18
 lastReviewed: 2026-08-16
 ---
 
@@ -40,7 +40,7 @@ Wähle eine offene Liste und verwende das Bedienelement zum Anlegen im Eintragsb
 | Lok Bezeichnung | Pflichtfeld. Der Server entfernt führende und nachgestellte Leerzeichen. |
 
 Mit **Bearbeiten** in einer vorhandenen Zeile öffnet sich **Eintrag bearbeiten** mit den aktuellen
-Werten. v0.1.17.6 bietet in diesem Dialog keine Fahrzeugauswahl und kein sichtbares Feld für eine
+Werten. v0.1.18 bietet in diesem Dialog keine Fahrzeugauswahl und kein sichtbares Feld für eine
 Fahrzeugverknüpfung. Der Eintrag bleibt ein Messedatensatz, auch wenn seine Beschreibung einem
 Fahrzeug im allgemeinen Bestand ähnelt.
 
@@ -85,7 +85,7 @@ zuerst mit Admin oder einem Messekonto mit bestandsberechtigter Zusatzrolle.
 Tabelle und Report verbinden DCC und SX unter **Adresse**, zeigen Analog als Ja oder Nein und führen
 Decoder-Typ und Schnittstelle getrennt auf. Leere Werte erscheinen als Strich.
 
-**Baureihe** wird mit dem Eintrag gespeichert, erscheint in v0.1.17.6 jedoch weder in Tabelle und
+**Baureihe** wird mit dem Eintrag gespeichert, erscheint in v0.1.18 jedoch weder in Tabelle und
 Listenansicht noch im gedruckten Report. Öffne **Eintrag bearbeiten**, um den Wert zu prüfen.
 
 ### Nr. / Beschriftung / Merkmale
@@ -160,7 +160,7 @@ Bezeichnung liefert. Prüfe den Namen nach der Symbolauswahl. Beim **Speichern**
 belegte Funktionen als strukturierte Daten ab. Tabelle, Detailansicht und Report zeigen nur diese
 Funktionen.
 
-v0.1.17.6 kann außerdem frühere Klartextwerte lesen, die durch Kommas, Semikolons oder Zeilen
+v0.1.18 kann außerdem frühere Klartextwerte lesen, die durch Kommas, Semikolons oder Zeilen
 getrennt sind und jeweils mit einer Taste wie `F1 Sound` beginnen. Das Öffnen und Speichern eines
 solchen Eintrags schreibt die aktuell konfigurierte strukturierte Darstellung.
 
@@ -233,5 +233,5 @@ Betriebssystem. Eine leere Liste erzeugt eine Reportzeile mit **Keine Einträge.
 
 ## Dokumentierte RailKeeper-Version
 
-Diese Seite beschreibt RailKeeper v0.1.17.6. Der Entwicklungsstand auf `main` kann abweichen und
+Diese Seite beschreibt RailKeeper v0.1.18. Der Entwicklungsstand auf `main` kann abweichen und
 gehört nicht zu diesem Benutzerablauf.

--- a/docs/site/de/guide/exhibition/index.md
+++ b/docs/site/de/guide/exhibition/index.md
@@ -3,7 +3,7 @@ title: Messearbeitsbereich
 description: Messelisten sicher vorbereiten, pflegen, prüfen und drucken.
 audience: user
 status: stable
-reviewedVersion: 0.1.17.6
+reviewedVersion: 0.1.18
 lastReviewed: 2026-08-16
 ---
 
@@ -14,7 +14,7 @@ in einer Betriebsansicht. Jede Liste besitzt ein Datum, den Zustand offen oder g
 Lokomotiveinträge. Das Betriebspersonal kann eine offene Liste pflegen, ohne den allgemeinen
 Fahrzeugbestand zu öffnen.
 
-Dieses Kapitel dokumentiert RailKeeper v0.1.17.6. Benutzer- und Stammdatenverwaltung,
+Dieses Kapitel dokumentiert RailKeeper v0.1.18. Benutzer- und Stammdatenverwaltung,
 Backup-Bedienung sowie der Anlagen-Arbeitsbereich gehören nicht zu diesem Kapitel.
 
 ## Zugriffsrechte und Trennung
@@ -131,5 +131,5 @@ versehentlich doppelt ausgeführt.
 
 ## Dokumentierte RailKeeper-Version
 
-Diese Seite beschreibt RailKeeper v0.1.17.6. Der Entwicklungsstand auf `main` kann abweichen und
+Diese Seite beschreibt RailKeeper v0.1.18. Der Entwicklungsstand auf `main` kann abweichen und
 gehört nicht zu diesem Benutzerablauf.

--- a/docs/site/de/guide/exhibition/lists-and-locking.md
+++ b/docs/site/de/guide/exhibition/lists-and-locking.md
@@ -3,7 +3,7 @@ title: Listen und Sperren
 description: Messelisten anlegen, sperren, entsperren und sicher löschen.
 audience: user
 status: stable
-reviewedVersion: 0.1.17.6
+reviewedVersion: 0.1.18
 lastReviewed: 2026-08-16
 ---
 
@@ -42,7 +42,7 @@ den Dialog und lädt die Listentabelle neu. Das Anlegen ist ein sofortiger Serve
 bis zum Erfolg sind die Dialogwerte nur lokaler Formularzustand.
 
 Ist eines der Pflichtfelder leer, verhindert der Browser die normale Übermittlung. Der Server weist
-auch Werte zurück, die nach dem Entfernen äußerer Leerzeichen leer sind. In v0.1.17.6 prüft der
+auch Werte zurück, die nach dem Entfernen äußerer Leerzeichen leer sind. In v0.1.18 prüft der
 Server beim Datum, dass der Wert nicht leer ist; das Datumsfeld liefert den normalen Kalenderwert.
 
 ## Listen auswählen, sortieren und prüfen
@@ -132,5 +132,5 @@ nicht erklärt.
 
 ## Dokumentierte RailKeeper-Version
 
-Diese Seite beschreibt RailKeeper v0.1.17.6. Der Entwicklungsstand auf `main` kann abweichen und
+Diese Seite beschreibt RailKeeper v0.1.18. Der Entwicklungsstand auf `main` kann abweichen und
 gehört nicht zu diesem Benutzerablauf.

--- a/docs/site/de/guide/getting-started/index.md
+++ b/docs/site/de/guide/getting-started/index.md
@@ -3,7 +3,7 @@ title: Ersteinrichtung und Anmeldung
 description: Ersten Administrator anlegen, sicher anmelden und den Zugang zu RailKeeper wiederherstellen.
 audience: user
 status: stable
-reviewedVersion: 0.1.17.6
+reviewedVersion: 0.1.18
 lastReviewed: 2026-08-16
 ---
 
@@ -11,7 +11,7 @@ lastReviewed: 2026-08-16
 
 Dieses Kapitel erklärt das erste Administratorkonto, die normale Anmeldung und Anmeldung mit
 Zwei-Faktor-Code, die Abmeldung sowie die Passwort-Wiederherstellung. Es beschreibt den stabilen
-RailKeeper-Stand v0.1.17.6.
+RailKeeper-Stand v0.1.18.
 
 ## Voraussetzungen
 
@@ -77,7 +77,7 @@ Die Passwort-Wiederherstellung verwendet die für das Konto gespeicherte E-Mail-
 6. Setze das Passwort, kehre zur Anmeldung zurück und verwende die neuen Zugangsdaten.
 
 Die im Anmeldeformular angezeigte Bestätigung ist für bekannte und unbekannte Adressen absichtlich
-identisch. Die HTTP-Antwort von v0.1.17.6 enthält jedoch nur bei einem bekannten Konto den Wert
+identisch. Die HTTP-Antwort von v0.1.18 enthält jedoch nur bei einem bekannten Konto den Wert
 `expiresAt`. API-Clients oder Personen, die Netzwerkantworten untersuchen, können daraus ableiten,
 ob ein Konto existiert. Betreiber müssen dies als bekannte Einschränkung beim Schutz vor
 Kontenermittlung in dieser Version behandeln.
@@ -111,7 +111,7 @@ Reset-Bestätigungen auf zehn innerhalb von zehn Minuten.
   Administrator-Zugangsdaten.
 - Verwende HTTPS und sichere Cookies, wenn die Instanz über ein Netzwerk erreichbar ist. Die
   Betriebsanforderungen stehen unter [Installation und Administration](/de/administration/).
-- Die allgemeine Formularmeldung bietet in v0.1.17.6 keinen vollständigen Schutz vor
+- Die allgemeine Formularmeldung bietet in v0.1.18 keinen vollständigen Schutz vor
   Kontenermittlung, weil sich die HTTP-Antwort für bekannte Konten unterscheidet. Begrenze den
   Netzwerkzugriff, überwache wiederholte Reset-Anfragen und installiere eine Version mit korrigiertem
   Verhalten, sobald sie verfügbar ist.
@@ -125,5 +125,5 @@ Reset-Bestätigungen auf zehn innerhalb von zehn Minuten.
 
 ## Dokumentierter RailKeeper-Stand
 
-Diese Seite dokumentiert den stabilen RailKeeper-Stand **v0.1.17.6** und wurde zuletzt am
+Diese Seite dokumentiert den stabilen RailKeeper-Stand **v0.1.18** und wurde zuletzt am
 2026-08-16 mit der Anwendung abgeglichen.

--- a/docs/site/de/guide/index.md
+++ b/docs/site/de/guide/index.md
@@ -3,7 +3,7 @@ title: Benutzerhandbuch
 description: Alle stabilen Arbeitsabläufe in RailKeeper kennenlernen.
 audience: user
 status: stable
-reviewedVersion: 0.1.17.6
+reviewedVersion: 0.1.18
 lastReviewed: 2026-08-16
 ---
 
@@ -13,7 +13,7 @@ Dieses Handbuch erklärt den vollständigen veröffentlichten RailKeeper-Arbeits
 Vereine und kleine Werkstätten. Es umfasst Ersteinrichtung, Navigation, Fahrzeuge, Zubehör,
 Decoderdaten, Wartung, Dokumente, Berichte, Ausstellungen sowie kontrollierten Import und Export.
 
-Die Inhalte dieses Bereichs beschreiben RailKeeper v0.1.17.6. Der Anlagen-Arbeitsbereich befindet
+Die Inhalte dieses Bereichs beschreiben RailKeeper v0.1.18. Der Anlagen-Arbeitsbereich befindet
 sich noch in Entwicklung und wird deshalb nicht als stabile Benutzerfunktion dargestellt.
 
 ## Hier beginnen

--- a/docs/site/de/guide/overview/index.md
+++ b/docs/site/de/guide/overview/index.md
@@ -3,7 +3,7 @@ title: Übersicht, Kennzahlen und Datenqualität
 description: RailKeeper-Dashboard auswerten, Datenlücken bearbeiten und Kacheln anordnen.
 audience: user
 status: stable
-reviewedVersion: 0.1.17.6
+reviewedVersion: 0.1.18
 lastReviewed: 2026-08-16
 ---
 
@@ -12,7 +12,7 @@ lastReviewed: 2026-08-16
 Die **Übersicht** ist das Arbeits-Dashboard von RailKeeper für Bestandsgröße, erfassten Wert,
 Digitalisierung, Wartung und Datenqualität. Dieses Kapitel erklärt die Bedeutung jeder Kennzahl und
 den Weg von einem Hinweis zu den betroffenen Fahrzeugen. Es beschreibt den stabilen
-RailKeeper-Stand v0.1.17.6.
+RailKeeper-Stand v0.1.18.
 
 Benutzer mit den Rollen Admin, Editor, Viewer oder Planner können die Übersicht öffnen. Ein Konto,
 das ausschließlich die Rolle Messe besitzt, startet unter **Ausstellung** und kann dieses Dashboard
@@ -101,7 +101,7 @@ zu öffnen.
 | **Ohne EAN** | Fahrzeuge ohne EAN |
 | **Digital ohne Decoder-Nr.** | Digitale Fahrzeuge ohne Wert in beiden Decoder-Nummernfeldern |
 
-In v0.1.17.6 prüft **Ohne Hauptbild** technisch, ob irgendein Bild vorhanden ist. Die Prüfung
+In v0.1.18 prüft **Ohne Hauptbild** technisch, ob irgendein Bild vorhanden ist. Die Prüfung
 unterscheidet kein ausdrücklich ausgewähltes Hauptbild. Sind alle vier Werte null, meldet die Kachel,
 dass keine größeren Datenlücken erkannt wurden.
 
@@ -213,5 +213,5 @@ gespeichert.
 
 ## Dokumentierter RailKeeper-Stand
 
-Diese Seite dokumentiert den stabilen RailKeeper-Stand **v0.1.17.6** und wurde zuletzt am
+Diese Seite dokumentiert den stabilen RailKeeper-Stand **v0.1.18** und wurde zuletzt am
 2026-08-16 geprüft.

--- a/docs/site/de/guide/vehicles/decoder-cv.md
+++ b/docs/site/de/guide/vehicles/decoder-cv.md
@@ -3,7 +3,7 @@ title: Decoder, Funktionen und CV-Daten
 description: Digitalfunktionen zuordnen, Fahrkurven prüfen, CV-Werte pflegen und Decoder-Dateien speichern.
 audience: user
 status: stable
-reviewedVersion: 0.1.17.6
+reviewedVersion: 0.1.18
 lastReviewed: 2026-08-16
 ---
 
@@ -322,5 +322,5 @@ nacheinander ausgeführten Aktion rückgängig.
 
 ## Dokumentierte RailKeeper-Version
 
-Diese Seite dokumentiert die stabile RailKeeper-Version **v0.1.17.6** und wurde zuletzt am
+Diese Seite dokumentiert die stabile RailKeeper-Version **v0.1.18** und wurde zuletzt am
 16.08.2026 geprüft.

--- a/docs/site/de/guide/vehicles/index.md
+++ b/docs/site/de/guide/vehicles/index.md
@@ -3,7 +3,7 @@ title: Fahrzeugbestand und Grunddaten
 description: Fahrzeuge suchen, filtern, anlegen, pflegen, ausgeben und sicher löschen.
 audience: user
 status: stable
-reviewedVersion: 0.1.17.6
+reviewedVersion: 0.1.18
 lastReviewed: 2026-08-16
 ---
 
@@ -11,10 +11,10 @@ lastReviewed: 2026-08-16
 
 Der **Fahrzeugbestand** ist der zentrale Arbeitsbereich für Modellbahnfahrzeuge. Er verbindet
 Bestandsstatus, Suche, Filter, Tabellen- und Kartenansicht, Fahrzeuggrunddaten, QR-Etiketten und
-druckbare Reports. Dieses Kapitel beschreibt die stabile RailKeeper-Version v0.1.17.6.
+druckbare Reports. Dieses Kapitel beschreibt die stabile RailKeeper-Version v0.1.18.
 
 Admin, Editor, Viewer und Planner können den Bestand einsehen. Fahrzeuge anlegen, ändern und
-löschen dürfen nur Admin und Editor. In v0.1.17.6 können Schreibfunktionen für Viewer und Planner
+löschen dürfen nur Admin und Editor. In v0.1.18 können Schreibfunktionen für Viewer und Planner
 trotzdem sichtbar sein. Der Server lehnt ihre Schreibversuche ab und RailKeeper zeigt den
 Fehler an.
 
@@ -41,15 +41,20 @@ ausgeblendeten Tab zurückkehrt.
 ## Bestand durchsuchen
 
 Gib Text in **Bestand durchsuchen** ein. Jede Änderung lädt die Fahrzeugliste neu vom Server. Die
-Suche findet Teilzeichenfolgen in genau vier Feldern:
+Suche ignoriert Leerzeichen am Anfang und Ende und findet Teilzeichenfolgen in diesen Feldern:
 
 - Inventarnummer
 - Hersteller
 - Artikelnummer
 - Bezeichnung
+- Baureihe
+- Fahrzeugnummer
+- Decoder-Typ
+- Heimat-Bw / Einsatzstelle
+- Höchstgeschwindigkeit
 
 Beschreibungen, Bahngesellschaften, Epochen, Kategorien, Decodernummern, EANs und andere
-Detailfelder durchsucht v0.1.17.6 nicht. Die nachfolgenden Filter wirken im Browser auf die vom
+Detailfelder durchsucht v0.1.18 nicht. Die nachfolgenden Filter wirken im Browser auf die vom
 Server gelieferten Suchergebnisse. Suche und Filter werden daher kombiniert.
 
 Schlägt das Laden fehl, erscheint der Fehler über der Liste. Bereits geladene Zeilen können sichtbar
@@ -59,15 +64,16 @@ bleiben. Behebe den Fehler oder aktualisiere die Liste, bevor du sie als aktuell
 
 Filtergruppen sind UND-verknüpft. Ein Fahrzeug muss jede aktive Gruppe erfüllen.
 
-| Gruppe | Stabile Auswahl in v0.1.17.6 |
+| Gruppe | Stabile Auswahl in v0.1.18 |
 | --- | --- |
 | Bestandsstatus | **Alle**, **Digital**, **Analog**, **Mit Bild**, **Ohne Bild** |
 | Wartung | **Alle**, **Wartung fällig**, **Ohne Wartung** |
-| Stammdaten | Hersteller, Kategorie, Gattung |
+| Stammdaten | Hersteller, Kategorie, Gattung, Bahngesellschaft, Epoche |
+| Digitaltechnik | Adapter / Schnittstelle |
 | Betriebsmerkmal | **Messe tauglich** |
 | Datenlücke aus der Übersicht | **Ohne Artikel-Nr.**, **Ohne EAN** oder **Digital ohne Decoder-Nr.**, wenn der Bestand aus der **Übersicht** geöffnet wurde |
 
-Die Bezeichnung **Ohne Wartung** ist in v0.1.17.6 ungenau. Der Filter zeigt Fahrzeuge ohne fälligen
+Die Bezeichnung **Ohne Wartung** ist in v0.1.18 ungenau. Der Filter zeigt Fahrzeuge ohne fälligen
 Wartungseintrag. Dazu können Fahrzeuge mit erledigten oder noch nicht fälligen Wartungen gehören.
 
 Eine ausgewählte Kategorie beschränkt die Gattungen auf die unterschiedlichen Werte der aktuell vom
@@ -75,22 +81,32 @@ Server geladenen Suchergebnisse in dieser Kategorie und entfernt die aktuelle Ga
 **Filter entfernen** setzt alle Gruppen zurück und entfernt einen `gap`-Parameter der Übersicht aus
 der Browseradresse. Der Ergebniszähler bezieht sich immer auf alle aktiven Filter.
 
-Zusätzliche Filter für Bahngesellschaft, Epoche und Schnittstelle aus späteren Entwicklungsständen
-gehören nicht zur stabilen v0.1.17.6.
-
 ## Ansicht wählen und sortieren
 
 Auf dem Desktop wechselst du über die Ansichtssymbole zwischen Tabelle und Karten. RailKeeper
 speichert die Auswahl im lokalen Speicher des aktuellen Browsers, nicht im Benutzerkonto. Auf
-schmalen Bildschirmen zeigt die Oberfläche unabhängig davon eine kompakte mobile Liste.
+schmalen Bildschirmen zeigt die Oberfläche unabhängig davon kompakte, aufklappbare Fahrzeugkarten.
 
-Die Tabelle enthält Auswahl, Bild, Inventarnummer, Hersteller, Artikelnummer, Bezeichnung,
-Spurweite, Epoche, Ausstellungsstatus und Aktionen. Sortierbar sind Inventarnummer, Hersteller,
-Artikelnummer, Bezeichnung, Spurweite und Epoche.
+Über **Tabellenspalten auswählen** bestimmst du sichtbare Spalten und deren Reihenfolge. Die
+Standardauswahl umfasst Bild, Inventarnummer, Hersteller, Artikelnummer, Bezeichnung, Spurweite,
+Epoche und Ausstellungsstatus. Weitere kurze Fahrzeugfelder lassen sich nach fachlichen Gruppen
+einblenden. RailKeeper speichert diese Einstellung serverseitig im Benutzerkonto, sodass sie auch
+nach einem Neustart und in einem anderen Browser verfügbar bleibt.
+
+Die Inventarnummer darf ausgeblendet werden. Würde dadurch keine Datenspalte mehr sichtbar bleiben,
+blendet RailKeeper sie automatisch wieder ein. **Auf Standard zurücksetzen** stellt Auswahl und
+Reihenfolge wieder her. Spalten, die eine spätere Version neu einführt, bleiben in vorhandenen
+Benutzerkonfigurationen zunächst ausgeblendet.
+
+Mit Ausnahme von Bild und Ausstellungsstatus sind die angebotenen Spalten sortierbar. Wird die
+aktive Sortierspalte ausgeblendet, wechselt RailKeeper bevorzugt zur Inventarnummer oder zur ersten
+weiterhin sichtbaren sortierbaren Spalte.
 
 Die Anfangssortierung ist Inventarnummer aufsteigend und berücksichtigt Zahlen, sodass `...2` vor
 `...10` steht. Ein weiterer Klick auf die aktive Überschrift kehrt die Richtung um. Karten- und
 Mobilansicht folgen der aktuellen Tabellensortierung, bieten aber keine eigenen Sortierschalter.
+Die mobilen Karten übernehmen die konfigurierte Spaltenauswahl und zeigen zusätzliche Felder nach
+dem Aufklappen in der festgelegten Reihenfolge.
 
 ## Fahrzeuge markieren
 
@@ -188,7 +204,7 @@ Artikeldatensuche.
 
 ## Stabile Auswahllisten
 
-Die folgenden Werte sind in v0.1.17.6 statisch. Sie bleiben in beiden Oberflächensprachen auf
+Die folgenden Werte sind in v0.1.18 statisch. Sie bleiben in beiden Oberflächensprachen auf
 Deutsch gespeichert.
 
 | Feld | Werte |
@@ -196,7 +212,7 @@ Deutsch gespeichert.
 | Radsatz | `2-Leiter DC`, `3-Leiter AC`, `NEM`, `RP25`, `Metall`, `Kunststoff` |
 | Kupplung | `NEM-Schacht`, `Kurzkupplung`, `Bügelkupplung`, `Klauenkupplung`, `Schraubenkupplung` |
 | Stromabnahme | `Schiene`, `Oberleitung`, `Batterie`, `Akku` |
-| Adapter / Schnittstelle | `NEM 651`, `NEM 652`, `PluX16`, `PluX22`, `MTC21`, `Next18`, `8-polig`, `21-polig` |
+| Adapter / Schnittstelle | `NEM 651`, `NEM 652`, `PluX12`, `PluX16`, `PluX22`, `MTC21`, `Next18`, `8-polig`, `21-polig` |
 | Erwerb | `Kauf`, `Tausch`, `Geschenk`, `Erbe`, `Leihgabe`, `Sonstiges` |
 | von/bei | `Händler`, `Privat`, `Messe / Börse`, `Online`, `Auktion`, `Hersteller`, `Verein`, `Sonstiges` |
 | Standort | `Auf Anlage`, `Vitrine`, `Lager`, `Werkstatt`, `Transportbox`, `Ausgeliehen`, `Sonstiges` |
@@ -234,7 +250,7 @@ Decoder-Nr.: <Decodernummer, nur wenn vorhanden>
 RailKeeper verwendet zuerst die primäre digitale Decodernummer, danach die DT-Decodernummer. Der
 QR-Dialog kann PNG oder SVG herunterladen und ein druckbares Etikett öffnen. Schnellmenü und
 Fahrzeugansicht können bei vorhandenen Identitätsdaten immer einen QR-Code erzeugen. Der Schalter
-**QR-Code erstellen** steuert in v0.1.17.6 nur die QR-Schaltfläche im Detailbereich des
+**QR-Code erstellen** steuert in v0.1.18 nur die QR-Schaltfläche im Detailbereich des
 Bearbeitungsformulars.
 
 Ist Inventarnummer oder Bezeichnung leer, schreibt die Nutzlast für dieses Feld `-`. Mindestens eines
@@ -278,7 +294,7 @@ bereits vorhandenen Ausstellungslisteneintrag.
 ## Fahrzeug löschen
 
 Admin und Editor können **Löschen** wählen und das durch Inventarnummer und Bezeichnung
-identifizierte Fahrzeug bestätigen. v0.1.17.6 bietet weder Rückgängig noch eine Eingabebestätigung.
+identifizierte Fahrzeug bestätigen. v0.1.18 bietet weder Rückgängig noch eine Eingabebestätigung.
 
 Das Löschen entfernt das Fahrzeug und seine abhängigen Datenbankeinträge, darunter
 Inventarnummernhistorie, Bilder, Anhangsmetadaten, Wartungen, Funktionen, CV-Daten, externe
@@ -319,5 +335,5 @@ Datei physisch zu entfernen.
 
 ## Dokumentierte RailKeeper-Version
 
-Diese Seite dokumentiert die stabile RailKeeper-Version **v0.1.17.6** und wurde zuletzt am
+Diese Seite dokumentiert die stabile RailKeeper-Version **v0.1.18** und wurde zuletzt am
 16.08.2026 geprüft.

--- a/docs/site/de/guide/vehicles/maintenance.md
+++ b/docs/site/de/guide/vehicles/maintenance.md
@@ -3,7 +3,7 @@ title: Fahrzeugwartung und Zustand
 description: Fahrzeugwartungen erfassen, planen, abschließen, prüfen und sicher entfernen.
 audience: user
 status: stable
-reviewedVersion: 0.1.17.6
+reviewedVersion: 0.1.18
 lastReviewed: 2026-08-16
 ---
 
@@ -105,7 +105,7 @@ getrennte Zähler für Bilder und Beilagen. Bildverknüpfungen werden im Tab **U
 Auswahl **Keine Wartung** an einem Bild bleibt eine ausstehende Metadatenänderung, bis du
 **Änderungen speichern** am Fahrzeug verwendest.
 
-RailKeeper v0.1.17.6 kann Beilagen anzeigen, die bereits eine Wartungsreferenz enthalten. Die
+RailKeeper v0.1.18 kann Beilagen anzeigen, die bereits eine Wartungsreferenz enthalten. Die
 normale Beilagenzeile bietet jedoch keine Funktion zum Zuweisen oder Ändern dieser Referenz. Nutze
 keinen erfundenen Zuordnungsablauf, den die Oberfläche nicht bereitstellt.
 
@@ -122,7 +122,7 @@ Vor dem Löschen eines Eintrags:
 3. Wähle im Tab **Uploads** für jedes verknüpfte Bild **Keine Wartung** und nutze
    **Änderungen speichern**.
 4. Muss eine verknüpfte Beilage ihre Zuordnung behalten, behalte auch den Wartungseintrag.
-   RailKeeper v0.1.17.6 besitzt keinen Editor für Beilagenverknüpfungen. Entferne eine Beilage erst
+   RailKeeper v0.1.18 besitzt keinen Editor für Beilagenverknüpfungen. Entferne eine Beilage erst
    nach Sicherungs- und Inhaltsprüfung, wenn die Datei tatsächlich nicht mehr benötigt wird.
 5. Kehre zu **Wartung** zurück, prüfe, dass **Verknüpfte Medien** nicht mehr erscheint, und lösche
    erst danach den Eintrag.
@@ -176,5 +176,5 @@ Medienaktion nicht rückgängig.
 
 ## Dokumentierte RailKeeper-Version
 
-Diese Seite dokumentiert die stabile RailKeeper-Version **v0.1.17.6** und wurde zuletzt am
+Diese Seite dokumentiert die stabile RailKeeper-Version **v0.1.18** und wurde zuletzt am
 16.08.2026 geprüft.

--- a/docs/site/de/guide/vehicles/media.md
+++ b/docs/site/de/guide/vehicles/media.md
@@ -3,7 +3,7 @@ title: Fahrzeugbilder und Beilagen
 description: Fahrzeugbilder und Beilagen hochladen, ordnen, anzeigen, herunterladen und sicher entfernen.
 audience: user
 status: stable
-reviewedVersion: 0.1.17.6
+reviewedVersion: 0.1.18
 lastReviewed: 2026-08-16
 ---
 
@@ -118,7 +118,7 @@ Metadaten entfernt wurden.
 ## Rollen-, Speicher- und Sicherungsgrenzen
 
 Medien sind lokale und private RailKeeper-Daten, keine öffentlichen Website-Inhalte.
-Anwendungssicherungen enthalten gespeicherte Fahrzeugmedien. RailKeeper akzeptiert in v0.1.17.6
+Anwendungssicherungen enthalten gespeicherte Fahrzeugmedien. RailKeeper akzeptiert in v0.1.18
 jedoch nur Sicherungsdateien bis 250 MiB für Prüfung und Wiederherstellung. Exportiere vor
 umfangreichen Aufräumarbeiten eine Sicherung und bitte einen Admin, diese Datei im
 Wiederherstellungsbereich auszuwählen. Verlasse dich erst darauf, wenn RailKeeper sie als kompatibel
@@ -158,4 +158,4 @@ das Bearbeiten von Wartungen bleiben Fachgrenzen, die auf dieser Seite nicht erk
 
 ## Dokumentierte RailKeeper-Version
 
-Diese Seite dokumentiert die stabile RailKeeper-Version **v0.1.17.6** und wurde zuletzt am 16.08.2026 geprüft.
+Diese Seite dokumentiert die stabile RailKeeper-Version **v0.1.18** und wurde zuletzt am 16.08.2026 geprüft.

--- a/docs/site/de/guide/vehicles/search-and-spares.md
+++ b/docs/site/de/guide/vehicles/search-and-spares.md
@@ -3,7 +3,7 @@ title: Artikelsuche, Web-Dokumente und Ersatzteile
 description: Externe Artikeldaten prüfen, Web-Dokumente importieren und Fahrzeugersatzteile pflegen.
 audience: user
 status: stable
-reviewedVersion: 0.1.17.6
+reviewedVersion: 0.1.18
 lastReviewed: 2026-08-16
 ---
 
@@ -316,5 +316,5 @@ was bereits geschrieben worden sein kann.
 
 ## Dokumentierte RailKeeper-Version
 
-Diese Seite dokumentiert die stabile RailKeeper-Version **v0.1.17.6** und wurde zuletzt am
+Diese Seite dokumentiert die stabile RailKeeper-Version **v0.1.18** und wurde zuletzt am
 16.08.2026 geprüft.

--- a/docs/site/de/index.md
+++ b/docs/site/de/index.md
@@ -4,12 +4,12 @@ title: RailKeeper-Dokumentation
 description: Vollständige Benutzer-, Administrations- und Entwicklungsdokumentation für RailKeeper.
 audience: reference
 status: stable
-reviewedVersion: 0.1.17.6
+reviewedVersion: 0.1.18
 lastReviewed: 2026-08-15
 hero:
   name: RailKeeper-Dokumentation
   text: Werkstattwissen direkt beim Projekt
-  tagline: Das Handbuch folgt v0.1.17.6, die Entwicklungsdokumentation dem Stand von main.
+  tagline: Das Handbuch folgt v0.1.18, die Entwicklungsdokumentation dem Stand von main.
   image:
     src: /brand/railkeeper-logo.png
     alt: RailKeeper

--- a/docs/site/guide/accessories/allocations-history.md
+++ b/docs/site/guide/accessories/allocations-history.md
@@ -3,7 +3,7 @@ title: Reservations, installations, and usage
 description: Reserve accessory stock, record installations, and understand usage history.
 audience: user
 status: stable
-reviewedVersion: 0.1.17.6
+reviewedVersion: 0.1.18
 lastReviewed: 2026-08-16
 ---
 
@@ -198,4 +198,4 @@ availability or lifecycle state.
 
 ## Documented RailKeeper version
 
-This page documents stable RailKeeper **v0.1.17.6** and was last reviewed on 2026-08-16.
+This page documents stable RailKeeper **v0.1.18** and was last reviewed on 2026-08-16.

--- a/docs/site/guide/accessories/article-records.md
+++ b/docs/site/guide/accessories/article-records.md
@@ -3,7 +3,7 @@ title: Article records and technical data
 description: Create accessory records, maintain their identity, and verify technical data.
 audience: user
 status: stable
-reviewedVersion: 0.1.17.6
+reviewedVersion: 0.1.18
 lastReviewed: 2026-08-16
 ---
 
@@ -12,7 +12,7 @@ lastReviewed: 2026-08-16
 An accessory article is the shared product record behind stock, purchases, documents,
 reservations, and installations. Create it once for a manufacturer and catalogue article, then
 record quantities or individual items against it. This chapter covers the article identity and the
-type-specific data in stable RailKeeper v0.1.17.6.
+type-specific data in stable RailKeeper v0.1.18.
 
 ## Access rights and persistence
 
@@ -135,7 +135,7 @@ Settings, the command stops without changing the article.
 The result dialog can apply manufacturer, article number, name, EAN, scale, description, product
 URL, and gauge. A manufacturer or gauge is selectable only when it matches an active known master-
 data value. A selected gauge is added to the existing gauges. Invalid common values and non-HTTP(S)
-product URLs are ignored. In stable v0.1.17.6, selectable technical result fields are exposed only
+product URLs are ignored. In stable v0.1.18, selectable technical result fields are exposed only
 for **Track** articles; other article types can apply the common result groups but not their
 technical attributes.
 
@@ -216,4 +216,4 @@ unreferenced stored blobs. Deletion has no undo, so validate a current backup fi
 
 ## Documented RailKeeper version
 
-This page documents stable RailKeeper **v0.1.17.6** and was last reviewed on 2026-08-16.
+This page documents stable RailKeeper **v0.1.18** and was last reviewed on 2026-08-16.

--- a/docs/site/guide/accessories/index.md
+++ b/docs/site/guide/accessories/index.md
@@ -3,7 +3,7 @@ title: Accessories overview
 description: Find, filter, inspect, and safely manage accessory articles.
 audience: user
 status: stable
-reviewedVersion: 0.1.17.6
+reviewedVersion: 0.1.18
 lastReviewed: 2026-08-16
 ---
 
@@ -12,7 +12,7 @@ lastReviewed: 2026-08-16
 **Accessories** is RailKeeper's catalogue and inventory workspace for track, signals, decoders,
 electrical components, scenery, lighting, and other model railway articles. It combines product
 identity, stored and allocated quantities, images, storage locations, and article lifecycle actions.
-This chapter describes stable RailKeeper v0.1.17.6.
+This chapter describes stable RailKeeper v0.1.18.
 
 An article is the common product record. Its stock can consist of interchangeable quantities,
 individually tracked items, or both. Reservations and installations bind some of that stock to a
@@ -51,7 +51,7 @@ Four metric cards appear above the article list:
 | **Care hints** | Total number of incomplete-data hints across active articles. It is informative and has no filter action. |
 
 **Care hints** is a count of missing fields, not a count of affected articles. One article can
-contribute several hints. Stable v0.1.17.6 checks for missing manufacturer, article number, article
+contribute several hints. Stable v0.1.18 checks for missing manufacturer, article number, article
 type, and stock unit. Track, signal, decoder, electrical/control, building/equipment, and lighting
 articles also contribute a hint when they have no gauge. Landscape consumables and **Other** do not
 require a gauge for this metric.
@@ -140,7 +140,7 @@ sort controls.
 ## Select, open, and manage an article
 
 Table checkboxes select one row or all currently visible rows. Selection is removed when a new
-search or filter result no longer contains the article. Stable v0.1.17.6 provides no bulk action for
+search or filter result no longer contains the article. Stable v0.1.18 provides no bulk action for
 this selection. It is visual state only and must not be treated as a pending archive, report, or
 stock command.
 
@@ -202,4 +202,4 @@ write.
 
 ## Documented RailKeeper version
 
-This page documents stable RailKeeper **v0.1.17.6** and was last reviewed on 2026-08-16.
+This page documents stable RailKeeper **v0.1.18** and was last reviewed on 2026-08-16.

--- a/docs/site/guide/accessories/stock-purchases-documents.md
+++ b/docs/site/guide/accessories/stock-purchases-documents.md
@@ -3,7 +3,7 @@ title: Stock, purchases, and documents
 description: Manage accessory quantities, individual items, purchases, images, and documents.
 audience: user
 status: stable
-reviewedVersion: 0.1.17.6
+reviewedVersion: 0.1.18
 lastReviewed: 2026-08-16
 ---
 
@@ -12,7 +12,7 @@ lastReviewed: 2026-08-16
 RailKeeper can count interchangeable accessory units, track physical items individually, or move
 units from counted stock into individual tracking when needed. Purchases and documents belong to
 the same article but have their own immediate save actions. This chapter describes the stable
-behavior of RailKeeper v0.1.17.6.
+behavior of RailKeeper v0.1.18.
 
 Admin and Editor users can manage these resources. Viewer and Planner users can inspect them, but a
 Planner's reservation authority does not include stock, purchase, item, or document changes. Save
@@ -130,7 +130,7 @@ that lifecycle, location, and history remain consistent.
 
 ## Record purchases
 
-The purchase list is a stable, newest-first history. Stable v0.1.17.6 provides an add action but no
+The purchase list is a stable, newest-first history. Stable v0.1.18 provides an add action but no
 purchase edit or delete action.
 
 | Purchase field | Stable rule |
@@ -237,4 +237,4 @@ Reload before attempting to delete again.
 
 ## Documented RailKeeper version
 
-This page documents stable RailKeeper **v0.1.17.6** and was last reviewed on 2026-08-16.
+This page documents stable RailKeeper **v0.1.18** and was last reviewed on 2026-08-16.

--- a/docs/site/guide/exhibition/entries-and-printing.md
+++ b/docs/site/guide/exhibition/entries-and-printing.md
@@ -3,7 +3,7 @@ title: Entries and printing
 description: Record exhibition locomotives, resolve address conflicts, and print the operating list.
 audience: user
 status: stable
-reviewedVersion: 0.1.17.6
+reviewedVersion: 0.1.18
 lastReviewed: 2026-08-16
 ---
 
@@ -36,7 +36,7 @@ Select an open list and use the add-entry control in the entry panel. **Create e
 | Owner | Required. Leading and trailing whitespace is removed on the server. |
 | Locomotive name | Required. Leading and trailing whitespace is removed on the server. |
 
-Use **Edit** on an existing row to open **Edit entry** with its current values. Stable v0.1.17.6
+Use **Edit** on an existing row to open **Edit entry** with its current values. Stable v0.1.18
 does not expose a vehicle picker or a visible vehicle-link field in this dialog. The entry remains
 an exhibition record even when its description resembles a vehicle in general inventory.
 
@@ -151,7 +151,7 @@ Selecting a symbol applies the symbol label as the function name when the picker
 Review the name after choosing a symbol. On **Save**, RailKeeper stores only configured functions as
 structured data. The table, detail view, and report show only those functions.
 
-Stable v0.1.17.6 can also read earlier plain-text values separated by commas, semicolons, or lines
+Stable v0.1.18 can also read earlier plain-text values separated by commas, semicolons, or lines
 when each item starts with a key such as `F1 Sound`. Opening and saving such an entry writes the
 currently configured structured representation.
 
@@ -222,5 +222,5 @@ An empty list produces a report row reading **No entries.**
 
 ## Documented RailKeeper version
 
-This page describes stable RailKeeper v0.1.17.6. Development behavior on `main` may differ and is
+This page describes stable RailKeeper v0.1.18. Development behavior on `main` may differ and is
 not part of this user workflow.

--- a/docs/site/guide/exhibition/index.md
+++ b/docs/site/guide/exhibition/index.md
@@ -3,7 +3,7 @@ title: Exhibition workspace
 description: Prepare, maintain, review, and print exhibition lists safely.
 audience: user
 status: stable
-reviewedVersion: 0.1.17.6
+reviewedVersion: 0.1.18
 lastReviewed: 2026-08-16
 ---
 
@@ -13,7 +13,7 @@ The **Exhibition list** workspace keeps the information needed for an exhibition
 one operational view. Each list has a date, an open or locked state, and its own locomotive
 entries. Operators can maintain an open list without entering the general vehicle inventory.
 
-This chapter documents stable RailKeeper v0.1.17.6. It does not explain user administration,
+This chapter documents stable RailKeeper v0.1.18. It does not explain user administration,
 master-data administration, backup operation, or the layout workspace.
 
 ## Access rights and isolation
@@ -122,5 +122,5 @@ already have succeeded before the refresh failed.
 
 ## Documented RailKeeper version
 
-This page describes stable RailKeeper v0.1.17.6. Development behavior on `main` may differ and is
+This page describes stable RailKeeper v0.1.18. Development behavior on `main` may differ and is
 not part of this user workflow.

--- a/docs/site/guide/exhibition/lists-and-locking.md
+++ b/docs/site/guide/exhibition/lists-and-locking.md
@@ -3,7 +3,7 @@ title: Lists and locking
 description: Create exhibition lists, control their lock state, and remove them safely.
 audience: user
 status: stable
-reviewedVersion: 0.1.17.6
+reviewedVersion: 0.1.18
 lastReviewed: 2026-08-16
 ---
 
@@ -41,7 +41,7 @@ reloads the list table. The create operation is an immediate server write; the d
 only local form state until it succeeds.
 
 If either required field is empty, the browser prevents normal submission. The server also rejects
-blank values after trimming them. In stable v0.1.17.6 the server checks that the date value is not
+blank values after trimming them. In stable v0.1.18 the server checks that the date value is not
 empty; the date control supplies the normal calendar value.
 
 ## Select, sort, and inspect lists
@@ -126,5 +126,5 @@ log. Audit-log operation belongs to administration and is not documented on this
 
 ## Documented RailKeeper version
 
-This page describes stable RailKeeper v0.1.17.6. Development behavior on `main` may differ and is
+This page describes stable RailKeeper v0.1.18. Development behavior on `main` may differ and is
 not part of this user workflow.

--- a/docs/site/guide/getting-started/index.md
+++ b/docs/site/guide/getting-started/index.md
@@ -3,14 +3,14 @@ title: First setup and sign-in
 description: Create the first administrator, sign in securely, and recover access to RailKeeper.
 audience: user
 status: stable
-reviewedVersion: 0.1.17.6
+reviewedVersion: 0.1.18
 lastReviewed: 2026-08-16
 ---
 
 # First setup and sign-in
 
 This chapter covers the first administrator account, normal and two-factor sign-in, sign-out, and
-password recovery. It describes stable RailKeeper v0.1.17.6.
+password recovery. It describes stable RailKeeper v0.1.18.
 
 ## Before you start
 
@@ -74,7 +74,7 @@ Password recovery depends on the email address stored for the account.
 6. Set the password, return to sign-in, and use the new credentials.
 
 The confirmation shown in the sign-in form is deliberately identical for known and unknown
-addresses. However, the v0.1.17.6 HTTP response includes an `expiresAt` value only for a known
+addresses. However, the v0.1.18 HTTP response includes an `expiresAt` value only for a known
 account. API clients or people inspecting network responses can therefore infer whether an account
 exists. Operators must treat this as a known account-enumeration limitation of this release.
 
@@ -107,7 +107,7 @@ confirmations to ten within ten minutes.
 - Use HTTPS and secure cookies when the instance is reachable over a network. See
   [Installation and Administration](/administration/) for the operating requirements.
 - The generic message shown by the form is not complete account-enumeration protection in
-  v0.1.17.6 because the HTTP response schema differs for known accounts. Restrict network access,
+  v0.1.18 because the HTTP response schema differs for known accounts. Restrict network access,
   monitor repeated reset attempts, and apply a release that corrects this behavior when available.
 - Ask an administrator to review unexpected sign-in or recovery activity rather than continuing to
   guess credentials.
@@ -119,5 +119,5 @@ confirmations to ten within ten minutes.
 
 ## Documented RailKeeper version
 
-This page documents stable RailKeeper **v0.1.17.6** and was last checked against the application on
+This page documents stable RailKeeper **v0.1.18** and was last checked against the application on
 2026-08-16.

--- a/docs/site/guide/index.md
+++ b/docs/site/guide/index.md
@@ -3,7 +3,7 @@ title: User Guide
 description: Learn every stable RailKeeper workflow.
 audience: user
 status: stable
-reviewedVersion: 0.1.17.6
+reviewedVersion: 0.1.18
 lastReviewed: 2026-08-16
 ---
 
@@ -13,7 +13,7 @@ This guide explains the complete published RailKeeper workflow for collectors, c
 workshops. It covers first setup, navigation, vehicles, accessories, decoder data, maintenance,
 documents, reports, exhibitions, and controlled import and export.
 
-Content in this section describes stable RailKeeper v0.1.17.6. The layout workspace is still under
+Content in this section describes stable RailKeeper v0.1.18. The layout workspace is still under
 development and is therefore not presented as a stable user feature.
 
 ## Start here

--- a/docs/site/guide/overview/index.md
+++ b/docs/site/guide/overview/index.md
@@ -3,7 +3,7 @@ title: Overview, metrics, and data quality
 description: Read the RailKeeper dashboard, follow data gaps, and arrange its widgets.
 audience: user
 status: stable
-reviewedVersion: 0.1.17.6
+reviewedVersion: 0.1.18
 lastReviewed: 2026-08-16
 ---
 
@@ -11,7 +11,7 @@ lastReviewed: 2026-08-16
 
 The **Overview** is RailKeeper's working dashboard for inventory size, recorded value,
 digitalization, maintenance, and data quality. This chapter explains what each number means and how
-to continue from an indicator to the affected vehicles. It describes stable RailKeeper v0.1.17.6.
+to continue from an indicator to the affected vehicles. It describes stable RailKeeper v0.1.18.
 
 Admin, Editor, Viewer, and Planner users can open the overview. An account with only the Messe role
 starts in **Exhibition** and cannot open this dashboard.
@@ -94,7 +94,7 @@ heading is **Inventory**, with the matching filter active.
 | **Without EAN** | Vehicles without an EAN |
 | **Digital without decoder no.** | Digital vehicles without a value in either decoder-number field |
 
-In v0.1.17.6, **Without main image** technically checks whether any image exists. It does not
+In v0.1.18, **Without main image** technically checks whether any image exists. It does not
 distinguish a specifically selected main image. When all four counts are zero, the widget reports
 that no major data gaps were detected.
 
@@ -201,4 +201,4 @@ shared with other browsers or saved as account-wide dashboard settings.
 
 ## Documented RailKeeper version
 
-This page documents stable RailKeeper **v0.1.17.6** and was last reviewed on 2026-08-16.
+This page documents stable RailKeeper **v0.1.18** and was last reviewed on 2026-08-16.

--- a/docs/site/guide/vehicles/decoder-cv.md
+++ b/docs/site/guide/vehicles/decoder-cv.md
@@ -3,7 +3,7 @@ title: Decoder, functions, and CV data
 description: Map digital functions, inspect speed curves, manage CV values, and store decoder files.
 audience: user
 status: stable
-reviewedVersion: 0.1.17.6
+reviewedVersion: 0.1.18
 lastReviewed: 2026-08-16
 ---
 
@@ -302,4 +302,4 @@ No failed later request rolls back an earlier successful request in the same seq
 
 ## Documented RailKeeper version
 
-This page documents stable RailKeeper **v0.1.17.6** and was last reviewed on 2026-08-16.
+This page documents stable RailKeeper **v0.1.18** and was last reviewed on 2026-08-16.

--- a/docs/site/guide/vehicles/index.md
+++ b/docs/site/guide/vehicles/index.md
@@ -3,7 +3,7 @@ title: Vehicle inventory and core records
 description: Search, filter, create, maintain, report, and safely delete RailKeeper vehicle records.
 audience: user
 status: stable
-reviewedVersion: 0.1.17.6
+reviewedVersion: 0.1.18
 lastReviewed: 2026-08-16
 ---
 
@@ -11,10 +11,10 @@ lastReviewed: 2026-08-16
 
 **Vehicle inventory** is the central workspace for model railway vehicles. It combines inventory
 status, search, filters, table and card views, core vehicle data, QR labels, and printable reports.
-This chapter describes stable RailKeeper v0.1.17.6.
+This chapter describes stable RailKeeper v0.1.18.
 
 Admin, Editor, Viewer, and Planner users can inspect the inventory. Creating, changing, and deleting
-vehicle records requires Admin or Editor. In v0.1.17.6, write controls can still be visible to Viewer
+vehicle records requires Admin or Editor. In v0.1.18, write controls can still be visible to Viewer
 and Planner users. The server rejects their write requests, and RailKeeper displays the error.
 
 Media, maintenance, decoder/CV data, article-data lookup, and spare parts have their own workflows.
@@ -38,16 +38,21 @@ when the browser regains focus, comes online, or returns from a hidden tab.
 
 ## Search the inventory
 
-Enter text in **Search inventory**. Each change reloads the vehicle list from the server. The search
-matches substrings in exactly four fields:
+Enter text in **Search inventory**. Each change reloads the vehicle list from the server. Leading
+and trailing spaces are ignored, and the search matches substrings in these fields:
 
 - Inventory number
 - Manufacturer
 - Article number
 - Designation
+- Series
+- Vehicle number
+- Decoder type
+- Home depot / assignment location
+- Maximum speed
 
 It does not search descriptions, railway companies, epochs, categories, decoder numbers, EANs, or
-other detail fields in v0.1.17.6. The filters below are applied in the browser to the vehicles
+other detail fields in v0.1.18. The filters below are applied in the browser to the vehicles
 returned by the server search. Search and filters therefore combine.
 
 If loading fails, the error appears above the list. Previously loaded rows can remain visible, so
@@ -57,15 +62,16 @@ resolve the error or refresh before treating them as current.
 
 Filter groups combine with AND logic. A vehicle must satisfy every active group.
 
-| Group | Stable v0.1.17.6 choices |
+| Group | Stable v0.1.18 choices |
 | --- | --- |
 | Inventory state | **All**, **Digital**, **Analog**, **With image**, **Without image** |
 | Maintenance | **All**, **Maintenance due**, **Without maintenance** |
-| Master data | Manufacturer, Category, Subtype |
+| Master data | Manufacturer, Category, Subtype, Railway company, Epoch |
+| Digital technology | Adapter / interface |
 | Operational flag | **Exhibition ready** |
 | Overview data gap | **Without article no.**, **Without EAN**, or **Digital without decoder no.** when opened from **Overview** |
 
-The **Without maintenance** label is imprecise in v0.1.17.6. It selects vehicles without a due
+The **Without maintenance** label is imprecise in v0.1.18. It selects vehicles without a due
 maintenance entry, including vehicles that have completed or non-due maintenance history.
 
 Selecting a category limits the subtype choices to distinct subtypes among the currently loaded
@@ -73,24 +79,32 @@ server-search results in that category and clears the current subtype selection.
 returns all groups to their defaults and removes an Overview `gap` parameter from the browser
 address. The result counter always reports the number after every active filter.
 
-Additional railway-company, epoch, and adapter filters available in later development are not part
-of stable v0.1.17.6.
-
 ## Choose a view and sort
 
 On a desktop, switch between table and card view with the view icons. RailKeeper stores that choice
 in the current browser's local storage. It is not an account-wide setting. At narrow widths, the
-interface uses a compact mobile list regardless of the desktop preference.
+interface uses compact, expandable vehicle cards regardless of the desktop preference.
 
-The table displays selection, image, inventory number, manufacturer, article number, designation,
-gauge, epoch, exhibition status, and actions. Sortable headers are Inventory number, Manufacturer,
-Article number, Designation, Gauge, and Epoch.
+Use **Choose table columns** to control visible columns and their order. The default selection is
+Image, Inventory number, Manufacturer, Article number, Designation, Gauge, Epoch, and Exhibition
+status. Additional short vehicle fields are available in domain groups. RailKeeper stores this
+preference server-side in the user account, so it remains available after a restart and in another
+browser.
+
+Inventory number may be hidden. If that would leave no data column visible, RailKeeper restores it
+automatically. **Reset to defaults** restores both selection and order. Columns introduced by a
+later version remain hidden initially in existing user configurations.
+
+Every offered column except Image and Exhibition status is sortable. If the active sort column is
+hidden, RailKeeper falls back to Inventory number where possible or to the first remaining sortable
+column.
 
 The initial order is Inventory number ascending with numeric-aware comparison, so `...2` sorts
 before `...10`. Select the active header again to reverse its direction. Card and mobile layouts
-follow the current table sort but do not expose separate sort controls.
+follow the current table sort but do not expose separate sort controls. Mobile cards use the
+configured column selection and reveal additional fields in the configured order when expanded.
 
-In the English locale, the table/card and refresh tooltips remain German in v0.1.17.6. This is a
+In the English locale, the table/card and refresh tooltips remain German in v0.1.18. This is a
 localization limitation, not a different operation.
 
 ## Select vehicles
@@ -183,7 +197,7 @@ sources. Suggestions require user review and belong to the separate article-sear
 
 ## Stable select choices
 
-The following choices are static in v0.1.17.6. Their stored values remain German in both UI
+The following choices are static in v0.1.18. Their stored values remain German in both UI
 locales.
 
 | Field | Choices |
@@ -191,7 +205,7 @@ locales.
 | Wheelset | `2-Leiter DC`, `3-Leiter AC`, `NEM`, `RP25`, `Metall`, `Kunststoff` |
 | Coupling | `NEM-Schacht`, `Kurzkupplung`, `Bügelkupplung`, `Klauenkupplung`, `Schraubenkupplung` |
 | Power pickup | `Schiene`, `Oberleitung`, `Batterie`, `Akku` |
-| Adapter / interface | `NEM 651`, `NEM 652`, `PluX16`, `PluX22`, `MTC21`, `Next18`, `8-polig`, `21-polig` |
+| Adapter / interface | `NEM 651`, `NEM 652`, `PluX12`, `PluX16`, `PluX22`, `MTC21`, `Next18`, `8-polig`, `21-polig` |
 | Acquisition | `Kauf`, `Tausch`, `Geschenk`, `Erbe`, `Leihgabe`, `Sonstiges` |
 | from/at | `Händler`, `Privat`, `Messe / Börse`, `Online`, `Auktion`, `Hersteller`, `Verein`, `Sonstiges` |
 | Location | `Auf Anlage`, `Vitrine`, `Lager`, `Werkstatt`, `Transportbox`, `Ausgeliehen`, `Sonstiges` |
@@ -228,7 +242,7 @@ Decoder-Nr.: <decoder number, only when available>
 RailKeeper uses the primary digital decoder number first, then the DT decoder number. The QR dialog
 can download PNG or SVG and open a printable label. The quick menu and read-only view can generate a
 QR code whenever identity data exists. The **Create QR code** switch controls only the QR button in
-the edit-form Details section in v0.1.17.6.
+the edit-form Details section in v0.1.18.
 
 When either inventory number or designation is empty, the payload writes `-` for that field. At
 least one of the two fields must contain a value before RailKeeper creates the QR code.
@@ -254,7 +268,7 @@ maintenance, CV data, images, attachments, and external mappings. Printing one v
 quick menu or read-only view always creates a detail report with QR code and images enabled.
 
 Reports and some report labels are generated in German even under the English locale in
-v0.1.17.6. If no matching vehicle exists, RailKeeper does not create a report. Allow the print window
+v0.1.18. If no matching vehicle exists, RailKeeper does not create a report. Allow the print window
 if the browser blocks popups.
 
 ## Exhibition switch boundary
@@ -270,7 +284,7 @@ vehicle flag, but it does not delete an existing exhibition-list entry.
 ## Delete a vehicle
 
 Admin and Editor users can select **Delete** and confirm the vehicle identified by inventory number
-and designation. There is no undo or typed confirmation in v0.1.17.6.
+and designation. There is no undo or typed confirmation in v0.1.18.
 
 Deletion removes the vehicle and cascades through its vehicle-owned database records, including
 inventory-number history, images, attachment metadata, maintenance, functions, CV data, external
@@ -310,4 +324,4 @@ important records; the application does not promise physical cleanup of every re
 
 ## Documented RailKeeper version
 
-This page documents stable RailKeeper **v0.1.17.6** and was last reviewed on 2026-08-16.
+This page documents stable RailKeeper **v0.1.18** and was last reviewed on 2026-08-16.

--- a/docs/site/guide/vehicles/maintenance.md
+++ b/docs/site/guide/vehicles/maintenance.md
@@ -3,7 +3,7 @@ title: Vehicle maintenance and condition
 description: Record, schedule, complete, review, and safely remove vehicle maintenance entries.
 audience: user
 status: stable
-reviewedVersion: 0.1.17.6
+reviewedVersion: 0.1.18
 lastReviewed: 2026-08-16
 ---
 
@@ -100,7 +100,7 @@ When at least one link exists, the maintenance card shows image and attachment c
 **Linked media**. Manage image links in **Uploads**. Selecting **No maintenance** for an image is
 pending metadata until you use the vehicle's **Save changes** action.
 
-Stable v0.1.17.6 can display attachments that already contain a maintenance reference, but the
+Stable v0.1.18 can display attachments that already contain a maintenance reference, but the
 normal attachment row cannot assign or change that reference. Do not invent a reassignment flow
 that the interface does not provide.
 
@@ -116,7 +116,7 @@ Before deleting an entry:
 2. Check its linked image and attachment counts.
 3. In **Uploads**, select **No maintenance** for every linked image and use **Save changes**.
 4. If a linked attachment must retain the association, keep the maintenance entry. Stable
-   v0.1.17.6 has no attachment-link editor. Remove an attachment only after backup and content
+   v0.1.18 has no attachment-link editor. Remove an attachment only after backup and content
    review when the file is genuinely no longer needed.
 5. Return to **Maintenance**, confirm that **Linked media** no longer appears, then delete the entry.
 
@@ -163,4 +163,4 @@ A failed action does not undo an earlier successful independent maintenance or m
 
 ## Documented RailKeeper version
 
-This page documents stable RailKeeper **v0.1.17.6** and was last reviewed on 2026-08-16.
+This page documents stable RailKeeper **v0.1.18** and was last reviewed on 2026-08-16.

--- a/docs/site/guide/vehicles/media.md
+++ b/docs/site/guide/vehicles/media.md
@@ -3,7 +3,7 @@ title: Vehicle images and attachments
 description: Upload, organize, preview, download, and safely remove vehicle images and attachments.
 audience: user
 status: stable
-reviewedVersion: 0.1.17.6
+reviewedVersion: 0.1.18
 lastReviewed: 2026-08-16
 ---
 
@@ -105,7 +105,7 @@ name. If deletion fails, reload the record and do not assume the file or metadat
 ## Roles, storage, and backup boundaries
 
 Media is local and private RailKeeper data, not public website content. Application backups include
-stored vehicle media. In v0.1.17.6, however, RailKeeper accepts backup files up to 250 MiB for
+stored vehicle media. In v0.1.18, however, RailKeeper accepts backup files up to 250 MiB for
 validation and restore. Before extensive cleanup, export a backup and ask an Admin to select that
 file in the restore panel. Rely on it only after RailKeeper accepts it as compatible. This page
 makes no promise about copies downloaded or created outside RailKeeper.
@@ -143,4 +143,4 @@ editing maintenance records remain specialist boundaries that are not explained 
 
 ## Documented RailKeeper version
 
-This page documents stable RailKeeper **v0.1.17.6** and was last reviewed on 2026-08-16.
+This page documents stable RailKeeper **v0.1.18** and was last reviewed on 2026-08-16.

--- a/docs/site/guide/vehicles/search-and-spares.md
+++ b/docs/site/guide/vehicles/search-and-spares.md
@@ -3,7 +3,7 @@ title: Article search, web documents, and spare parts
 description: Verify external article data, import web documents, and maintain vehicle spare parts.
 audience: user
 status: stable
-reviewedVersion: 0.1.17.6
+reviewedVersion: 0.1.18
 lastReviewed: 2026-08-16
 ---
 
@@ -296,4 +296,4 @@ have been stored.
 
 ## Documented RailKeeper version
 
-This page documents stable RailKeeper **v0.1.17.6** and was last reviewed on 2026-08-16.
+This page documents stable RailKeeper **v0.1.18** and was last reviewed on 2026-08-16.

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -4,12 +4,12 @@ title: RailKeeper Documentation
 description: Complete user, administration, and development documentation for RailKeeper.
 audience: reference
 status: stable
-reviewedVersion: 0.1.17.6
+reviewedVersion: 0.1.18
 lastReviewed: 2026-08-15
 hero:
   name: RailKeeper Documentation
   text: Workshop knowledge, kept with the project
-  tagline: User guidance follows stable v0.1.17.6. Development documentation follows main.
+  tagline: User guidance follows stable v0.1.18. Development documentation follows main.
   image:
     src: /brand/railkeeper-logo.png
     alt: RailKeeper

--- a/docs/versions.json
+++ b/docs/versions.json
@@ -1,4 +1,4 @@
 {
-  "stable": "0.1.17.6",
+  "stable": "0.1.18",
   "development": "main"
 }


### PR DESCRIPTION
## Zusammenfassung

- Version und Docker-Beispiele auf v0.1.18 anheben
- zweisprachige Changelogs und Release Notes ergänzen
- stabiles Handbuch auf v0.1.18 aktualisieren, einschließlich Fahrzeugspalten, Suche, Filter und mobiler Karten
- Windows-Update- und Datensicherheit dokumentieren

## Prüfung

- `go test ./...`
- `npm.cmd run test -- --run` (102 Dateien, 523 Tests)
- `npm.cmd run build`
- `docs: npm.cmd run check` (19 Tests, Metadatenprüfung, VitePress-Build)
- Windows-Paketvalidierung
- ZIP geprüft: 106 Einträge, 0 Datenbank-/Benutzerdaten
- lokales Windows-ZIP SHA-256: `D26C351DE67DA1200A3B63B9354CAFACAD5ACCAEB3B126EA1B101C08350EC2F4`