### PR TITLE
docs: add bilingual import and export guide

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -73,6 +73,15 @@ export default defineConfig({
                 { text: "Einträge und Drucken", link: "/de/guide/exhibition/entries-and-printing" },
               ],
             },
+            {
+              text: "Import und Export",
+              items: [
+                { text: "Überblick und Berechtigungen", link: "/de/guide/import-export/" },
+                { text: "Fahrzeugdateien importieren", link: "/de/guide/import-export/file-import" },
+                { text: "Bestand exportieren", link: "/de/guide/import-export/exports" },
+                { text: "ECoS-Lokabgleich", link: "/de/guide/import-export/ecos-sync" },
+              ],
+            },
           ],
           "/de/administration/": [
             {
@@ -163,6 +172,15 @@ export default defineConfig({
             { text: "Exhibition workspace", link: "/guide/exhibition/" },
             { text: "Lists and locking", link: "/guide/exhibition/lists-and-locking" },
             { text: "Entries and printing", link: "/guide/exhibition/entries-and-printing" },
+          ],
+        },
+        {
+          text: "Import and export",
+          items: [
+            { text: "Overview and permissions", link: "/guide/import-export/" },
+            { text: "Import vehicle files", link: "/guide/import-export/file-import" },
+            { text: "Export inventory", link: "/guide/import-export/exports" },
+            { text: "ECoS locomotive sync", link: "/guide/import-export/ecos-sync" },
           ],
         },
       ],

--- a/docs/coverage.json
+++ b/docs/coverage.json
@@ -67,7 +67,7 @@
     {
       "id": "import-export",
       "audience": "user",
-      "status": "planned",
+      "status": "documented",
       "englishPath": "guide/import-export/index.md",
       "germanPath": "de/guide/import-export/index.md"
     },

--- a/docs/site/de/guide/import-export/ecos-sync.md
+++ b/docs/site/de/guide/import-export/ecos-sync.md
@@ -1,0 +1,136 @@
+---
+title: ECoS-Lokabgleich
+description: Ausgewählte ESU-ECoS-Lokdaten lesen, prüfen, importieren und ausdrücklich schreiben.
+audience: user
+status: stable
+reviewedVersion: 0.1.18
+lastReviewed: 2026-08-16
+---
+
+# ECoS-Lokabgleich
+
+Der ECoS-Arbeitsbereich liest Lokstammdaten, statische Funktionsbeschreibungen und bereitgestellte
+CV-Werte aus einer aktiven ESU ECoS. Jede Lok bleibt in einer Arbeitsliste, bis ein Admin sie im
+Fahrzeugeditor öffnet und speichert oder bewusst überspringt.
+
+Alle ECoS-API-Routen sind ausschließlich für Admin verfügbar. Die Digitalzentrale muss vor der
+Verwendung unter **Einstellungen > Digitalzentralen** eingerichtet und geprüft werden. Host und
+Port sind im Import-Arbeitsbereich schreibgeschützt.
+
+## Unterstützte und nicht unterstützte Digitalzentralen
+
+| Aktiver Anbieter | Verhalten unter Import/Export in v0.1.18 |
+| --- | --- |
+| ESU ECoS | Leseablauf, Fahrzeugübergabe, CV- und statische Funktionsvorschläge sowie geprüfter Schreib-Sync sind verfügbar. |
+| Z21, Intellibox 3 oder Märklin CS3 | RailKeeper zeigt, dass der Importpfad vorbereitet, aber noch nicht umgesetzt ist. |
+| Kein aktiver Anbieter | Die Seite zeigt einen Verweis zu den Digitalzentralen-Einstellungen. |
+
+RailKeeper überwacht in diesem Ablauf weder Geschwindigkeit noch Richtung, aktive
+Funktionszustände, Lokbilder oder Anlagenobjekte. Laufzeitattribute wie Geschwindigkeit, Richtung
+und Funktionsstatus werden aus der Prüfung ausgeschlossen. Nur statische Funktionsbeschreibungen
+und CV-Werte, die das ECoS-Lokobjekt bereitstellt, kommen infrage.
+
+## Lok-Arbeitsliste einlesen
+
+Mit aktivierter ECoS und gespeichertem Host:
+
+1. **Import/Export** öffnen.
+2. Live-Monitor-Zustand sowie gespeicherten Host und Port prüfen.
+3. **Daten holen** wählen.
+4. Auf Lokanzahl und Arbeitsliste warten.
+5. ECoS-Name, Objekt-ID, Adresse, erkannten RailKeeper-Treffer, Decoderhinweis, CV-Anzahl und
+   aktuellen Arbeitslistenstatus prüfen.
+
+RailKeeper fragt den ECoS-Live-Zustand alle 15 Sekunden ab. Ist der Live-Monitor bereits verbunden,
+holt die Seite einmal automatisch Daten, sofern weder Prüfergebnis noch Importsitzung aktiv sind.
+
+Ein erfolgreicher Abruf erzeugt eine Arbeitssitzung im Sitzungsspeicher des Browser-Tabs. Nach der
+Rückkehr aus dem Fahrzeugeditor werden Liste und Zustände **offen**, **in Bearbeitung**,
+**gespeichert** oder **übersprungen** wiederhergestellt. Das Schließen des Browser-Tabs beendet
+diese browserseitige Speicherung.
+
+## So wird ein bestehendes Fahrzeug vorgeschlagen
+
+RailKeeper prüft Kandidaten in dieser Reihenfolge:
+
+1. vorhandene externe ECoS-Zuordnung mit derselben ECoS-Objekt-ID;
+2. gleiche Decoder-Adresse unter **Digital / Decoder-Nr.**;
+3. normalisierter Vergleich mit Fahrzeugbezeichnung oder Fahrzeugnummer.
+
+Der Namensvergleich ignoriert Groß- und Kleinschreibung, Umlautschreibweise, Satzzeichen sowie ein
+führendes `BR` oder `V` vor einer Zahl. Bei längeren Namen wird auch ein Enthaltensein akzeptiert.
+Diese Treffer sind Vorschläge, kein Identitätsnachweis. Inventarnummer und Fahrzeug müssen vor
+Update oder ECoS-Schreibvorgang geprüft werden.
+
+## CV- und Funktionsvorschläge prüfen
+
+Arbeitsliste und CV-Vorschau zeigen ausschließlich Werte, welche die ECoS geliefert hat.
+Standard-CV-Definitionen ergänzen nach Möglichkeit Bedeutung, Kategorie und Interpretation. CV8
+kann den Decoder-Hersteller aus RailKeeper-Stammdaten erkennen. Eine fehlende oder unbekannte CV8
+bleibt sichtbar ungeklärt. Fehlende CVs blockieren den Import nicht.
+
+Statische ECoS-Funktionsbeschreibungen werden zu F-Tasten-Vorschlägen und nach Möglichkeit
+RailKeeper-Symbolen zugeordnet. Der aktive Ein-/Aus-Zustand wird nie importiert. Funktions- und
+CV-Vorschau müssen vor dem Speichern im Fahrzeugeditor geprüft werden.
+
+## Ein Fahrzeug anlegen oder aktualisieren
+
+Bei einer nicht zugeordneten Lok **Fahrzeug erfassen**, bei einem Vorschlag **Treffer
+aktualisieren** wählen. Die allgemeine CSV/XML/JSON-Prüfung wird nicht verwendet. RailKeeper öffnet
+direkt den Fahrzeugeditor und übergibt:
+
+- ECoS-Objekt-ID, Name, Adresse, Protokoll und Profil als Quellkontext;
+- Name, Kategorie, Digitalzustand, Decoder-Adresse, Decoder-Typ und Beschreibung als
+  Fahrzeugfeld-Vorschläge;
+- eine externe ECoS-Zuordnung;
+- statische Funktionsvorschläge;
+- CV-Wert-Vorschläge.
+
+Bei einem neuen Fahrzeug lautet die voreingestellte Kategorie `Lokomotive`. Hersteller,
+Bezeichnung, Spurweite, Kategorie und Gattung bleiben Pflichtfelder. Nicht von der ECoS gelieferte
+Felder werden hervorgehoben und müssen vor dem Speichern geklärt werden.
+
+Das Speichern führt mehrere Schreibvorgänge nacheinander aus: zuerst Fahrzeuggrunddaten, dann
+ECoS-Zuordnung, CV-Werte und konfigurierte Funktionen. Erst nach dem vollständigen Erfolg wird die
+Arbeitslistenzeile **gespeichert** und RailKeeper kehrt zur ECoS-Sitzung zurück. Scheitert ein
+späterer Schritt, kann das Grundfahrzeug bereits angelegt oder aktualisiert sein. Vor einem erneuten
+Versuch muss es geprüft werden, um Duplikate oder wiederholte Werte zu vermeiden.
+
+**Überspringen** verwenden, wenn eine Lok unverändert bleiben soll. **Nächste offene Lok** wählt
+den nächsten offenen Eintrag, danach einen noch in Bearbeitung markierten Eintrag, wenn kein offener
+Eintrag mehr vorhanden ist.
+
+## Geprüfte RailKeeper-Daten in die ECoS schreiben
+
+Der Schreib-Sync ist nur bei einer Lok mit erkanntem RailKeeper-Treffer verfügbar:
+
+1. Prüfen, ob das vorgeschlagene Fahrzeug stimmt.
+2. **Sync prüfen** wählen. Diese Vorschau schreibt nichts in die Digitalzentrale.
+3. Bis zu drei angezeigte Unterschiede zwischen aktuellem ECoS-Wert und gewünschtem
+   RailKeeper-Wert prüfen.
+4. Sind Änderungen vorhanden, **In ECoS schreiben** wählen.
+5. Die Browser-Rückfrage für diese Lok bestätigen.
+
+Der stabile Schreibumfang ist bewusst eng: nur Name, Adresse und Protokoll. Leere Sollwerte werden
+nicht geschrieben. RailKeeper sendet die kombinierte ECoS-Änderung erst nach ausdrücklicher
+Bestätigung, lädt danach das RailKeeper-Fahrzeug neu und markiert dessen externe Zuordnung nach
+Möglichkeit als synchronisiert.
+
+CVs, Funktionsdefinitionen, Geschwindigkeit, Richtung, aktive Funktionen, Bilder und Anlagenobjekte
+werden nicht in die Digitalzentrale geschrieben.
+
+## Fehlerbehebung
+
+| Symptom | Prüfen |
+| --- | --- |
+| ECoS-Arbeitsbereich fehlt oder ist deaktiviert | Prüfen, ob ein Admin ECoS aktiviert und unter Digitalzentralen einen nicht leeren Host gespeichert hat. |
+| Ein anderer Anbieter ist aktiv | v0.1.18 setzt diesen Importpfad nur für ECoS um. |
+| Datenabruf scheitert | Netzwerkerreichbarkeit, gespeicherten Host und Port, ECoS-Verfügbarkeit und Admin-Rolle prüfen. |
+| Ein falsches Fahrzeug wird vorgeschlagen | Nicht aktualisieren oder synchronisieren. Zuerst externe Zuordnung oder Decoder-/Namensdaten im Fahrzeugablauf korrigieren. |
+| Eine CV oder Funktion fehlt | Das ECoS-Lokobjekt hat sie nicht bereitgestellt oder RailKeeper hat sie nicht als statischen unterstützten Wert erkannt. Fehlende CVs blockieren das Speichern nicht. |
+| Arbeitsliste kehrt zurück, aber Zeile ist nicht gespeichert | Die vollständige Folge aus Fahrzeug, Zuordnung, CVs und Funktionen wurde nicht beendet. Fahrzeug und Fehler vor erneutem Versuch prüfen. |
+| **In ECoS schreiben** ist nicht sichtbar | Zuerst **Sync prüfen** ausführen. Die Schreibschaltfläche erscheint nur bei einem Treffer mit nicht leerem, noch nicht angewendetem Änderungsplan. |
+
+## Dokumentierte RailKeeper-Version
+
+Diese Seite dokumentiert RailKeeper **v0.1.18** und wurde zuletzt am 16.08.2026 geprüft.

--- a/docs/site/de/guide/import-export/exports.md
+++ b/docs/site/de/guide/import-export/exports.md
@@ -1,0 +1,88 @@
+---
+title: Bestand exportieren
+description: CSV, RailKeeper-JSON und eine druckbare Fahrzeug-Bestandsausgabe erstellen.
+audience: user
+status: stable
+reviewedVersion: 0.1.18
+lastReviewed: 2026-08-16
+---
+
+# Bestand exportieren
+
+Die Exportaktionen verwenden die vollständige Fahrzeugliste, die **Import/Export** lädt. Sie
+übernehmen keine Suche oder Filter der Fahrzeugbestandsseite. Alle drei Bedienelemente bleiben
+deaktiviert, während die Liste geladen wird oder wenn keine Fahrzeuge vorhanden sind.
+
+Admin, Editor, Viewer und Planner dürfen exportieren. Der Export verändert keine RailKeeper-Daten.
+
+## CSV-Export
+
+**CSV exportieren** lädt `railkeeper-bestand.csv` mit folgenden Eigenschaften herunter:
+
+- UTF-8-Text mit Byte-Reihenfolge-Markierung für Tabellenprogramm-Kompatibilität;
+- durch Semikolon getrennte Spalten;
+- die 62 skalaren Ziele aus [Fahrzeugdateien importieren](/de/guide/import-export/file-import);
+- Spaltenbezeichnungen in der aktuell gewählten RailKeeper-Oberflächensprache;
+- übersetzte Ja-/Nein-Texte für boolesche Felder;
+- doppelte Anführungszeichen zur Maskierung von Semikolons, Anführungszeichen und Zeilenumbrüchen.
+
+Dies ist der breiteste stabile Rundlauf für Fahrzeugfelder. Eine CSV aus einer Oberflächensprache
+wird durch die eingebauten deutschen und englischen Spaltenaliasse erkannt. Trotzdem müssen
+Zuordnung und Zeilen vor dem Schreiben in eine andere Installation geprüft werden.
+
+Die CSV enthält keine Bilder, Beilagendateien, Wartungen, Ersatzteile, Funktionsdatensätze,
+CV-Datensätze, Decoder-Dateien oder externe Zuordnungen.
+
+## RailKeeper-JSON-Export
+
+**JSON exportieren** lädt `railkeeper-bestand.json` herunter. Die oberste Struktur lautet:
+
+```json
+{
+  "format": "railkeeper-vehicles",
+  "version": 1,
+  "vehicles": []
+}
+```
+
+Das `vehicles`-Array enthält die Fahrzeugobjekte, welche an diese Seite geliefert wurden. Dadurch
+eignet sich JSON zur Prüfung und für einen verlustärmeren Datenaustausch, ist aber keine
+Anwendungssicherung und kein vollständiges Wiederherstellungsformat.
+
+Der stabile JSON-Import von v0.1.18 liest pro Objekt nur 14 Felder. Er stellt nicht alle im
+exportierten Objekt vorhandenen Eigenschaften, verschachtelten Datensätze oder gespeicherten
+Dateibytes wieder her. Vor einem Rundlauf die genaue
+[JSON-Teilmenge](/de/guide/import-export/file-import#teilmenge-beim-json-import) prüfen.
+
+## PDF- und Druckansicht
+
+**PDF/Druckansicht** öffnet ein neues Browserfenster und startet sofort den Browser-Druckdialog.
+Das Dokument verwendet A4 im Querformat und enthält:
+
+- Gesamtzahl sowie Anzahl digitaler und analoger Fahrzeuge;
+- Erstellungsdatum und -uhrzeit;
+- Inventarnummer, Hersteller, Artikel-Nr., Bezeichnung, Spurweite, Epoche, Kategorie,
+  Digital/Analog und Listenpreis für jedes Fahrzeug.
+
+RailKeeper erzeugt keine PDF-Datei auf dem Server. Im Browser-Druckdialog **Als PDF speichern**
+wählen, wenn Browser oder Betriebssystem dieses Ziel anbieten.
+
+Öffnet sich nichts, müssen Popups für die RailKeeper-Adresse erlaubt werden. Das Druckfenster
+maskiert Fahrzeugtexte, bevor sie in den Bericht eingesetzt werden.
+
+## Den Export wählen
+
+| Bedarf | Empfohlene Ausgabe |
+| --- | --- |
+| Unterstützte skalare Felder in einem Tabellenprogramm prüfen oder bearbeiten | CSV |
+| Die an die Seite gelieferten Fahrzeugobjekte im Rohformat prüfen | JSON |
+| Eine kompakte, lesbare Bestandsliste ausgeben oder archivieren | PDF/Druckansicht |
+| Anwendungsdaten, Uploads und zugehörige Datensätze wiederherstellen | Admin-Anwendungssicherung, nicht diese Exporte |
+
+Exportdateien müssen entsprechend der Vertraulichkeit des Bestands behandelt werden. Artikelquellen,
+Kaufdaten, Lagerorte, Werte, Notizen und andere private Sammlungsdetails können in CSV oder JSON
+enthalten sein.
+
+## Dokumentierte RailKeeper-Version
+
+Diese Seite dokumentiert RailKeeper **v0.1.18** und wurde zuletzt am 16.08.2026 geprüft.

--- a/docs/site/de/guide/import-export/file-import.md
+++ b/docs/site/de/guide/import-export/file-import.md
@@ -1,0 +1,146 @@
+---
+title: Fahrzeugdateien importieren
+description: Fahrzeugzeilen aus CSV, TSV, XML oder JSON zuordnen, prüfen und speichern.
+audience: user
+status: stable
+reviewedVersion: 0.1.18
+lastReviewed: 2026-08-16
+---
+
+# Fahrzeugdateien importieren
+
+Der Dateiimport ist ein Prüfvorgang, kein direkter Datenbankimport. RailKeeper liest die gewählte
+Datei, ordnet ihre Spalten zu, prüft jede Zeile gegen die bereits geladenen Fahrzeuge und lässt
+einen berechtigten Benutzer auswählen, welche Zeilen angelegt oder aktualisiert werden.
+
+Zum Speichern ist ein Editor- oder Admin-Konto erforderlich. Viewer und Planner können die
+Vorschau prüfen, ihre Fahrzeug-Schreibvorgänge werden aber vom Server abgelehnt.
+
+## Unterstützte Eingabeformate
+
+| Endung | Stabile Auswertung |
+| --- | --- |
+| `.csv` | Verwendet den häufigsten Trenner in der ersten nicht leeren Zeile: Tabulator, Semikolon oder Komma. Bei Gleichstand zwischen Semikolon und Komma gewinnt das Semikolon. |
+| `.tsv` | Verwendet immer einen Tabulator als Trenner. |
+| `.xml` | Liest Elemente mit den Namen `vehicle`, `fahrzeug`, `locomotive` oder `lok`. Fehlen diese, verwendet RailKeeper das am häufigsten wiederholte verschachtelte Element als Datensatzform. Attribute und direkte Text-Kindelemente werden zu Spalten. |
+| `.json` | Akzeptiert ein Fahrzeug-Array oder ein Objekt mit einem `vehicles`-Array. Der stabile Import übernimmt nur die unten genannte JSON-Teilmenge. |
+
+Getrennte Werte können in doppelte Anführungszeichen eingeschlossen werden. Doppelte
+Anführungszeichen innerhalb eines solchen Feldes werden korrekt aufgelöst. Führende und
+nachgestellte Leerzeichen werden aus jeder Zelle entfernt, vollständig leere Zeilen werden
+ignoriert.
+
+Ungültige JSON- oder XML-Dokumente werden nicht unterstützt. XML ohne auswertbare Datensätze meldet
+eine leere Tabelle. Nach der Korrektur muss die Datei erneut ausgewählt werden.
+
+## Teilmenge beim JSON-Import
+
+Der JSON-Export verpackt die Fahrzeugliste als `{ "format": "railkeeper-vehicles", "version": 1,
+"vehicles": [...] }`. Der stabile JSON-Import prüft `format` und `version` nicht und übernimmt nicht
+jede Eigenschaft. Er erzeugt seine Prüftabelle nur aus diesen 14 Feldern:
+
+| Identität | Einordnung | Betrieb und Wert |
+| --- | --- | --- |
+| Inventarnummer, Hersteller, Artikel-Nr., Bezeichnung | Spurweite, Epoche, Bahngesellschaft, Kategorie, Gattung | Höchstgeschwindigkeit, Heimat-Bw / Einsatzstelle, Digital, Digital / Decoder-Nr., Listenpreis |
+
+Verwende CSV für den vollständigen unterstützten Austausch der 62 skalaren Felder. Verwende eine
+Anwendungssicherung, wenn wiederherstellbare Anwendungsdaten und Uploads benötigt werden.
+
+## Spaltenzuordnung
+
+Die erste Zeile liefert die Spaltennamen. RailKeeper normalisiert Groß- und Kleinschreibung,
+Leerzeichen, deutsche Umlaute, übliche Satzzeichen sowie bekannte deutsche und englische Aliasse,
+bevor nach einem Zielfeld gesucht wird.
+
+Nach dem Laden einer Datei:
+
+1. Die Anzahl **zugeordnet** und **offen** prüfen.
+2. Unter **Spaltenzuordnung** jede benötigte offene Spalte einem RailKeeper-Feld zuweisen.
+3. Eine nicht benötigte Quellspalte auf **Ignorieren** belassen.
+4. Vor dem Speichern die neu berechnete Importprüfung kontrollieren.
+
+Ein Zielfeld kann nur einer Quellspalte gehören. Wird dasselbe Ziel einer zweiten Spalte
+zugewiesen, löscht RailKeeper automatisch die vorherige Zuordnung. Jede Zuordnungsänderung baut
+alle Vorschauzeilen neu auf, daher anschließend Auswahl und Korrekturen erneut prüfen.
+
+## Alle 62 CSV- und Tabellenziele
+
+Der vollständige stabile CSV-Export verwendet dieselben Ziele und kann deshalb ohne manuelle
+Neuzuordnung importiert werden. Andere Dateien dürfen jede beliebige Teilmenge verwenden.
+
+| Gruppe | Unterstützte Felder |
+| --- | --- |
+| Identität und Katalog | Inventarnummer; Hersteller; Artikel-Nr.; Quelle / URL; Bezeichnung; Spurweite; Epoche; Bahngesellschaft; Kategorie; Gattung; Beschreibung; Baureihe; Fahrzeug-Nr.; EAN; Produktionszeit; Listenpreis |
+| Betrieb, Digital und Messe | Höchstgeschwindigkeit; Heimat-Bw / Einsatzstelle; Digital; Digital / Decoder-Nr.; Decoder-Typ; DT / Decoder; DT / Decoder-Nr.; Messe tauglich; Ausstellung; ABC-Bremsen; QR-Code erstellen |
+| Erwerb, Lagerung und Zustand | Erwerbsart; Erworben von/bei; Kaufpreis; Kaufdatum; Lagerort; Lagerdetails; Zustand; Zustandsdetails; Verpackung |
+| Physische und mechanische Daten | Länge (mm); Gewicht (g); Farbe; Beschriftung; Beladung; Inneneinrichtung; Achsen; Anzahl Achsen; Anzahl Haftreifen; Radsatz; Kupplung (V=H); Kupplung vorne; Kupplung hinten; Stromabnahme; Adapter / Schnittstelle |
+| Ausstattung und Hinweise | Antrieb; Antrieb Beschreibung; Fahrlicht; Fahrlicht Beschreibung; Beleuchtung; Beleuchtung Beschreibung; Soundgenerator; Soundgenerator Beschreibung; Rauchgenerator; Rauchgenerator Beschreibung; Zusatzinformationen |
+
+Bilder sowie andere verschachtelte oder dateibasierte Datensätze sind keine Ziele.
+
+## Boolesche Werte
+
+Bei Digital, DT / Decoder, Messe tauglich, Ausstellung, ABC-Bremsen, Kupplung (V=H), Antrieb,
+Fahrlicht, Beleuchtung, Soundgenerator, Rauchgenerator und QR-Code erstellen bedeuten diese nicht
+leeren Werte unabhängig von Groß- und Kleinschreibung **ja**:
+
+`1`, `ja`, `yes`, `true`, `wahr`, `digital`, `d`, `x`, `vorhanden`
+
+Jeder andere nicht leere Wert wird zu **nein**. Eine leere Zelle wird ignoriert. Verwende möglichst
+die eindeutigen Ja-/Nein-Werte des RailKeeper-CSV-Exports, um mehrdeutige Quelldaten zu vermeiden.
+
+## Prüfung und Vorauswahl
+
+Eine neue Zeile benötigt Hersteller, Bezeichnung, Spurweite, Kategorie und Gattung, bevor sie in
+der Vorschau ausgewählt werden kann. Beim Speichern kann der Server weitere Fahrzeugregeln prüfen.
+
+Zwei feldbezogene Prüfungen laufen bereits im Browser:
+
+- Die Höchstgeschwindigkeit muss eine ganze Zahl von 1 bis 1000 km/h sein.
+- Heimat-Bw / Einsatzstelle darf höchstens 200 Unicode-Zeichen enthalten.
+
+Eine ungültige Zeile wird als Fehler markiert, abgewählt und kann bis zur Korrektur des sichtbaren
+Problems oder der Quellzuordnung nicht ausgewählt werden. In der Prüftabelle lassen sich nur
+Inventarnummer, Hersteller, Artikel-Nr., Bezeichnung, Spurweite, Kategorie und Gattung direkt
+bearbeiten. Andere Werte müssen in der Quelldatei oder über die Spaltenzuordnung korrigiert und bei
+Bedarf neu geladen werden.
+
+## Neue Fahrzeuge und erkannte Duplikate
+
+RailKeeper vergleicht eine nicht leere Inventarnummer ohne Beachtung der Groß- und Kleinschreibung
+mit der aktuellen Fahrzeugliste.
+
+| Ergebnis | Standardverhalten |
+| --- | --- |
+| Kein Inventarnummer-Treffer und kein Prüfproblem | Aktion **Neu**, Zeile ausgewählt |
+| Bestehende Inventarnummer | Aktion **Aktualisieren**, Warnung, Zeile nicht ausgewählt |
+| Bestehende Inventarnummer plus weiteres Prüfproblem | Aktion **Aktualisieren**, Fehler, Zeile gesperrt |
+
+Bei einem Update die Feldvorschau aufklappen und **gleich**, **ergänzt leeres Feld** sowie
+**überschreibt** prüfen. Übernommen werden nur zugeordnete, nicht leere Zeichenketten, gültige
+Zahlen und ausgewertete boolesche Werte. Leere Quellzellen löschen vorhandene Zeichenketten nicht.
+Ein nicht leerer boolescher Wert außerhalb der Ja-Liste übernimmt ausdrücklich **nein**.
+
+Wird eine Duplikatzeile auf **Neu** umgestellt, entsteht kein zweites Fahrzeug mit derselben
+Inventarnummer. RailKeeper markiert die Zeile stattdessen als Fehler.
+
+## Geprüfte Auswahl speichern
+
+1. Sichtbare Grundfelder korrigieren und jeden Update-Vergleich prüfen.
+2. Nur die zu schreibenden Zeilen auswählen.
+3. **Auswahl speichern** wählen.
+4. Warten, bis jede erfolgreiche Zeile **gespeichert** anzeigt.
+5. Zeilenbezogene Fehler lesen und bereits gespeicherte Fahrzeuge vor einem erneuten Versuch
+   prüfen.
+
+Zeilen werden nacheinander verarbeitet. Jede ausgewählte Zeile ruft entweder die Fahrzeuganlage
+oder die Fahrzeugaktualisierung auf. Scheitert eine Zeile, wird sie zum Fehler und RailKeeper fährt
+mit späteren ausgewählten Zeilen fort. Der Vorgang ist daher nicht atomar und besitzt kein
+gemeinsames Rückgängig.
+
+Dateiimporte erzeugen keine Funktionszuordnungen, CV-Einträge, ECoS-Zuordnungen, Bilder, Beilagen,
+Wartungen, Ersatzteile oder Decoder-Dateien. Ergänze diese über die jeweiligen Fahrzeugabläufe.
+
+## Dokumentierte RailKeeper-Version
+
+Diese Seite dokumentiert RailKeeper **v0.1.18** und wurde zuletzt am 16.08.2026 geprüft.

--- a/docs/site/de/guide/import-export/index.md
+++ b/docs/site/de/guide/import-export/index.md
@@ -1,0 +1,88 @@
+---
+title: Import und Export
+description: Fahrzeugbestand sicher austauschen und den getrennten ECoS-Ablauf verstehen.
+audience: user
+status: stable
+reviewedVersion: 0.1.18
+lastReviewed: 2026-08-16
+---
+
+# Import und Export
+
+Der Arbeitsbereich **Import/Export** tauscht Fahrzeugbestand aus, ohne die normalen RailKeeper-
+Prüfungen und Berechtigungen zu umgehen. Dateiimporte werden zuerst als Prüftabelle aufbereitet.
+Exporte erstellen eine CSV-Datei, eine RailKeeper-JSON-Datei oder eine Druckansicht im Browser. Ein
+getrennt kontrollierter ECoS-Ablauf kann Lokdaten lesen und jede Lok einzeln an den Fahrzeugeditor
+übergeben.
+
+Dieses Kapitel dokumentiert RailKeeper v0.1.18. Es behandelt ausschließlich den
+Fahrzeugdatenaustausch. Stammdaten-Transfer, Digitalzentralen-Konfiguration sowie
+Anwendungssicherung und Wiederherstellung bleiben getrennte Administrationsaufgaben.
+
+## Zugriffsrechte
+
+Admin, Editor, Viewer und Planner können **Import/Export** öffnen. Ein reines Messe-Konto bleibt im
+isolierten Messearbeitsbereich und kann diese Seite nicht öffnen. Der Server prüft weiterhin jeden
+Lese- und Schreibvorgang einzeln.
+
+| Aktion | Admin | Editor | Viewer | Planner |
+| --- | --- | --- | --- | --- |
+| Aktuelle Fahrzeugliste laden | Ja | Ja | Ja | Ja |
+| CSV, JSON oder Druckansicht exportieren | Ja | Ja | Ja | Ja |
+| Datei einlesen und lokale Vorschau prüfen | Ja | Ja | Ja | Ja |
+| Fahrzeuge aus der Vorschau anlegen oder aktualisieren | Ja | Ja | Nein | Nein |
+| ECoS konfigurieren, lesen oder beschreiben | Ja | Nein | Nein | Nein |
+
+Die Seite blendet **Auswahl speichern** für Viewer und Planner nicht aus. Die geschützte Fahrzeug-
+API lehnt deren Schreibvorgang dennoch ab. Verwende für einen tatsächlichen Dateiimport ein
+Editor- oder Admin-Konto.
+
+## Den passenden Ablauf wählen
+
+| Ziel | Ablauf |
+| --- | --- |
+| CSV, TSV, XML oder RailKeeper-JSON prüfen und Fahrzeuge anlegen oder aktualisieren | [Fahrzeugdateien importieren](/de/guide/import-export/file-import) |
+| Aktuellen Fahrzeugbestand herunterladen oder kompakten Bestandsbericht drucken | [Bestand exportieren](/de/guide/import-export/exports) |
+| Loks, statische Funktionen und CV-Werte aus einer ESU ECoS lesen | [ECoS-Lokabgleich](/de/guide/import-export/ecos-sync) |
+| Hersteller, Spurweiten, Kategorien, Symbole oder andere Stammdaten übertragen | **Einstellungen > Stammdaten** verwenden, nicht diesen Arbeitsbereich |
+| Anwendungsdaten und gespeicherte Uploads erhalten oder wiederherstellen | Admin-Anwendungssicherung verwenden, keinen Fahrzeugexport |
+
+## Sicherer Arbeitsablauf
+
+1. Vor einem großen oder unbekannten Import einen Admin um eine aktuelle Anwendungssicherung
+   bitten.
+2. CSV als lesbare Vergleichsdatei exportieren, wenn die aktuellen skalaren Fahrzeugfelder in
+   einem Tabellenprogramm geprüft werden sollen.
+3. Quelldatei laden und jedes Pflichtfeld, jede Validierungsmeldung und jedes Duplikat klären.
+4. Nur geprüfte Zeilen auswählen. Besonders auf als Überschreibung gekennzeichnete Felder achten.
+5. Auswahl speichern und anschließend sowohl gespeicherte als auch fehlgeschlagene Zeilen prüfen.
+6. Nach einem großen Import einige repräsentative Fahrzeuge öffnen und deren Grunddaten prüfen.
+
+## Wichtige Grenzen
+
+- Der Dateiaustausch behandelt Fahrzeugfelder. Er stellt keine Bilder, Beilagendateien, Wartung,
+  Ersatzteile, Decoder-Dateien, Funktionszuordnungen, CV-Datensätze oder Benutzerkonten wieder her.
+- Die Dateivorschau wird im Browser berechnet. Eine Zeile wird erst durch **Auswahl speichern** mit
+  einem berechtigten Konto geschrieben.
+- Ausgewählte Zeilen werden nacheinander gespeichert, nicht als Alles-oder-nichts-Transaktion. Ein
+  späterer Fehler macht bereits als **gespeichert** markierte Fahrzeuge nicht rückgängig.
+- CSV ist das breiteste stabile Rundlaufformat für die 62 unterstützten skalaren Felder. Der
+  JSON-Import liest absichtlich weniger Felder, auch wenn der JSON-Export weitere Eigenschaften
+  enthält.
+- ECoS-Daten verwenden eine getrennte Arbeitsliste und Fahrzeugeditor-Übergabe. Sie gelangen nie
+  automatisch in die allgemeine Datei-Importprüfung.
+
+## Fehlerbehebung
+
+| Symptom | Prüfen |
+| --- | --- |
+| Export-Schaltflächen sind deaktiviert | Warten, bis die Fahrzeugliste geladen wurde. Bei leerem Bestand bleiben alle Export-Schaltflächen deaktiviert. |
+| Eine Spalte wird als offen angezeigt | Unter **Spaltenzuordnung** ein Zielfeld wählen oder bei einer nicht benötigten Spalte **Ignorieren** belassen. |
+| Eine Duplikatzeile ist nicht ausgewählt | Update-Vorschau prüfen und nur dann ausdrücklich auswählen, wenn der erkannte Inventarnummer-Treffer stimmt. |
+| Speichern scheitert trotz gültiger Vorschau | Admin- oder Editor-Rolle prüfen und die zeilenbezogene Servermeldung lesen. Die Servervalidierung bleibt maßgeblich. |
+| Einige Zeilen wurden vor einem Fehler gespeichert | Das ist beim sequenziellen Import zu erwarten. Gespeicherte Zeilen prüfen und nur fehlgeschlagene oder noch offene Zeilen wiederholen. |
+| Druckansicht öffnet sich nicht | Popups für die RailKeeper-Adresse erlauben und erneut versuchen. |
+
+## Dokumentierte RailKeeper-Version
+
+Dieses Kapitel dokumentiert RailKeeper **v0.1.18** und wurde zuletzt am 16.08.2026 geprüft.

--- a/docs/site/de/guide/index.md
+++ b/docs/site/de/guide/index.md
@@ -49,6 +49,10 @@ Verwendungshistorie.
 [Messearbeitsbereich](/de/guide/exhibition/) erklärt, wie du Listen vorbereitest, Betriebseinträge
 pflegst, Sperren verwendest, DCC- und SX-Adresskonflikte löst und den Veranstaltungsreport druckst.
 
+[Import und Export](/de/guide/import-export/) behandelt geprüfte Fahrzeugimporte aus CSV, TSV, XML
+und JSON, die drei Bestandsausgaben, deren Rundlaufgrenzen sowie den getrennten Admin-ECoS-
+Lokabgleich.
+
 ## Windows Standalone aktualisieren
 
 Unter **Einstellungen > Allgemein > Updates** nach einer neuen Version suchen. Erkennt RailKeeper

--- a/docs/site/guide/import-export/ecos-sync.md
+++ b/docs/site/guide/import-export/ecos-sync.md
@@ -1,0 +1,130 @@
+---
+title: ECoS locomotive sync
+description: Read, review, import, and explicitly write selected ESU ECoS locomotive data.
+audience: user
+status: stable
+reviewedVersion: 0.1.18
+lastReviewed: 2026-08-16
+---
+
+# ECoS locomotive sync
+
+The ECoS workspace reads locomotive master data, static function descriptions, and exposed CV
+values from an active ESU ECoS. Every locomotive remains in a work list until an Admin opens it in
+the vehicle editor, saves it, or deliberately skips it.
+
+All ECoS API routes are Admin-only. Configure and test the command station under **Settings >
+Digital command stations** before using this page. Host and port are read-only in the import
+workspace.
+
+## Supported and unsupported command stations
+
+| Active provider | Import/Export behavior in v0.1.18 |
+| --- | --- |
+| ESU ECoS | Read workflow, vehicle handoff, CV and static-function suggestions, and reviewed write sync are available. |
+| Z21, Intellibox 3, or Märklin CS3 | RailKeeper shows that the import path is prepared but not implemented. |
+| No active provider | The page shows a link to the Digital command-station settings. |
+
+RailKeeper does not monitor speed, direction, active function states, locomotive images, or layout
+objects in this workflow. Runtime attributes such as speed, direction, and function state are
+excluded from the review. Only static function descriptions and CV values exposed by the ECoS
+locomotive object are candidates.
+
+## Read the locomotive work list
+
+With an enabled ECoS and stored host:
+
+1. Open **Import/Export**.
+2. Check the live-monitor state and stored host and port.
+3. Choose **Fetch data**.
+4. Wait for the locomotive count and work list.
+5. Review the ECoS name, object ID, address, detected RailKeeper match, decoder hint, CV count, and
+   current work-list status.
+
+RailKeeper polls the ECoS live status every 15 seconds. When the live monitor is already connected,
+the page automatically fetches once if no probe or import session is active.
+
+A successful fetch creates a work session in the browser tab's session storage. Returning from the
+vehicle editor restores the list and its **open**, **editing**, **saved**, or **skipped** states.
+Closing the browser tab ends that browser-side persistence.
+
+## How an existing vehicle is suggested
+
+RailKeeper checks candidates in this order:
+
+1. an existing external ECoS mapping with the same ECoS object ID;
+2. the same decoder address in **Digital / decoder no.**;
+3. a normalized match against vehicle designation or vehicle number.
+
+Name comparison ignores case, umlaut spelling, punctuation, and a leading `BR` or `V` before a
+number. For longer names it also accepts containment. These matches are suggestions, not identity
+proof. Verify the inventory number and vehicle before updating or writing to the ECoS.
+
+## Review CV and function suggestions
+
+The work list and CV preview show only values returned by the ECoS. Standard CV definitions add a
+meaning, category, and interpretation where possible. CV8 can identify the decoder manufacturer
+from RailKeeper master data; an absent or unknown CV8 remains visibly unresolved. Missing CVs do
+not block the import.
+
+Static ECoS function descriptions become F-key suggestions and are matched to RailKeeper symbols
+where possible. Active on/off state is never imported. Review the function and CV previews in the
+vehicle editor before saving.
+
+## Create or update one vehicle
+
+Choose **Create vehicle** for an unmatched locomotive or **Update match** for a suggestion. The
+generic CSV/XML/JSON review is not used. RailKeeper opens the vehicle editor directly and carries:
+
+- ECoS object ID, name, address, protocol, and profile as source context;
+- name, category, digital state, decoder address, decoder type, and description as vehicle-field
+  suggestions;
+- an external ECoS mapping;
+- static function suggestions;
+- CV-value suggestions.
+
+For a new vehicle, Category defaults to the stored German value `Lokomotive`, even in the English
+interface. Manufacturer, Designation, Gauge, Category, and Subtype remain required. Fields that the
+ECoS could not supply are highlighted and must be resolved before saving.
+
+Saving runs several writes in sequence: vehicle core data first, then the ECoS mapping, CV values,
+and configured functions. Only after the full sequence succeeds does the work-list row become
+**saved** and RailKeeper return to the ECoS session. If a later step fails, the core vehicle may
+already exist or be updated. Inspect it before retrying to avoid duplicates or repeated values.
+
+Use **Skip** when a locomotive should remain unchanged. **Next open loco** selects the next open
+entry, then an entry still marked editing when no open one remains.
+
+## Write reviewed RailKeeper data to the ECoS
+
+Write sync is available only for a locomotive with a detected RailKeeper match:
+
+1. Verify that the suggested vehicle is correct.
+2. Choose **Check sync**. This is a dry run and does not write to the command station.
+3. Review up to three displayed differences between the current ECoS value and the desired
+   RailKeeper value.
+4. If changes exist, choose **Write to ECoS**.
+5. Confirm the browser prompt for that locomotive.
+
+The stable write scope is deliberately narrow: Name, Address, and Protocol only. Empty desired
+values are not written. RailKeeper sends the combined ECoS change only after explicit confirmation,
+then refreshes the RailKeeper vehicle and marks its external mapping as synchronized when possible.
+
+Writing does not send CVs, function definitions, speed, direction, active functions, images, or
+layout objects to the command station.
+
+## Troubleshooting
+
+| Symptom | Check |
+| --- | --- |
+| The ECoS workspace is absent or disabled | Confirm an Admin enabled ECoS and stored a non-empty host under Digital command stations. |
+| Another provider is active | v0.1.18 only implements this import path for ECoS. |
+| Fetching fails | Check network reachability, stored host and port, ECoS availability, and Admin role. |
+| A wrong vehicle is suggested | Do not update or sync it. Correct the external mapping or decoder/name data through the vehicle workflow first. |
+| A CV or function is missing | The ECoS locomotive object did not expose it, or RailKeeper did not recognize it as a static supported value. Missing CVs do not block saving. |
+| The work list returned after saving but the row is not saved | The complete vehicle, mapping, CV, and function sequence did not finish. Inspect the vehicle and error before retrying. |
+| **Write to ECoS** is not visible | Run **Check sync** first. The write button appears only for a match with a non-empty, unapplied change plan. |
+
+## Documented RailKeeper version
+
+This page documents stable RailKeeper **v0.1.18** and was last reviewed on 2026-08-16.

--- a/docs/site/guide/import-export/exports.md
+++ b/docs/site/guide/import-export/exports.md
@@ -1,0 +1,88 @@
+---
+title: Export inventory
+description: Create CSV, RailKeeper JSON, and printable vehicle inventory output.
+audience: user
+status: stable
+reviewedVersion: 0.1.18
+lastReviewed: 2026-08-16
+---
+
+# Export inventory
+
+The export actions use the complete vehicle list loaded by **Import/Export**. They do not inherit
+searches or filters from the vehicle-inventory page. All three controls remain disabled while the
+list is loading or when no vehicles exist.
+
+Admin, Editor, Viewer, and Planner can export. Export does not modify RailKeeper data.
+
+## CSV export
+
+**CSV export** downloads `railkeeper-bestand.csv` with these properties:
+
+- UTF-8 text with a byte-order mark for spreadsheet compatibility;
+- semicolon-separated columns;
+- the 62 scalar targets listed in [Import vehicle files](/guide/import-export/file-import);
+- column labels in the currently selected RailKeeper interface language;
+- localized yes/no text for boolean fields;
+- double-quote escaping for semicolons, quotes, and line breaks.
+
+This is the broadest stable vehicle-field round trip. A CSV created in one interface language is
+recognized through the built-in German and English header aliases. Still review its mapping and
+rows before writing it into another installation.
+
+The CSV excludes images, attachment bytes, maintenance, spare parts, function records, CV records,
+decoder files, and external mappings.
+
+## RailKeeper JSON export
+
+**JSON export** downloads `railkeeper-bestand.json`. Its top-level shape is:
+
+```json
+{
+  "format": "railkeeper-vehicles",
+  "version": 1,
+  "vehicles": []
+}
+```
+
+The `vehicles` array contains the vehicle objects returned to this page. This makes JSON useful for
+inspection and lower-loss data exchange, but it is not an application backup or a complete restore
+format.
+
+The stable v0.1.18 JSON importer reads only 14 fields from each object. It does not restore all
+properties present in the exported object, nested records, or stored file bytes. See the exact
+[JSON import subset](/guide/import-export/file-import#json-import-subset) before relying on a
+round trip.
+
+## PDF and print view
+
+**PDF/Print view** opens a new browser window and immediately starts the browser print dialog. The
+document uses A4 landscape and contains:
+
+- a total, digital, and analog vehicle count;
+- generation date and time;
+- Inventory number, Manufacturer, Article no., Designation, Gauge, Epoch, Category,
+  Digital/analog, and List price for every vehicle.
+
+RailKeeper does not generate a PDF file on the server. Choose **Save as PDF** in the browser print
+dialog when the browser or operating system provides that destination.
+
+If nothing opens, allow popups for the RailKeeper address. The print window escapes vehicle text
+before inserting it into the report.
+
+## Choosing an export
+
+| Need | Recommended output |
+| --- | --- |
+| Inspect or edit supported scalar fields in a spreadsheet | CSV |
+| Inspect the raw vehicle objects returned to the page | JSON |
+| Hand out or archive a compact human-readable inventory list | PDF/Print view |
+| Restore application data, uploads, and related records | Admin application backup, not these exports |
+
+Keep exported files according to the sensitivity of the inventory. Article sources, purchase data,
+storage locations, values, notes, and other private collection details can be present in CSV or
+JSON.
+
+## Documented RailKeeper version
+
+This page documents stable RailKeeper **v0.1.18** and was last reviewed on 2026-08-16.

--- a/docs/site/guide/import-export/file-import.md
+++ b/docs/site/guide/import-export/file-import.md
@@ -1,0 +1,140 @@
+---
+title: Import vehicle files
+description: Map, validate, review, and save vehicle rows from CSV, TSV, XML, or JSON.
+audience: user
+status: stable
+reviewedVersion: 0.1.18
+lastReviewed: 2026-08-16
+---
+
+# Import vehicle files
+
+File import is a review workflow, not a direct database load. RailKeeper reads the selected file,
+maps its columns, validates each row against the vehicles already loaded, and lets an authorized
+user choose which rows to create or update.
+
+Use an Editor or Admin account to save. Viewer and Planner can inspect the preview but the server
+rejects their vehicle writes.
+
+## Supported input formats
+
+| Extension | Stable interpretation |
+| --- | --- |
+| `.csv` | Uses the most frequent delimiter in the first non-empty line: tab, semicolon, or comma. A tie between semicolon and comma prefers semicolon. |
+| `.tsv` | Always uses a tab delimiter. |
+| `.xml` | Reads elements named `vehicle`, `fahrzeug`, `locomotive`, or `lok`. If none exist, RailKeeper uses the most frequently repeated nested element as the record shape. Attributes and direct text children become columns. |
+| `.json` | Accepts a vehicle array or an object with a `vehicles` array. The stable importer copies only the JSON subset listed below. |
+
+Delimited values may be quoted with double quotes. Doubled quotes inside a quoted field are
+unescaped. Leading and trailing whitespace is removed from every parsed cell, and completely empty
+rows are ignored.
+
+An invalid JSON or XML document is not a supported import. XML without usable records reports an
+empty table. Choose the corrected file again after fixing it.
+
+## JSON import subset
+
+The JSON export wraps the vehicle list as `{ "format": "railkeeper-vehicles", "version": 1,
+"vehicles": [...] }`. The stable JSON importer does not validate `format` or `version` and does not
+round-trip every property. It builds its review table from these 14 fields only:
+
+| Identity | Classification | Operation and value |
+| --- | --- | --- |
+| Inventory number, manufacturer, article number, designation | Gauge, epoch, railway company, category, subtype | Maximum speed, home depot / operating location, digital, digital / decoder number, list price |
+
+Use CSV when you need the complete supported 62-field scalar exchange. Use an application backup
+when you need restorable application data and uploads.
+
+## Column mapping
+
+The first row supplies the column names. RailKeeper normalizes case, whitespace, German umlauts,
+common punctuation, and known German or English aliases before looking for a target field.
+
+After loading a file:
+
+1. Review the **mapped** and **open** counts.
+2. In **Column mapping**, assign every useful open column to a RailKeeper field.
+3. Leave an irrelevant source column on **Ignore**.
+4. Check the recalculated import review before saving.
+
+One target field can belong to only one source column. Assigning the same target to a second column
+automatically clears the earlier assignment. Every mapping change rebuilds all preview rows, so
+review selections and corrections again afterwards.
+
+## All 62 CSV and table targets
+
+The complete stable CSV export uses the same targets and can therefore be imported without manual
+remapping. Other files may use any subset.
+
+| Group | Supported fields |
+| --- | --- |
+| Identity and catalogue | Inventory number; Manufacturer; Article no.; Source / URL; Designation; Gauge; Epoch; Railway company; Category; Subtype; Description; Series; Vehicle no.; EAN; Production period; List price |
+| Operation, digital, and exhibition | Maximum speed; Home depot / operating location; Digital; Digital / decoder no.; Decoder type; DT / decoder; DT / decoder no.; Exhibition ready; Exhibition; ABC brakes; Create QR code |
+| Acquisition, storage, and condition | Acquisition type; Acquired from; Purchase price; Purchase date; Storage location; Storage details; Condition; Condition details; Packaging |
+| Physical and mechanical data | Length (mm); Weight (g); Color; Lettering; Load; Interior; Axles; Axle count; Traction tire count; Wheelset; Coupling (F=R); Front coupling; Rear coupling; Power pickup; Adapter / interface |
+| Equipment and notes | Drive; Drive description; Headlights; Headlight description; Lighting; Lighting description; Sound generator; Sound generator description; Smoke generator; Smoke generator description; Additional information |
+
+Images and other nested or file-backed records are not targets.
+
+## Boolean values
+
+For Digital, DT / decoder, Exhibition ready, Exhibition, ABC brakes, Coupling (F=R), Drive,
+Headlights, Lighting, Sound generator, Smoke generator, and Create QR code, these non-empty values
+mean **yes** regardless of case:
+
+`1`, `ja`, `yes`, `true`, `wahr`, `digital`, `d`, `x`, `vorhanden`
+
+Every other non-empty value becomes **no**. An empty cell is ignored. Prefer the explicit `yes` and
+`no` values created by RailKeeper's CSV export to avoid ambiguous source data.
+
+## Validation and initial selection
+
+A new row needs Manufacturer, Designation, Gauge, Category, and Subtype before the preview allows
+selection. The server may apply additional vehicle rules when saving.
+
+Two field-specific checks run in the browser:
+
+- Maximum speed must be an integer from 1 through 1000 km/h.
+- Home depot / operating location must contain at most 200 Unicode characters.
+
+An invalid row is marked as an error, is deselected, and cannot be selected until the visible
+problem is corrected or its source mapping is changed. The review table directly edits only
+Inventory number, Manufacturer, Article no., Designation, Gauge, Category, and Subtype. Correct
+other values in the source file or through the column mapping, then reload when necessary.
+
+## New vehicles and detected duplicates
+
+RailKeeper compares a non-empty inventory number case-insensitively with the current vehicle list.
+
+| Result | Default behavior |
+| --- | --- |
+| No inventory-number match and no validation issue | Action **New**, row selected |
+| Existing inventory number | Action **Update**, warning, row not selected |
+| Existing inventory number plus another validation issue | Action **Update**, error, row blocked |
+
+For an update, expand the field preview and inspect **same**, **fills empty field**, and
+**overwrites**. Only mapped, non-empty imported strings, valid numbers, and parsed booleans are
+applied. Empty source cells do not erase existing strings. A non-empty boolean token that is not in
+the yes list explicitly applies **no**.
+
+Changing a duplicate row to **New** does not create a second vehicle with the same inventory
+number. RailKeeper marks the row as an error instead.
+
+## Save the reviewed selection
+
+1. Correct the visible core fields and review every update comparison.
+2. Select only rows that should be written.
+3. Choose **Save selection**.
+4. Wait until each successful row shows **saved**.
+5. Read any row-specific error and verify already saved vehicles before retrying.
+
+Rows are processed sequentially. Each selected row calls either vehicle creation or vehicle update.
+If one row fails, it becomes an error and RailKeeper continues with later selected rows. The
+operation is therefore not atomic and there is no bulk undo.
+
+File imports do not create function mappings, CV entries, ECoS mappings, images, attachments,
+maintenance, spare parts, or decoder files. Add those through their dedicated vehicle workflows.
+
+## Documented RailKeeper version
+
+This page documents stable RailKeeper **v0.1.18** and was last reviewed on 2026-08-16.

--- a/docs/site/guide/import-export/index.md
+++ b/docs/site/guide/import-export/index.md
@@ -1,0 +1,84 @@
+---
+title: Import and export
+description: Exchange vehicle inventory safely and understand the separate ECoS workflow.
+audience: user
+status: stable
+reviewedVersion: 0.1.18
+lastReviewed: 2026-08-16
+---
+
+# Import and export
+
+The **Import/Export** workspace exchanges vehicle inventory without bypassing RailKeeper's normal
+validation and permissions. File imports first become a review table. Exports create a CSV, a
+RailKeeper JSON file, or a browser print view. An independently controlled ECoS workflow can read
+locomotive data and hand one locomotive at a time to the vehicle editor.
+
+This chapter documents stable RailKeeper v0.1.18. It covers vehicle exchange only. Master-data
+transfer, command-station configuration, and application backup and restore remain separate
+administrative tasks.
+
+## Access rights
+
+Admin, Editor, Viewer, and Planner can open **Import/Export**. A pure Messe account remains in the
+isolated exhibition workspace and cannot open this page. The server still checks every read and
+write independently.
+
+| Action | Admin | Editor | Viewer | Planner |
+| --- | --- | --- | --- | --- |
+| Load the current vehicle list | Yes | Yes | Yes | Yes |
+| Export CSV, JSON, or a print view | Yes | Yes | Yes | Yes |
+| Parse a file and inspect its local preview | Yes | Yes | Yes | Yes |
+| Create or update vehicles from the preview | Yes | Yes | No | No |
+| Configure, read, or write an ECoS | Yes | No | No | No |
+
+The page does not hide the **Save selection** button from Viewer or Planner. The protected vehicle
+API nevertheless rejects their write. Use an Editor or Admin account for an actual file import.
+
+## Choose the correct workflow
+
+| Goal | Workflow |
+| --- | --- |
+| Review CSV, TSV, XML, or RailKeeper JSON and create or update vehicles | [Import vehicle files](/guide/import-export/file-import) |
+| Download the current vehicle list or print a compact inventory report | [Export inventory](/guide/import-export/exports) |
+| Read locomotives, static functions, and CV values from an ESU ECoS | [ECoS locomotive sync](/guide/import-export/ecos-sync) |
+| Transfer manufacturers, gauges, categories, symbols, or other master data | Use **Settings > Master data**, not this workspace |
+| Preserve or restore application data and stored uploads | Use the Admin-only application backup, not a vehicle export |
+
+## Safe working sequence
+
+1. Ask an Admin to create a current application backup before a large or unfamiliar import.
+2. Export CSV as a readable comparison file when you want to inspect the current scalar vehicle
+   fields in a spreadsheet.
+3. Load the source file and resolve every required field, validation message, and duplicate.
+4. Select only rows you have checked. Pay particular attention to fields marked as overwrites.
+5. Save the selection, then inspect both saved and failed rows before leaving the page.
+6. Open representative vehicles and confirm their core data after a large import.
+
+## Important boundaries
+
+- File exchange covers vehicle fields. It does not restore images, attachment bytes, maintenance,
+  spare parts, decoder files, function mappings, CV records, or application users.
+- The file preview is calculated in the browser. A row is written only when **Save selection** is
+  used by an authorized account.
+- Selected rows are saved one after another, not in one all-or-nothing transaction. A later error
+  does not undo vehicles already marked **saved**.
+- CSV is the broadest stable round-trip format for the 62 supported scalar fields. The JSON import
+  intentionally reads a smaller field subset even when the JSON export contains more properties.
+- ECoS data uses a separate work list and vehicle-editor handoff. It never enters the generic file
+  import table automatically.
+
+## Troubleshooting
+
+| Symptom | Check |
+| --- | --- |
+| Export buttons are disabled | Wait until the vehicle list has loaded. All export buttons remain disabled when the inventory is empty. |
+| A column is shown as open | Assign its target in **Column mapping**, or leave it on **Ignore** when it is not needed. |
+| A duplicate row is not selected | Review its update preview and select it explicitly only when the detected inventory-number match is correct. |
+| Saving fails although the preview looked valid | Confirm the account is Admin or Editor, then read the row-specific server error. Server validation remains authoritative. |
+| Some rows were saved before another failed | This is expected for the sequential import. Recheck saved rows and retry only the failed or still-open rows. |
+| The print view does not open | Allow popups for the RailKeeper address and try again. |
+
+## Documented RailKeeper version
+
+This chapter documents stable RailKeeper **v0.1.18** and was last reviewed on 2026-08-16.

--- a/docs/site/guide/index.md
+++ b/docs/site/guide/index.md
@@ -47,6 +47,10 @@ usage history.
 [Exhibition workspace](/guide/exhibition/) explains how to prepare lists, maintain operating
 entries, use locks, resolve DCC and SX address conflicts, and print the event report.
 
+[Import and export](/guide/import-export/) covers reviewed CSV, TSV, XML, and JSON vehicle imports,
+the three inventory outputs, their round-trip limits, and the separate Admin-only ECoS locomotive
+workflow.
+
 ## Updating Windows Standalone
 
 Open **Settings > General > Updates** and check for a newer version. When RailKeeper recognizes the


### PR DESCRIPTION
## Summary
- add complete English and German Import/Export guide sections for stable v0.1.18
- document permissions, CSV/TSV/XML/JSON review, all 62 scalar exchange fields, export limits, and partial-write behavior
- document the Admin-only ECoS work list, vehicle handoff, CV/function review, and confirmed write sync
- register the new pages in VitePress navigation, guide landing pages, and documentation coverage

## Verification
- `npm.cmd --prefix docs run check`
- source-claim audit: 62 file-exchange fields, 14 JSON-import fields, 9 print columns, 7 Admin-only ECoS routes
- bilingual field-parity check
- `git diff --cached --check`