### PR TITLE
docs: add bilingual general settings guide

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -82,6 +82,14 @@ export default defineConfig({
                 { text: "ECoS-Lokabgleich", link: "/de/guide/import-export/ecos-sync" },
               ],
             },
+            {
+              text: "Einstellungen",
+              items: [
+                { text: "Überblick und Berechtigungen", link: "/de/guide/settings/" },
+                { text: "Persönliche Einstellungen", link: "/de/guide/settings/personal-preferences" },
+                { text: "Darstellung", link: "/de/guide/settings/appearance" },
+              ],
+            },
           ],
           "/de/administration/": [
             {
@@ -181,6 +189,14 @@ export default defineConfig({
             { text: "Import vehicle files", link: "/guide/import-export/file-import" },
             { text: "Export inventory", link: "/guide/import-export/exports" },
             { text: "ECoS locomotive sync", link: "/guide/import-export/ecos-sync" },
+          ],
+        },
+        {
+          text: "Settings",
+          items: [
+            { text: "Overview and permissions", link: "/guide/settings/" },
+            { text: "Personal preferences", link: "/guide/settings/personal-preferences" },
+            { text: "Appearance", link: "/guide/settings/appearance" },
           ],
         },
       ],

--- a/docs/coverage.json
+++ b/docs/coverage.json
@@ -74,7 +74,7 @@
     {
       "id": "settings-general",
       "audience": "user",
-      "status": "planned",
+      "status": "documented",
       "englishPath": "guide/settings/index.md",
       "germanPath": "de/guide/settings/index.md"
     },

--- a/docs/site/de/guide/index.md
+++ b/docs/site/de/guide/index.md
@@ -53,6 +53,10 @@ pflegst, Sperren verwendest, DCC- und SX-Adresskonflikte löst und den Veranstal
 und JSON, die drei Bestandsausgaben, deren Rundlaufgrenzen sowie den getrennten Admin-ECoS-
 Lokabgleich.
 
+[Einstellungen](/de/guide/settings/) erklärt persönliche Vorgaben, deren Speicherung im Browser und
+Profil, die Anordnung der Seitenleiste, aktuelle Grenzen der Datums- und Druckerauswahl sowie die
+getrennten hellen und dunklen Darstellungsvarianten.
+
 ## Windows Standalone aktualisieren
 
 Unter **Einstellungen > Allgemein > Updates** nach einer neuen Version suchen. Erkennt RailKeeper

--- a/docs/site/de/guide/settings/appearance.md
+++ b/docs/site/de/guide/settings/appearance.md
@@ -1,0 +1,78 @@
+---
+title: Darstellung
+description: Designmodus wählen und helle sowie dunkle Varianten getrennt konfigurieren.
+audience: user
+status: stable
+reviewedVersion: 0.1.18
+lastReviewed: 2026-08-16
+---
+
+# Darstellung
+
+Unter **Einstellungen > Darstellung** werden Farbmodus sowie helle und dunkle Variante von
+RailKeeper gesteuert. Jede Änderung wirkt sofort. Eine getrennte Speichern-Schaltfläche gibt es
+nicht.
+
+## Designmodus
+
+| Modus | Verhalten |
+| --- | --- |
+| **System** | Folgt der Hell-/Dunkel-Vorgabe des Betriebssystems oder Browsers. |
+| **Hell** | Verwendet dauerhaft die konfigurierte helle Variante. |
+| **Dunkel** | Verwendet dauerhaft die konfigurierte dunkle Variante. |
+
+Die Design-Schaltfläche am unteren Ende der Seitenleiste stellt dieselbe Moduswahl als Schnellzugriff
+bereit. Jeder Klick wechselt von Dunkel zu Hell, von Hell zu System und von System zu Dunkel.
+
+Ein reines Messe-Konto kann diesen Schnellzugriff verwenden, obwohl es die Einstellungen nicht
+öffnen darf. Die Auswahl wirkt in diesem Browser, die Messe-Rolle darf sie aber nicht in das
+geschützte Profil schreiben.
+
+## Helle und dunkle Varianten konfigurieren
+
+RailKeeper speichert getrennte Einstellungen für beide Farbmodi. Eine Änderung der hellen Variante
+verändert die dunkle Variante nicht und umgekehrt.
+
+| Option | Helle Variante | Dunkle Variante | Wirkung |
+| --- | --- | --- | --- |
+| Hintergrund | Neutral, Warm, Kühl | Neutral, Warm, Kühl, OLED Schwarz | Ändert Grund-, Panel- und Eingabeflächen. |
+| Akzent | Grün, Blau, Gold | Grün, Blau, Gold | Ändert interaktive und hervorgehobene Farben. |
+| Stil | Klassisch, Kompakt, Kontrast | Klassisch, Kompakt, Kontrast | Wählt Standarddarstellung, engere Abstände zwischen Einstellungskarten oder stärkere Trennlinien und Sekundärtexte. |
+
+Bei ausgewähltem **System** verwendet RailKeeper automatisch die konfigurierte helle Variante, wenn
+das System helle Farben anfordert, und die konfigurierte dunkle Variante bei dunkler Vorgabe. Beide
+Varianten bleiben deshalb sinnvoll, auch wenn weder Hell noch Dunkel erzwungen wird.
+
+**OLED Schwarz** steht nur für den dunklen Hintergrund bereit und verwendet eine schwarze
+Grundfläche sowie sehr dunkle Panels. **Kompakt** verkleinert in v0.1.18 hauptsächlich die Abstände
+zwischen Einstellungskarten; es ist keine globale Tabellendichte. **Kontrast** verstärkt Trennlinien
+und zurückgenommene Texte, ersetzt aber nicht Browser-Zoom oder Bedienungshilfen des Betriebssystems.
+
+## Speicherung und Benutzerbezug
+
+Der gewählte Modus und alle sechs Variantenoptionen werden im Browser sowie im Profil des aktuellen
+Benutzers gespeichert. RailKeeper stellt den Modus bereits in der Anwendungshülle wieder her. Beim
+Öffnen der Einstellungen werden zusätzlich die detaillierten hellen und dunklen Optionen geladen
+und angewendet.
+
+Der Profilzugriff im Hintergrund zeigt keine Erfolgsmeldung. Ist der Server vorübergehend nicht
+erreichbar, kann der aktuelle Browser die lokale Auswahl weiter anzeigen, während ein anderer
+Browser noch den älteren Profilwert besitzt. Nach wiederhergestellter Verbindung Einstellungen neu
+laden und die Auswahl bei Bedarf erneut setzen.
+
+Anwendungssicherung und Wiederherstellung schließen Benutzer-Profileinstellungen absichtlich aus.
+Darstellungsvorgaben gehören daher nicht zur Anwendungssicherung.
+
+## Fehlerbehebung
+
+| Symptom | Prüfen |
+| --- | --- |
+| Systemmodus wechselt unerwartet | Farbmodus des Betriebssystems oder Browsers prüfen. Der Systemmodus folgt diesem Signal. |
+| Hintergrund oder Akzent scheinen wirkungslos | Prüfen, ob die Anwendung gerade die bearbeitete helle oder dunkle Variante verwendet. |
+| Ein anderer Browser zeigt ein früheres Design | Einstellungen mit demselben Benutzer öffnen und neu laden. Nach einem Verbindungsfehler den Modus oder die Variante bei Bedarf erneut wählen. |
+| Kompakt verdichtet die Bestandstabellen nicht | In v0.1.18 verkleinert der Stil hauptsächlich Abstände zwischen Einstellungskarten. |
+| Kontrast reicht weiterhin nicht aus | Kontrast-Stil mit Browser-Zoom und Bedienungshilfen des Betriebssystems kombinieren. |
+
+## Dokumentierte RailKeeper-Version
+
+Diese Seite dokumentiert RailKeeper **v0.1.18** und wurde zuletzt am 16.08.2026 geprüft.

--- a/docs/site/de/guide/settings/index.md
+++ b/docs/site/de/guide/settings/index.md
@@ -1,0 +1,87 @@
+---
+title: Einstellungen
+description: Persönliche Einstellungen, Darstellung und die Abgrenzung zur Administration verstehen.
+audience: user
+status: stable
+reviewedVersion: 0.1.18
+lastReviewed: 2026-08-16
+---
+
+# Einstellungen
+
+Der Arbeitsbereich **Einstellungen** verbindet persönliche Einstellungen mit mehreren
+Administrationswerkzeugen. Dieses Kapitel behandelt die Einstellungen für Navigation und
+Darstellung eines einzelnen Benutzers. Stammdaten, Digitalzentralen, Anwendungssicherung, Speicher,
+Updates, Benutzer, Sitzungen und Authentifizierung sind eigene Themen, obwohl RailKeeper sie im
+selben Arbeitsbereich anzeigt.
+
+Dieses Kapitel dokumentiert RailKeeper v0.1.18.
+
+## Zugriffsrechte
+
+Admin, Editor, Viewer und Planner können **Einstellungen** öffnen. Ein reines Messe-Konto bleibt im
+isolierten Messearbeitsbereich und kann diese Seite nicht öffnen. Persönliche Profileinstellungen
+verwenden die angemeldete Profil-API und sind nach Benutzer getrennt.
+
+| Aktion | Admin | Editor | Viewer | Planner |
+| --- | --- | --- | --- | --- |
+| **Allgemein** und **Darstellung** öffnen | Ja | Ja | Ja | Ja |
+| Persönliche Profileinstellungen ändern | Ja | Ja | Ja | Ja |
+| Benannte Systemdrucker lesen | Ja | Nein | Nein | Nein |
+| Ausschließlich für Admins erlaubte Vorgänge ausführen | Ja | Nein | Nein | Nein |
+
+Die sichtbare Seite ist nicht die Berechtigungsgrenze. RailKeeper prüft geschützte System- und
+Datenvorgänge auf dem Server. Das Verschieben oder Ausblenden eines Navigationseintrags erteilt oder
+entfernt niemals Berechtigungen.
+
+## Den richtigen Einstellungsbereich wählen
+
+| Register oder Bereich | Zweck | Zuständiges Kapitel |
+| --- | --- | --- |
+| **Allgemein** | Sprache, Startseite, Datums- und Zeitvorgaben, Druckvorgabe und Seitenleisten-Reihenfolge | [Persönliche Einstellungen](/de/guide/settings/personal-preferences) |
+| **Darstellung** | System-, Hell- oder Dunkelmodus sowie getrennte Farb- und Stilvarianten | [Darstellung](/de/guide/settings/appearance) |
+| **Allgemein > Inventarnummern** | Nummernschemata für Bestandskategorien | Stammdaten-Administration |
+| **Allgemein > Artikelsuche** | Artikelsuche aktivieren und Quellgruppen wählen | [Artikelsuche](/de/guide/vehicles/search-and-spares) |
+| **Allgemein > Updates** | Versionsprüfung und Download des Windows-Pakets | Releases und Support |
+| **Allgemein > Speicher** | Speichernutzung und Optimierung | Systembetrieb |
+| **Daten** | Allgemeine und Zubehör-Stammdaten, Lebenszyklus und Transfer | Stammdaten-Administration |
+| **Digitalzentralen** | ECoS-, Z21-, Intellibox-3- und CS3-Konfiguration | Digitalzentralen-Administration |
+| **Import/Export** | Sicherung, Wiederherstellung und Stammdaten-Transfer innerhalb der Einstellungen | Sicherungs- und Stammdaten-Administration |
+| **Authentifizierung** | Eigenes Passwort und Zwei-Faktor-Einrichtung; Admin-Werkzeuge für Benutzer, Sitzungen, Audit und SMTP | Benutzer, Sitzungen und Sicherheit |
+
+Der allgemeine [Arbeitsbereich Import und Export](/de/guide/import-export/) ist eine andere Seite. Er
+tauscht Fahrzeugdatensätze aus und enthält den ECoS-Lokablauf. Das Register **Import/Export** in den
+**Einstellungen** enthält dagegen administrative Sicherung und Stammdaten-Transfer.
+
+## Speicherung persönlicher Einstellungen
+
+Die meisten Vorgaben wirken sofort im Browser, werden im Browserspeicher abgelegt und zusätzlich an
+das Profil des aktuellen Benutzers gesendet. Die Anwendungshülle stellt Designmodus und
+Seitenleistenvorgaben wieder her. Beim Öffnen der Einstellungen folgen die weiteren synchronisierten
+Vorgaben.
+
+Dabei gelten wichtige Ausnahmen und Grenzen:
+
+- Die Oberflächensprache ist in v0.1.18 nur im Browser gespeichert und wird nicht in das
+  Serverprofil geschrieben.
+- Der ein- oder ausgeklappte Zustand der Hauptseitenleiste ist browserlokal. Reihenfolge und
+  ausgeblendete Einträge sind Profileinstellungen.
+- Das Speichern des Profils läuft im Hintergrund. Für diese kleinen Schreibvorgänge zeigt die Seite
+  keine Erfolgs- oder Fehlermeldung. Scheitert der Serverzugriff, kann der lokale Browserwert
+  trotzdem aktiv bleiben.
+- Anwendungssicherungen schließen Benutzerkonten und `user_settings` absichtlich aus. Eine
+  Sicherung ist daher kein Export persönlicher Einstellungen.
+
+## Sicherer Arbeitsablauf
+
+1. **Einstellungen > Allgemein** öffnen und gewünschte Sprache sowie stabile Startseite wählen.
+2. Seitenleiste anordnen, häufig verwendete Arbeitsbereiche aber sichtbar lassen.
+3. **Darstellung** öffnen und **System**, **Hell** oder **Dunkel** wählen.
+4. Helle und dunkle Variante bei Bedarf getrennt anpassen.
+5. RailKeeper einmal neu laden, um die Wiederherstellung einer Vorgabe zu prüfen.
+6. Bei einem anderen Browser mit demselben Benutzer anmelden. Die Oberflächensprache erneut setzen,
+   weil sie in v0.1.18 nicht über das Profil synchronisiert wird.
+
+## Dokumentierte RailKeeper-Version
+
+Dieses Kapitel dokumentiert RailKeeper **v0.1.18** und wurde zuletzt am 16.08.2026 geprüft.

--- a/docs/site/de/guide/settings/personal-preferences.md
+++ b/docs/site/de/guide/settings/personal-preferences.md
@@ -1,0 +1,105 @@
+---
+title: Persönliche Einstellungen
+description: Sprache, Startseite, Datum, Zeit, Druckausgabe und Seitenleisten-Reihenfolge konfigurieren.
+audience: user
+status: stable
+reviewedVersion: 0.1.18
+lastReviewed: 2026-08-16
+---
+
+# Persönliche Einstellungen
+
+Die persönlichen Vorgaben befinden sich unter **Einstellungen > Allgemein**. Änderungen wirken
+sofort; eine getrennte Speichern-Schaltfläche gibt es nicht.
+
+## Sprache
+
+**Deutsch** oder **English** wählen. RailKeeper ändert sofort die Oberflächentexte und die vom
+Browser verwendete Dokumentensprache.
+
+Die Sprachwahl wird in RailKeeper v0.1.18 nur im aktuellen Browser gespeichert. Sie folgt dem
+Benutzerprofil nicht in einen anderen Browser oder auf ein anderes Gerät. Ein Browser ohne
+gespeicherte Auswahl startet auf Deutsch.
+
+## Standardansicht
+
+Die Standardansicht wird verwendet, wenn RailKeeper über seine Stammadresse ohne genaueren Pfad
+startet. Zur Auswahl stehen Übersicht, Fahrzeugbestand, Zubehör, Anlage, Ausstellung,
+Import/Export und Einstellungen.
+
+Dabei gelten folgende Grenzen:
+
+- Ein direkter Link wie `/vehicles` oder `/settings` hat Vorrang vor der Standardansicht.
+- Direkt nach der Anmeldung leitet RailKeeper das Konto zunächst in seinen ersten zulässigen
+  Arbeitsbereich. Die Standardansicht umgeht diese rollenabhängige Entscheidung nicht.
+- Darf die aktuelle Rolle ein gespeichertes Ziel nicht öffnen, verwendet RailKeeper die erste
+  zulässige Ansicht.
+- **Anlage** ist in v0.1.18 auswählbar, bleibt aber ein unveröffentlichter Entwicklungsbereich und
+  wird in der normalen Seitenleiste nicht angezeigt. Für den stabilen Benutzerablauf eine andere
+  Startseite wählen.
+
+## Datums- und Zeitformat
+
+Beim Datum stehen **Systemstandard**, ein deutsches Tag-Monat-Jahr-Format und das ISO-Format
+Jahr-Monat-Tag zur Auswahl. Für die Zeit gibt es **Systemstandard**, 24 Stunden und 12 Stunden.
+
+RailKeeper speichert und synchronisiert beide Vorgaben. In v0.1.18 sind sie noch nicht mit allen
+Datums- und Zeitausgaben der Anwendung verbunden. Viele Ansichten formatieren Werte weiterhin nach
+der gewählten Oberflächensprache oder mit einem eigenen festen Formatierer. Die Auswahl ist daher
+eine vorbereitete Vorgabe und noch keine verlässliche globale Überschreibung.
+
+## Standarddrucker
+
+Die Auswahl enthält:
+
+- **Systemdialog / Standarddrucker**;
+- einen benannten Drucker, wenn ein Admin konfigurierte oder vom Betriebssystem gemeldete Drucker
+  lesen kann;
+- **Jedes Mal fragen**;
+- **Als PDF speichern**.
+
+Kann RailKeeper bei aktiver Auswahl **Systemdialog / Standarddrucker** einen Systemstandard
+ermitteln, speichert es den gefundenen Druckernamen als Vorgabe. Die Druckererkennung selbst ist
+nur für Admins zugänglich. Andere Rollen können die allgemeine Druckvorgabe weiterhin behalten und
+ändern.
+
+RailKeeper v0.1.18 speichert diesen Wert, leitet aber noch nicht jeden Druckvorgang automatisch an
+das gewählte Ziel. Fahrzeugbestandsdruck, Messeberichte und die Druckausgabe unter Import/Export
+öffnen weiterhin den Browser-Druckdialog. Browser und Betriebssystem bestimmen dort den
+tatsächlichen Drucker oder das Ziel **Als PDF speichern**.
+
+## Reihenfolge und Sichtbarkeit der Seitenleiste
+
+Die **Seitenleisten-Reihenfolge** steuert die Hauptnavigation des aktuellen Benutzers:
+
+1. Mit den Pfeilen einen Eintrag nach oben oder unten verschieben.
+2. Mit dem Augen-Symbol einen Eintrag aus- oder einblenden.
+3. **Zurücksetzen** wählen, um Standardreihenfolge und alle Einträge wiederherzustellen.
+
+**Einstellungen** kann nicht ausgeblendet werden, damit die Konfigurationsseite erreichbar bleibt.
+Das Ausblenden entfernt nur den Link aus der Seitenleiste. Mit der erforderlichen Rolle lässt sich
+die zugrunde liegende Seite weiterhin direkt öffnen. Für die aktuelle Rolle unzulässige Einträge
+bleiben unabhängig von ihrer gespeicherten Position herausgefiltert.
+
+Die Liste kann **Anlage** enthalten, obwohl RailKeeper v0.1.18 diesen Arbeitsbereich nicht in der
+normalen Seitenleiste veröffentlicht. Verschieben oder Einblenden macht ihn nicht zu einer
+veröffentlichten Benutzerfunktion.
+
+Reihenfolge und ausgeblendete Einträge werden für jeden Benutzernamen getrennt gespeichert und über
+dessen Profil synchronisiert. Der kleine Pfeil am unteren Ende der Seitenleiste klappt sie nur im
+aktuellen Browser ein oder aus; dieser Zustand gehört nicht zu den Profileinstellungen.
+
+## Fehlerbehebung
+
+| Symptom | Prüfen |
+| --- | --- |
+| Eine Vorgabe änderte sich lokal, aber nicht in einem anderen Browser | Einstellungen mit demselben Benutzer neu laden. Der Hintergrundzugriff auf das Profil kann gescheitert sein, obwohl der lokale Wert aktiv blieb. |
+| Die Oberflächensprache unterscheidet sich auf einem anderen Gerät | Dort erneut einstellen. Die Sprache ist in v0.1.18 browserlokal. |
+| Die gewählte Startseite öffnet sich nach der Anmeldung nicht | Rollenabhängige Anmeldung und direkte URLs haben Vorrang. Zum Testen der Vorgabe die Stammadresse öffnen. |
+| Eine ausgeblendete Seite lässt sich weiterhin öffnen | Ausblenden ändert nur die Navigation, nicht Berechtigung oder Routing. |
+| Es erscheinen keine benannten Drucker | Die Systemdrucker-Erkennung erfordert Admin und hängt vom Server-Betriebssystem oder der Druckerkonfiguration ab. |
+| Gewählter Drucker oder Datumsformat zeigen keine Wirkung | Die Vorgaben werden gespeichert, aber in v0.1.18 noch nicht von jedem Arbeitsablauf global verwendet. |
+
+## Dokumentierte RailKeeper-Version
+
+Diese Seite dokumentiert RailKeeper **v0.1.18** und wurde zuletzt am 16.08.2026 geprüft.

--- a/docs/site/guide/index.md
+++ b/docs/site/guide/index.md
@@ -51,6 +51,10 @@ entries, use locks, resolve DCC and SX address conflicts, and print the event re
 the three inventory outputs, their round-trip limits, and the separate Admin-only ECoS locomotive
 workflow.
 
+[Settings](/guide/settings/) explains personal preferences, their browser and profile persistence,
+sidebar arrangement, the current limits of date and printer choices, and the independent light and
+dark appearance variants.
+
 ## Updating Windows Standalone
 
 Open **Settings > General > Updates** and check for a newer version. When RailKeeper recognizes the

--- a/docs/site/guide/settings/appearance.md
+++ b/docs/site/guide/settings/appearance.md
@@ -1,0 +1,75 @@
+---
+title: Appearance
+description: Choose the theme mode and configure light and dark variants independently.
+audience: user
+status: stable
+reviewedVersion: 0.1.18
+lastReviewed: 2026-08-16
+---
+
+# Appearance
+
+Open **Settings > Appearance** to control RailKeeper's color mode and its light and dark variants.
+Every change applies immediately. There is no separate Save button.
+
+## Theme mode
+
+| Mode | Behavior |
+| --- | --- |
+| **System** | Follows the operating system or browser light/dark preference. |
+| **Light** | Keeps RailKeeper in the configured light variant. |
+| **Dark** | Keeps RailKeeper in the configured dark variant. |
+
+The theme button in the sidebar footer provides the same mode choice as a shortcut. Each click
+cycles from Dark to Light, from Light to System, and from System to Dark.
+
+A pure Messe account can use this footer shortcut even though it cannot open Settings. Its choice
+applies in that browser, but the Messe role cannot write the protected profile setting.
+
+## Configure light and dark variants
+
+RailKeeper stores separate settings for each color mode. Changing the light variant does not alter
+the dark variant, and vice versa.
+
+| Option | Light variant | Dark variant | Effect |
+| --- | --- | --- | --- |
+| Background | Neutral, Warm, Cool | Neutral, Warm, Cool, OLED Black | Changes the base, panel, and input surfaces. |
+| Accent | Green, Blue, Gold | Green, Blue, Gold | Changes interactive and highlighted colors. |
+| Style | Classic, Compact, Contrast | Classic, Compact, Contrast | Chooses the standard treatment, tighter Settings-card gaps, or stronger separators and secondary text. |
+
+With **System** selected, RailKeeper automatically uses the configured light variant while the
+system requests light colors and the configured dark variant while it requests dark colors. Both
+variant cards therefore remain useful even when neither Light nor Dark is forced.
+
+**OLED Black** is available only for the dark background. It uses a black base and very dark panel
+surfaces. **Compact** in v0.1.18 primarily tightens spacing between Settings cards; it is not a
+global table-density control. **Contrast** strengthens separators and muted text but does not
+replace browser zoom or operating-system accessibility settings.
+
+## Persistence and user scope
+
+The selected mode and all six variant choices are written to browser storage and to the current
+user's profile. RailKeeper restores the mode in the application shell. Opening Settings restores
+and applies the detailed light and dark options as well.
+
+The background profile write has no visible success message. If the server is temporarily
+unavailable, the current browser can keep showing the local choice while another browser still has
+the older profile value. Reload Settings after connectivity returns and select the choice again if
+necessary.
+
+Application backup and restore deliberately exclude user profile settings. Appearance choices are
+therefore not part of an application backup.
+
+## Troubleshooting
+
+| Symptom | Check |
+| --- | --- |
+| System mode changes unexpectedly | Check the operating-system or browser color preference. System mode follows that signal. |
+| A background or accent appears to have no effect | Confirm whether the application currently uses the light or dark variant you edited. |
+| Another browser shows a previous theme | Open Settings with the same user and reload. If needed, choose the mode or variant again after server connectivity returns. |
+| Compact does not make inventory tables denser | In v0.1.18 it mainly reduces gaps between Settings cards. |
+| Contrast is still insufficient | Combine the Contrast style with browser zoom and operating-system accessibility controls. |
+
+## Documented RailKeeper version
+
+This page documents stable RailKeeper **v0.1.18** and was last reviewed on 2026-08-16.

--- a/docs/site/guide/settings/index.md
+++ b/docs/site/guide/settings/index.md
@@ -1,0 +1,83 @@
+---
+title: Settings
+description: Understand personal preferences, appearance, and the boundaries between user and administration settings.
+audience: user
+status: stable
+reviewedVersion: 0.1.18
+lastReviewed: 2026-08-16
+---
+
+# Settings
+
+The **Settings** workspace combines personal preferences with several administrative tools. This
+chapter covers the settings that shape an individual user's navigation and appearance. Master data,
+command stations, application backup, storage, updates, users, sessions, and authentication are
+separate topics even though RailKeeper presents them in the same workspace.
+
+This chapter documents stable RailKeeper v0.1.18.
+
+## Access rights
+
+Admin, Editor, Viewer, and Planner can open **Settings**. A pure Messe account remains in the
+isolated exhibition workspace and cannot open this page. Personal profile settings use the
+authenticated profile API and are isolated by user.
+
+| Action | Admin | Editor | Viewer | Planner |
+| --- | --- | --- | --- | --- |
+| Open **General** and **Appearance** | Yes | Yes | Yes | Yes |
+| Change personal profile preferences | Yes | Yes | Yes | Yes |
+| Read named system printers | Yes | No | No | No |
+| Run Admin-only operations | Yes | No | No | No |
+
+The visible page is not the permission boundary. RailKeeper checks protected system and data
+operations on the server. Reordering or hiding a navigation entry never grants or removes access.
+
+## Choose the correct settings area
+
+| Tab or area | Purpose | Documentation owner |
+| --- | --- | --- |
+| **General** | Language, start page, date and time preferences, printing preference, and sidebar order | [Personal preferences](/guide/settings/personal-preferences) |
+| **Appearance** | System, light, or dark mode plus separate color and style variants | [Appearance](/guide/settings/appearance) |
+| **General > Inventory numbers** | Number schemes for inventory categories | Master data administration |
+| **General > Article search** | Enable article search and choose source groups | [Article search](/guide/vehicles/search-and-spares) |
+| **General > Updates** | Release checks and Windows package download | Releases and support |
+| **General > Storage** | Storage usage and optimization | System operations |
+| **Data** | General and accessory master data, lifecycle, and transfer | Master data administration |
+| **Command stations** | ECoS, Z21, Intellibox 3, and CS3 configuration | Digital-center administration |
+| **Import/Export** | Backup, restore, and master-data transfer inside Settings | Backup and master-data administration |
+| **Authentication** | Own password and two-factor setup; Admin user, session, audit, and SMTP tools | Users, sessions, and security |
+
+The main [Import and export workspace](/guide/import-export/) is a different page. It exchanges
+vehicle records and performs the ECoS locomotive workflow. The **Import/Export** tab inside
+**Settings** contains administrative backup and master-data transfer instead.
+
+## How personal preferences are stored
+
+Most preferences apply immediately in the browser, are written to browser storage, and are also
+sent to the current user's profile. The application shell restores theme mode and sidebar
+preferences. Opening Settings restores the other synchronized preferences.
+
+There are important exceptions and limits:
+
+- Interface language is browser-local in v0.1.18 and is not written to the server profile.
+- The collapsed or expanded state of the main sidebar is browser-local. Sidebar order and hidden
+  entries are profile settings.
+- Profile saving runs in the background. The page does not show a success or failure message for
+  these small preference writes. If the server write fails, the local browser value can still
+  remain active.
+- Application backups deliberately exclude user accounts and `user_settings`. Do not treat a
+  backup as an export of personal preferences.
+
+## Safe working sequence
+
+1. Open **Settings > General** and choose the language and stable start page you want.
+2. Arrange the sidebar, but keep frequently used workspaces visible.
+3. Open **Appearance** and choose **System**, **Light**, or **Dark**.
+4. Adjust the light and dark variants independently when required.
+5. Reload RailKeeper once when verifying that a preference was restored.
+6. When moving to another browser, sign in with the same user. Set the interface language again
+   because language is not profile-synchronized in v0.1.18.
+
+## Documented RailKeeper version
+
+This chapter documents stable RailKeeper **v0.1.18** and was last reviewed on 2026-08-16.

--- a/docs/site/guide/settings/personal-preferences.md
+++ b/docs/site/guide/settings/personal-preferences.md
@@ -1,0 +1,99 @@
+---
+title: Personal preferences
+description: Configure language, start page, date and time choices, printing, and sidebar order.
+audience: user
+status: stable
+reviewedVersion: 0.1.18
+lastReviewed: 2026-08-16
+---
+
+# Personal preferences
+
+Open **Settings > General** for the personal preference controls. Changes take effect immediately;
+there is no separate Save button.
+
+## Language
+
+Choose **Deutsch** or **English**. RailKeeper immediately changes the interface text and the
+document language marker used by the browser.
+
+The language choice is stored only in the current browser in stable v0.1.18. It does not follow the
+user profile to another browser or device. A browser without a stored choice starts in German.
+
+## Default view
+
+The default view is used when RailKeeper starts from its root address without a more specific path.
+Available choices are Overview, Vehicle inventory, Accessories, Layout, Exhibition, Import/Export,
+and Settings.
+
+Keep these boundaries in mind:
+
+- A direct link such as `/vehicles` or `/settings` takes precedence over the default.
+- Signing in initially routes the account to its first permitted workspace. The default does not
+  bypass that role-based decision.
+- A stored destination that the current role cannot open is replaced by the first allowed view.
+- **Layout** is selectable in v0.1.18 but remains an unpublished development workspace and is not
+  shown in the normal sidebar. Choose another start page for the stable user workflow.
+
+## Date and time format
+
+The date preference offers **System default**, a German day-month-year format, and ISO
+year-month-day. The time preference offers **System default**, 24-hour, and 12-hour time.
+
+RailKeeper stores and synchronizes both choices. Stable v0.1.18 does not yet connect these settings
+to all date and time output across the application. Many current views continue to format values
+from the selected interface language or their own fixed formatter. Treat the controls as prepared
+preferences, not as a guaranteed global override.
+
+## Default printer
+
+The selector contains:
+
+- **System dialog / default printer**;
+- a named printer when an Admin account can read configured or operating-system printers;
+- **Ask every time**;
+- **Save as PDF**.
+
+When RailKeeper can discover a system default while **System dialog / default printer** is active,
+it stores the detected named printer as the preference. Printer discovery itself is Admin-only.
+Other roles can still retain and change the general print preference.
+
+Stable v0.1.18 stores this value but does not route all print actions to the chosen destination.
+Vehicle inventory printing, exhibition reports, and Import/Export printing still open the browser
+print dialog. The browser and operating system remain responsible for choosing the real printer or
+**Save as PDF** destination.
+
+## Sidebar order and visibility
+
+The **Sidebar Order** list controls the main navigation for the current user:
+
+1. Use the up and down buttons to move an entry.
+2. Use the eye button to hide or show an entry.
+3. Select **Reset** to restore the default order and show all entries.
+
+**Settings** cannot be hidden, so the configuration page remains reachable. Hiding an entry removes
+only its sidebar link. The underlying page can still be opened directly when the account has the
+required role. Entries unavailable to the current role remain filtered out regardless of their
+saved position.
+
+The list can include **Layout** even though stable v0.1.18 does not publish that workspace in the
+normal sidebar. Ordering or showing it here does not turn it into a published user feature.
+
+Sidebar order and hidden entries are stored separately for each username and synchronized through
+that user's profile. The small arrow at the bottom of the sidebar only collapses or expands the
+sidebar in the current browser; that collapsed state is not part of these profile preferences.
+
+## Troubleshooting
+
+| Symptom | Check |
+| --- | --- |
+| A preference changed locally but not on another browser | Reload Settings while signed in as the same user. The background profile write may have failed even though the local value remained active. |
+| The interface language differs on another device | Set it again there. Language is browser-local in v0.1.18. |
+| The selected start page is not opened after sign-in | Role-based login routing and direct URLs take precedence. Open the root address to test the stored default. |
+| A hidden page can still be opened | Hiding changes navigation only, not authorization or routing. |
+| Named printers do not appear | System-printer discovery requires Admin and depends on the server operating system or printer configuration. |
+| The selected printer or date format has no effect | These preferences are stored but are not yet used globally by every v0.1.18 workflow. |
+
+## Documented RailKeeper version
+
+This page documents stable RailKeeper **v0.1.18** and was last reviewed on 2026-08-16.


### PR DESCRIPTION
Adds the complete English and German user documentation for general settings and appearance. Covers access rights, browser-local versus profile-synchronized preferences, start-page and sidebar behavior, current date/time/printer limits, theme variants, and boundaries to the remaining administration topics. Verification: source-claim audit against stable v0.1.18; npm.cmd run check (19 tests, metadata and coverage validation, VitePress build); all six generated settings routes verified.