### PR TITLE
docs: add master data administration guide

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -94,7 +94,14 @@ export default defineConfig({
           "/de/administration/": [
             {
               text: "Administration",
-              items: [{ text: "Überblick", link: "/de/administration/" }],
+              items: [
+                { text: "Überblick", link: "/de/administration/" },
+                { text: "Stammdaten-Administration", link: "/de/administration/master-data" },
+                { text: "Allgemeine Stammdaten", link: "/de/administration/master-data-general" },
+                { text: "Artikelstammdaten und Lagerorte", link: "/de/administration/master-data-articles" },
+                { text: "Inventarnummernschemata", link: "/de/administration/master-data-inventory-numbers" },
+                { text: "Stammdatentransfer", link: "/de/administration/master-data-transfer" },
+              ],
             },
           ],
           "/de/development/": [
@@ -203,7 +210,14 @@ export default defineConfig({
       "/administration/": [
         {
           text: "Administration",
-          items: [{ text: "Overview", link: "/administration/" }],
+          items: [
+            { text: "Overview", link: "/administration/" },
+            { text: "Master-data administration", link: "/administration/master-data" },
+            { text: "General master data", link: "/administration/master-data-general" },
+            { text: "Article master data and locations", link: "/administration/master-data-articles" },
+            { text: "Inventory-number schemes", link: "/administration/master-data-inventory-numbers" },
+            { text: "Master-data transfer", link: "/administration/master-data-transfer" },
+          ],
         },
       ],
       "/development/": [

--- a/docs/coverage.json
+++ b/docs/coverage.json
@@ -81,7 +81,7 @@
     {
       "id": "master-data",
       "audience": "admin",
-      "status": "planned",
+      "status": "documented",
       "englishPath": "administration/master-data.md",
       "germanPath": "de/administration/master-data.md"
     },

--- a/docs/site/administration/index.md
+++ b/docs/site/administration/index.md
@@ -16,6 +16,11 @@ conservative troubleshooting.
 Administration guidance describes the stable v0.1.18 runtime and preserves RailKeeper's
 local-first, self-hosted security model.
 
+## Administrative workflows
+
+- [Master-data administration](./master-data) covers controlled values, lifecycle, storage
+  locations, inventory-number schemes, and the JSON transfer.
+
 ## Safe Windows Standalone updates
 
 The Windows Standalone ZIP contains the application only. It never contains a database, uploads,
@@ -80,3 +85,6 @@ invalidate historical inventory data.
 Edits and deactivation states survive application restarts, seed reconciliation, updates,
 master-data export and import, and application backup and restore. A current RailKeeper backup is
 still recommended before extensive master-data changes.
+
+The complete field, permission, numbering, location, and import rules are documented in
+[Master-data administration](./master-data).

--- a/docs/site/administration/master-data-articles.md
+++ b/docs/site/administration/master-data-articles.md
@@ -1,0 +1,115 @@
+---
+title: Article master data and storage locations
+description: Configure accessory units, classifications, custom fields, and hierarchical storage locations.
+audience: admin
+status: stable
+reviewedVersion: 0.1.18
+lastReviewed: 2026-08-16
+---
+
+# Article master data and storage locations
+
+Open **Settings > Data > Article data** for the controlled values used by accessory articles. The
+page separates stock units, article classification, custom fields, and storage locations. Admin and
+Editor can change them. Viewer and Planner receive an explicit read-only view.
+
+## Stock units
+
+Stock units describe what article quantities count, for example pieces, packs, metres, or grams.
+Each entry has an immutable key, editable label, active state, and origin.
+
+Create a unit only when the existing list cannot express the stock. Deactivating a unit removes it
+from new article selections, while articles already using it retain the historical value. A custom
+unit can be permanently deleted only when no article references its key.
+
+## Article types and subtypes
+
+RailKeeper ships eight protected article-type keys:
+
+- Track
+- Signal
+- Decoder
+- Electrical / control
+- Building / equipment
+- Landscape consumable
+- Lighting
+- Other
+
+Their labels and active states can be maintained, but v0.1.18 does not allow creating or deleting
+article-type keys. This protects the matching technical-data contracts. Deactivating a type removes
+it from new article selection without rewriting existing articles.
+
+Subtypes refine one of those types. Admin and Editor can create, edit, deactivate, reactivate, and,
+while unused, delete a custom subtype. Its key must begin with the parent article-type key and a
+colon, for example `track:turnout`. RailKeeper uses that prefix to decide which subtypes belong to
+the selected article type.
+
+Changing or deactivating a classification never migrates article records automatically. Review the
+affected articles and decide whether their historical classification should remain or be edited
+individually.
+
+## Controlled custom fields
+
+Custom fields appear only on articles of type **Other**. Each definition has a key, label, active
+state, and one of these data kinds:
+
+| Kind | Configuration and resulting value |
+| --- | --- |
+| Text | Free text |
+| Number | Numeric value and optional unit |
+| Yes / No | Explicit boolean value |
+| Date | Date value |
+| Single selection | Exactly one configured option |
+| Multiple selection | Zero or more configured options |
+
+Single- and multiple-selection definitions require a non-empty comma-separated option list. The UI
+removes empty options; the server rejects duplicate options. Choose the kind carefully: once a custom
+field is referenced by stored **Other** article attributes, its key cannot be deleted. Historical
+values whose definition becomes inactive remain readable but cannot be newly added or changed.
+
+## Storage locations
+
+Storage locations form a hierarchy independent from the controlled master-data table. Each
+location has a required name, optional parent, optional description, and archived state. The list
+shows the full path, for example `Store room / Cabinet A / Drawer 3`.
+
+Names must be unique among siblings without regard to letter case. A location cannot be its own
+parent or be moved beneath one of its descendants. The parent picker excludes those invalid
+choices.
+
+There is no permanent-delete action in v0.1.18. Archive a location to retire it and reactivate it
+when required. Stock and individual items can use a location only when that location and every
+ancestor are active. Archiving a parent therefore makes its entire branch unavailable for new
+stock operations without erasing stored location references.
+
+To build a safe hierarchy:
+
+1. Create the top-level room or store.
+2. Create cabinets or shelves with that top-level parent.
+3. Add bins or drawers under the appropriate branch.
+4. Verify the full displayed path before assigning stock.
+5. Archive obsolete leaves first, then their empty parents.
+
+Storage locations are included in application backup and restore, but not in the standalone
+master-data JSON transfer.
+
+## Lifecycle and conflict handling
+
+The action column reflects server-calculated capabilities. Bundled entries never show permanent
+deletion. Referenced custom entries also lose that action. Deactivation and deletion require a
+confirmation; reactivation writes immediately.
+
+If a save reports a conflict, check for a duplicate sibling location, a protected article type, a
+referenced custom value, or an invalid custom-field option list. A rejected operation leaves the
+stored configuration unchanged.
+
+## Related pages
+
+- [Master-data administration](./master-data)
+- [General master data](./master-data-general)
+- [Article records and technical data](/guide/accessories/article-records)
+- [Stock, purchases, and documents](/guide/accessories/stock-purchases-documents)
+
+## Documented RailKeeper version
+
+This page documents stable RailKeeper **v0.1.18** and was last reviewed on 2026-08-16.

--- a/docs/site/administration/master-data-general.md
+++ b/docs/site/administration/master-data-general.md
@@ -1,0 +1,110 @@
+---
+title: General master data
+description: Maintain vehicle classifications, manufacturers, CV8 identities, and function symbols.
+audience: admin
+status: stable
+reviewedVersion: 0.1.18
+lastReviewed: 2026-08-16
+---
+
+# General master data
+
+Open **Settings > Data > General** to maintain the shared selections used by vehicles, accessories,
+decoder data, and exhibitions. Stable v0.1.18 provides eight data types.
+
+## Data-type reference
+
+| Data type | Used for | Type-specific fields |
+| --- | --- | --- |
+| Manufacturers | Vehicle and article manufacturer selection, search-source matching | Name, nominal scales, website, search domains, aliases, source URL |
+| Vehicle categories | Broad vehicle classification and inventory-number selection | Name, source URL |
+| Vehicle types | More specific vehicle type or `Gattung` | Name, source URL |
+| Epochs | Vehicle and exhibition era selection | Name, source URL |
+| Gauges | Vehicle and article gauge selection | Name, source URL |
+| Railway companies | Vehicle and exhibition operator selection | Name, source URL |
+| CV8 manufacturers | Decoder manufacturer identity from CV8 | Name, decimal, binary, hexadecimal, country |
+| Function symbols | Images and descriptions for vehicle functions | Name, description, image |
+
+Every entry also has an active state, sort order, origin, immutable key, and timestamps in storage.
+The form exposes the fields relevant to the selected type. A new ordinary key is derived from the
+label. Editing a label does not change that key.
+
+## Search, sort, and inspect entries
+
+Select a type, then use the local search box. It searches the displayed name, key, source values,
+and the type-specific manufacturer, CV8, or symbol metadata. It does not search vehicle or article
+records.
+
+The table initially sorts by name. Select a sortable column to switch the sort key and select it
+again to reverse the order. It always shows active and inactive entries, their **Bundled** or
+**Custom** origin, and only the lifecycle actions allowed for that entry.
+
+Use refresh after another administrator changes the same type. Loading a different type resets
+the current edit, search, and sort selection.
+
+## Maintain manufacturers
+
+The manufacturer entry controls both selection labels and article-search hints:
+
+- **Nominal scales** accepts the scales associated with the manufacturer.
+- **Website** is the canonical manufacturer site.
+- **Search domains** narrows preferred article-search sources. If the list is empty and the website
+  is valid, the form derives its domain automatically.
+- **Aliases** provide alternative manufacturer spellings for matching.
+- **Source URL** records the provenance of the master-data entry itself.
+
+Separate multiple scales, domains, or aliases as indicated by the field. Keep only manufacturer or
+catalogue domains in the preferred-domain list. Dealer, marketplace, redirect, and SEO domains
+reduce search quality. A warning in the table marks manufacturer entries that still need a proper
+website review.
+
+Changing a manufacturer label does not rewrite the free-text manufacturer value already stored on
+vehicles, accessory articles, or exhibition entries. Review those records when correcting a label
+that is already in use.
+
+## Maintain CV8 manufacturers
+
+CV8 identifies the decoder manufacturer through a decimal value from 0 through 255. Entering the
+decimal value derives the binary and hexadecimal representations; both remain visible and are
+normalized before saving. The optional country value is uppercased and limited to eight
+characters.
+
+New entries receive an immutable key in the form `cv8-NNN`, for example `cv8-151`. The displayed
+name omits a redundant leading decimal number. RailKeeper links the official NMRA manufacturer-ID
+appendix above the list. Use that source before adding or correcting an identity.
+
+## Maintain function symbols
+
+A symbol consists of a name, optional description, and optional image. The upload accepts SVG,
+PNG, JPEG, or WebP and rejects files larger than 1 MiB. The image is stored inside the entry's
+metadata, so it is included in master-data export and application backup.
+
+Removing the preview from the form removes the image only when the entry is saved. Existing vehicle
+functions keep the symbol key. Deactivating a symbol prevents new normal selections while existing
+references remain readable. The exhibition workspace can retrieve active symbols without gaining
+general Settings access.
+
+## Create, edit, and retire an entry
+
+1. Select the required data type and search for an existing equivalent.
+2. Enter the name and the relevant source or type-specific values.
+3. Select **Add**. RailKeeper creates a local **Custom** entry.
+4. To correct an entry, select its edit action, change the form, and save.
+5. To retire it, use **Deactivate** and confirm. Existing stored uses remain unchanged.
+6. Reactivate the entry when it should return to new selections.
+7. Use permanent deletion only when RailKeeper offers it for an unused custom entry.
+
+Bundled entries can be edited and deactivated but not deleted. A referenced custom entry also
+cannot be deleted. If a write is rejected for Viewer or Planner, sign in with Admin or Editor
+authority instead of retrying the visible control.
+
+## Related pages
+
+- [Master-data administration](./master-data)
+- [Article master data and storage locations](./master-data-articles)
+- [Inventory-number schemes](./master-data-inventory-numbers)
+- [Article search, web documents, and spare parts](/guide/vehicles/search-and-spares)
+
+## Documented RailKeeper version
+
+This page documents stable RailKeeper **v0.1.18** and was last reviewed on 2026-08-16.

--- a/docs/site/administration/master-data-inventory-numbers.md
+++ b/docs/site/administration/master-data-inventory-numbers.md
@@ -1,0 +1,96 @@
+---
+title: Inventory-number schemes
+description: Configure automatic vehicle and accessory article inventory numbers without collisions.
+audience: admin
+status: stable
+reviewedVersion: 0.1.18
+lastReviewed: 2026-08-16
+---
+
+# Inventory-number schemes
+
+Open **Settings > General > Inventory numbers** to control automatic identities assigned during
+vehicle and accessory-article creation. A scheme contains a unique category, prefix, next number,
+padding width, active state, and preview.
+
+Stable v0.1.18 normally provides these active schemes:
+
+| Category | Default prefix | Default example | Used for |
+| --- | --- | --- | --- |
+| Vehicle | `RK-FAH` | `RK-FAH-000001` | Vehicle fallback |
+| Locomotive | `RK-LOK` | `RK-LOK-000001` | Categories containing `lok` |
+| Wagon | `RK-WAG` | `RK-WAG-000001` | Categories containing `wagen` or `waggon` |
+| Article | `RK-ART` | `RK-ART-000001` | Accessory article records |
+
+The displayed labels are localized, but the stored categories above use their German values
+`Fahrzeug`, `Lokomotive`, `Wagen`, and `Artikel`.
+
+## Assignment rules
+
+RailKeeper reserves the number inside the same database transaction that creates the record. A
+successful reservation increments **Next number**. If the create transaction fails, its number is
+not consumed.
+
+For a vehicle, RailKeeper first looks for an active scheme whose category exactly matches the
+selected vehicle category. It then tries the classified Locomotive or Wagon fallback and finally
+the Vehicle scheme. An accessory article requires the active Article scheme and has no fallback.
+
+The generated form is always `PREFIX-NUMBER`. RailKeeper uppercases the saved prefix, trims it, and
+replaces spaces with hyphens. Padding must be from 1 through 12, and the next number must be at least
+1. Padding is a minimum width, so a larger number is never truncated.
+
+Before assignment, RailKeeper checks the relevant record table. If a candidate is already used, it
+tries the next value and advances past the collision. It stops after 500 attempts. Vehicle and
+article numbers are checked in their respective tables, not as one shared global namespace.
+
+## Create or edit a scheme
+
+1. Review the existing categories before adding one. Each category can have only one scheme.
+2. Enter the category, prefix, next number, padding, and active state in the new row.
+3. Check the preview and select **Create**.
+4. For an existing row, edit its values in place and select **Save**.
+
+There is no delete endpoint in v0.1.18. Deactivate an unused scheme instead. Editing or
+deactivating a scheme never renumbers existing records.
+
+Only Admin and Editor may create or save schemes. Viewer and Planner can read the table. The stable
+UI can still show editable-looking fields to those read-only roles, but the server rejects the
+write.
+
+## Change the next number safely
+
+Moving **Next number** forward intentionally leaves a gap. Moving it backward does not reuse an
+existing number silently because collision checking skips occupied candidates, but it can require
+many attempts and makes audits harder. Prefer a forward-only sequence.
+
+Before changing prefixes or categories:
+
+1. Export an application backup.
+2. Record the current preview and next number.
+3. Confirm that the prefix does not overlap another scheme in the same record domain.
+4. Save the scheme and create one test record.
+5. Verify the assigned number and the updated next value.
+
+When article creation reports that no number can be allocated, reactivate or repair the Article
+scheme. For vehicles, verify the exact category scheme and its Locomotive, Wagon, and Vehicle
+fallbacks.
+
+## Backup and restore behavior
+
+Inventory-number schemes belong to the application database and are included in application backup
+and restore. They are excluded from the master-data JSON transfer. For legacy article rows without
+an inventory number, restore ensures that an Article scheme exists. It assigns missing numbers only
+when that scheme is active; otherwise restore is rejected. Generated values do not duplicate other
+restored article numbers. The scheme can remain numerically behind existing article numbers; later
+article creation safely skips those collisions.
+
+## Related pages
+
+- [Master-data administration](./master-data)
+- [Master-data transfer](./master-data-transfer)
+- [Vehicle inventory](/guide/vehicles/)
+- [Article records and technical data](/guide/accessories/article-records)
+
+## Documented RailKeeper version
+
+This page documents stable RailKeeper **v0.1.18** and was last reviewed on 2026-08-16.

--- a/docs/site/administration/master-data-transfer.md
+++ b/docs/site/administration/master-data-transfer.md
@@ -1,0 +1,102 @@
+---
+title: Master-data transfer
+description: Export and reconcile RailKeeper master data with the versioned JSON document.
+audience: admin
+status: stable
+reviewedVersion: 0.1.18
+lastReviewed: 2026-08-16
+---
+
+# Master-data transfer
+
+The **Master-data transfer** box under **Settings > Import/Export** moves controlled entries and
+their relations between RailKeeper instances. Both download and upload are Admin-only operations.
+This is a specialized configuration transfer, not an application backup and not the vehicle-file
+Import/Export workspace.
+
+## What the document contains
+
+The downloaded file is named `railkeeper-stammdaten-YYYYMMDD-HHMMSS.json`. Stable v0.1.18 exports
+format `railkeeper-master-data`, version 2, with:
+
+- the creation timestamp;
+- every active and inactive general and article master-data entry;
+- keys, labels, source URLs, metadata, sort order, origin, and timestamps;
+- configured master-data relations, such as vehicle category-to-type mappings;
+- embedded function-symbol images because they are entry metadata.
+
+It does not contain vehicles, accessory articles, stock, storage locations, inventory-number
+schemes, users, roles, sessions, or authentication data. Use application backup and restore for a
+recoverable inventory and operational-data transfer. Local authentication remains separate there
+as well.
+
+## Export master data
+
+1. Open **Settings > Import/Export** as an Admin.
+2. In **Master-data transfer**, select the download action.
+3. Store the JSON with the related RailKeeper version and a short change note.
+4. Keep a current application backup separately.
+
+Export is read-only. It includes custom edits and inactive states present at download time.
+
+## Understand import reconciliation
+
+Import is a full desired-state reconciliation, not an additive merge. RailKeeper accepts document
+versions 1 and 2 and validates the complete document before replacing entries and relations in one
+database transaction.
+
+The stable rules are:
+
+- A matching existing bundled identity remains **Bundled**, regardless of the imported origin.
+- An unknown identity becomes **Custom**, even if the document claims it is bundled.
+- Bundled entries omitted from the document are retained with their current state.
+- Unused custom entries omitted from the document are removed.
+- If an omitted custom entry is referenced, the entire import is rejected before mutation.
+- Standard article-type keys remain protected and must form a valid complete configuration.
+- If older documents omit article types or accessory subtypes, the current protected data is
+  preserved according to the compatibility rules.
+- Relations must be unique and point to entries that exist after reconciliation.
+- An omitted current relation is retained only when both endpoints are bundled; other omitted
+  relations are removed.
+- Custom-field definitions and their stored article references must remain valid.
+
+Only after every check succeeds does RailKeeper replace the master-data tables and refresh the
+runtime cache. A failed validation or database operation leaves the previous committed state
+unchanged.
+
+## Import safely
+
+1. Create and validate a current application backup.
+2. Export the current master data as a separate rollback reference.
+3. Compare the incoming file with the current export, especially omitted custom entries, inactive
+   states, article types, subtypes, and relations.
+4. Select the JSON file in **Master-data transfer**.
+5. Select upload and confirm the destructive reconciliation.
+6. Wait for the reported imported-entry and imported-relation counts.
+7. Reload **Settings > Data** and verify representative general and article data.
+8. Create or edit one affected vehicle and accessory article before accepting the transfer.
+
+The stable UI has no dry-run preview. The upload limit is 25 MiB. A malformed file, unsupported
+version, duplicate identity, broken relation, protected article-type change, or referenced omitted
+custom entry rejects the import.
+
+## Recover from a rejected or incorrect transfer
+
+For a rejection, leave the instance running, read the error, correct the source document or its
+origin instance, export again, and retry. Do not remove referenced values merely to make an import
+pass.
+
+If a technically valid import produced the wrong desired state, import the previously exported
+master-data file. If inventory context, number schemes, locations, or other application data also
+need recovery, use the validated application backup instead.
+
+## Related pages
+
+- [Master-data administration](./master-data)
+- [General master data](./master-data-general)
+- [Article master data and storage locations](./master-data-articles)
+- [Import and export workspace](/guide/import-export/)
+
+## Documented RailKeeper version
+
+This page documents stable RailKeeper **v0.1.18** and was last reviewed on 2026-08-16.

--- a/docs/site/administration/master-data.md
+++ b/docs/site/administration/master-data.md
@@ -1,0 +1,85 @@
+---
+title: Master-data administration
+description: Govern RailKeeper master data, inventory-number schemes, locations, and transfers safely.
+audience: admin
+status: stable
+reviewedVersion: 0.1.18
+lastReviewed: 2026-08-16
+---
+
+# Master-data administration
+
+RailKeeper uses controlled master data wherever records must share names, classifications, symbols,
+or numbering rules. Most of it is managed under **Settings > Data**. Inventory-number schemes are
+under **Settings > General**, and the master-data JSON transfer is under
+**Settings > Import/Export**.
+
+This section documents stable RailKeeper v0.1.18. It separates four administrative workflows:
+
+- [General master data](./master-data-general) for vehicles, manufacturers, CV8 identities, and
+  function symbols.
+- [Article master data and storage locations](./master-data-articles) for accessory catalogue and
+  stock structure.
+- [Inventory-number schemes](./master-data-inventory-numbers) for automatic vehicle and article
+  identities.
+- [Master-data transfer](./master-data-transfer) for complete JSON export and reconciliation.
+
+## Access rights
+
+| Action | Admin | Editor | Viewer | Planner | Messe |
+| --- | --- | --- | --- | --- | --- |
+| Open Settings and read master data | Yes | Yes | Yes | Yes | No |
+| Create, edit, deactivate, or reactivate entries | Yes | Yes | No | No | No |
+| Permanently delete an eligible custom entry | Yes | Yes | No | No | No |
+| Manage storage locations | Yes | Yes | No | No | No |
+| Manage inventory-number schemes | Yes | Yes | No | No | No |
+| Export or import the master-data document | Yes | No | No | No | No |
+
+Viewer and Planner inherit read access. Article management explicitly displays a read-only state.
+Some controls in the general master-data and inventory-number panels can still remain visible to
+those roles in v0.1.18, but the server rejects every write. Visible controls are never an access
+grant.
+
+A pure Messe account cannot open Settings. It can read the active function-symbol subset only
+through the isolated exhibition workflow.
+
+## Understand origin and lifecycle
+
+Every controlled entry has an origin:
+
+| Origin | Meaning | Permanent deletion |
+| --- | --- | --- |
+| **Bundled** | Shipped and reconciled by RailKeeper | Never allowed |
+| **Custom** | Created locally or imported without a matching bundled identity | Allowed only while unused |
+
+Both origins can be edited, deactivated, and reactivated. Deactivation removes an entry from new
+selections. Existing records retain their stored value and continue to show it as inactive. It is
+therefore the safe way to retire a value that remains part of inventory history.
+
+Permanent deletion is deliberately narrower. RailKeeper offers it only for a custom entry whose
+type has a known usage check and whose key or label is not referenced. Standard article-type keys
+are additionally protected. Deleting an eligible entry also removes its master-data relations and
+cannot be undone.
+
+## Use a conservative change sequence
+
+1. Create and validate a current application backup before a broad change.
+2. Export the current master-data JSON when changing many classifications.
+3. Prefer editing a spelling mistake over creating a near-duplicate value.
+4. Deactivate an obsolete value first and verify affected vehicle, article, and exhibition views.
+5. Delete only a confirmed unused custom entry.
+6. Test creation of one affected vehicle or article before continuing with a batch of changes.
+
+Inventory-number schemes and storage locations are not part of the master-data JSON export. Use an
+application backup when those settings must be recoverable together with the inventory.
+
+## Related pages
+
+- [Settings overview and permissions](/guide/settings/)
+- [Accessories overview](/guide/accessories/)
+- [Vehicle inventory](/guide/vehicles/)
+- [Installation and Administration](./)
+
+## Documented RailKeeper version
+
+This section documents stable RailKeeper **v0.1.18** and was last reviewed on 2026-08-16.

--- a/docs/site/de/administration/index.md
+++ b/docs/site/de/administration/index.md
@@ -16,6 +16,11 @@ Betriebsprüfungen und konservative Fehlerbehebung.
 Die Administrationsanleitungen beschreiben die stabile Laufzeit v0.1.18 und erhalten das lokale,
 selbst gehostete Sicherheitsmodell von RailKeeper.
 
+## Administrative Abläufe
+
+- [Stammdaten-Administration](./master-data) behandelt kontrollierte Werte, Lebenszyklus,
+  Lagerorte, Inventarnummernschemata und den JSON-Transfer.
+
 ## Sichere Updates unter Windows
 
 Das ZIP-Paket von Windows Standalone enthält ausschließlich die Anwendung. Datenbank, Uploads,
@@ -86,3 +91,6 @@ Bearbeitungen und Deaktivierungen bleiben nach einem Neustart, einem Abgleich de
 Stammdaten, einem Update, dem Export und Import von Stammdaten sowie einer Sicherung und
 Wiederherstellung der Anwendung erhalten. Vor umfangreichen Stammdatenänderungen wird dennoch eine
 aktuelle RailKeeper-Sicherung empfohlen.
+
+Die vollständigen Feld-, Berechtigungs-, Nummerierungs-, Lagerort- und Importregeln beschreibt die
+[Stammdaten-Administration](./master-data).

--- a/docs/site/de/administration/master-data-articles.md
+++ b/docs/site/de/administration/master-data-articles.md
@@ -1,0 +1,118 @@
+---
+title: Artikelstammdaten und Lagerorte
+description: Bestandseinheiten, Artikelklassifizierung, eigene Felder und hierarchische Lagerorte konfigurieren.
+audience: admin
+status: stable
+reviewedVersion: 0.1.18
+lastReviewed: 2026-08-16
+---
+
+# Artikelstammdaten und Lagerorte
+
+Unter **Einstellungen > Daten > Artikeldaten** stehen die kontrollierten Werte für Zubehörartikel.
+Die Seite trennt Bestandseinheiten, Artikelklassifizierung, eigene Felder und Lagerorte. Admin und
+Editor können sie ändern. Viewer und Planner sehen ausdrücklich eine Nur-Lese-Ansicht.
+
+## Bestandseinheiten
+
+Bestandseinheiten beschreiben, was Artikelmengen zählen, beispielsweise Stück, Packungen, Meter
+oder Gramm. Jeder Eintrag besitzt einen unveränderlichen Schlüssel, eine bearbeitbare Bezeichnung,
+einen Aktivstatus und eine Herkunft.
+
+Eine neue Einheit nur anlegen, wenn die vorhandene Liste den Bestand nicht ausdrücken kann. Eine
+Deaktivierung entfernt sie aus neuen Artikelauswahlen. Bereits zugeordnete Artikel behalten den
+historischen Wert. Eine eigene Einheit kann nur endgültig gelöscht werden, solange kein Artikel
+ihren Schlüssel verwendet.
+
+## Artikelarten und Unterarten
+
+RailKeeper liefert acht geschützte Artikelart-Schlüssel aus:
+
+- Gleis
+- Signal
+- Decoder
+- Elektrik / Steuerung
+- Gebäude / Ausstattung
+- Landschaftsverbrauchsmaterial
+- Beleuchtung
+- Sonstiges
+
+Bezeichnungen und Aktivstatus lassen sich verwalten, aber v0.1.18 erlaubt weder neue noch gelöschte
+Artikelart-Schlüssel. Dadurch bleiben die zugehörigen Verträge für Fachangaben geschützt. Eine
+Deaktivierung entfernt die Art aus neuen Artikelauswahlen, ohne vorhandene Artikel umzuschreiben.
+
+Unterarten verfeinern eine dieser Artikelarten. Admin und Editor können eigene Unterarten anlegen,
+bearbeiten, deaktivieren, reaktivieren und im ungenutzten Zustand löschen. Ihr Schlüssel muss mit
+dem Schlüssel der übergeordneten Artikelart und einem Doppelpunkt beginnen, beispielsweise
+`track:turnout`. An diesem Präfix erkennt RailKeeper die zugehörige Artikelart.
+
+Eine geänderte oder deaktivierte Klassifizierung migriert Artikeldatensätze niemals automatisch.
+Die betroffenen Artikel prüfen und bewusst entscheiden, ob ihre historische Klassifizierung bleibt
+oder einzeln bearbeitet wird.
+
+## Kontrollierte eigene Felder
+
+Eigene Felder erscheinen nur bei Artikeln der Art **Sonstiges**. Jede Definition besitzt Schlüssel,
+Bezeichnung, Aktivstatus und einen dieser Datentypen:
+
+| Datentyp | Konfiguration und gespeicherter Wert |
+| --- | --- |
+| Text | Freitext |
+| Zahl | Zahlenwert und optionale Einheit |
+| Ja / Nein | Ausdrücklicher boolescher Wert |
+| Datum | Datumswert |
+| Einfachauswahl | Genau ein konfigurierter Auswahlwert |
+| Mehrfachauswahl | Kein, ein oder mehrere konfigurierte Auswahlwerte |
+
+Einfach- und Mehrfachauswahl benötigen eine nicht leere, kommagetrennte Optionsliste. Die Oberfläche
+entfernt leere Optionen, der Server weist doppelte Optionen ab. Den Datentyp sorgfältig wählen: Sobald
+ein eigenes Feld in gespeicherten Attributen eines **Sonstiges**-Artikels verwendet wird, kann sein
+Schlüssel nicht mehr gelöscht werden. Historische Werte mit inaktiver Definition bleiben lesbar,
+lassen sich aber weder neu hinzufügen noch ändern.
+
+## Lagerorte
+
+Lagerorte bilden eine Hierarchie außerhalb der kontrollierten Stammdatentabelle. Jeder Ort besitzt
+einen erforderlichen Namen, optionalen übergeordneten Ort, optionale Beschreibung und Archivstatus.
+Die Liste zeigt den vollständigen Pfad, beispielsweise `Lager / Schrank A / Schublade 3`.
+
+Namen müssen innerhalb derselben Ebene ohne Beachtung der Groß- und Kleinschreibung eindeutig sein.
+Ein Lagerort kann weder sein eigener übergeordneter Ort sein noch unter einen seiner Nachfolger
+verschoben werden. Die Elternauswahl blendet diese ungültigen Möglichkeiten aus.
+
+In v0.1.18 gibt es keine endgültige Löschaktion. Einen nicht mehr verwendeten Ort archivieren und
+bei Bedarf reaktivieren. Bestand und Einzelstücke können einen Ort nur verwenden, wenn dieser Ort
+und alle übergeordneten Orte aktiv sind. Das Archivieren eines Elternorts sperrt daher seinen
+gesamten Zweig für neue Bestandsvorgänge, ohne gespeicherte Ortsverweise zu löschen.
+
+Eine sichere Hierarchie wird so aufgebaut:
+
+1. Übergeordneten Raum oder Lagerbereich anlegen.
+2. Schränke oder Regale mit diesem Elternort anlegen.
+3. Fächer oder Schubladen unter dem passenden Zweig ergänzen.
+4. Vor der Bestandszuordnung den vollständig angezeigten Pfad prüfen.
+5. Veraltete Endpunkte zuerst archivieren, danach ihre leeren Elternorte.
+
+Lagerorte sind in Anwendungssicherung und Wiederherstellung enthalten, aber nicht im eigenständigen
+Stammdaten-JSON.
+
+## Lebenszyklus und Konflikte
+
+Die Aktionsspalte folgt den vom Server berechneten Möglichkeiten. Mitgelieferte Einträge zeigen nie
+das endgültige Löschen. Verwendete eigene Einträge verlieren diese Aktion ebenfalls. Deaktivieren
+und Löschen erfordern eine Bestätigung, Reaktivieren schreibt sofort.
+
+Meldet das Speichern einen Konflikt, auf einen doppelten gleichgeordneten Lagerort, eine geschützte
+Artikelart, einen verwendeten eigenen Wert oder eine ungültige Optionsliste prüfen. Ein
+abgewiesener Vorgang lässt die gespeicherte Konfiguration unverändert.
+
+## Verwandte Seiten
+
+- [Stammdaten-Administration](./master-data)
+- [Allgemeine Stammdaten](./master-data-general)
+- [Artikelstammdaten und Fachangaben](/de/guide/accessories/article-records)
+- [Bestand, Käufe und Dokumente](/de/guide/accessories/stock-purchases-documents)
+
+## Dokumentierte RailKeeper-Version
+
+Diese Seite dokumentiert RailKeeper **v0.1.18** und wurde zuletzt am 16.08.2026 geprüft.

--- a/docs/site/de/administration/master-data-general.md
+++ b/docs/site/de/administration/master-data-general.md
@@ -1,0 +1,114 @@
+---
+title: Allgemeine Stammdaten
+description: Fahrzeugklassifizierungen, Hersteller, CV8-Kennungen und Funktionssymbole verwalten.
+audience: admin
+status: stable
+reviewedVersion: 0.1.18
+lastReviewed: 2026-08-16
+---
+
+# Allgemeine Stammdaten
+
+Unter **Einstellungen > Daten > Allgemein** werden die gemeinsamen Auswahlen für Fahrzeuge,
+Zubehör, Decoderdaten und Messen verwaltet. RailKeeper v0.1.18 stellt acht Datentypen bereit.
+
+## Datentypen
+
+| Datentyp | Verwendung | Spezifische Felder |
+| --- | --- | --- |
+| Hersteller | Herstellerwahl für Fahrzeuge und Artikel, Zuordnung von Suchquellen | Name, Nenngrößen, Website, Suchdomains, Aliasse, Quell-URL |
+| Fahrzeugkategorien | Grobe Fahrzeugklassifizierung und Wahl des Inventarnummernschemas | Name, Quell-URL |
+| Fahrzeuggattungen | Genauere Fahrzeugart oder Gattung | Name, Quell-URL |
+| Epochen | Epochenwahl für Fahrzeuge und Messeinträge | Name, Quell-URL |
+| Spurweiten | Spurweitenwahl für Fahrzeuge und Artikel | Name, Quell-URL |
+| Bahngesellschaften | Betreiberwahl für Fahrzeuge und Messeinträge | Name, Quell-URL |
+| CV8-Hersteller | Decoderhersteller-Kennung aus CV8 | Name, Dezimal, Binär, Hexadezimal, Land |
+| Funktionssymbole | Bilder und Beschreibungen für Fahrzeugfunktionen | Name, Beschreibung, Bild |
+
+Jeder Eintrag besitzt außerdem Aktivstatus, Sortierreihenfolge, Herkunft, unveränderlichen Schlüssel
+und Zeitstempel im Speicher. Das Formular zeigt die zum gewählten Typ passenden Felder. Der
+Schlüssel eines neuen gewöhnlichen Eintrags wird aus der Bezeichnung erzeugt. Eine spätere
+Umbenennung ändert diesen Schlüssel nicht.
+
+## Einträge suchen, sortieren und prüfen
+
+Nach Auswahl eines Datentyps durchsucht das lokale Suchfeld den angezeigten Namen, Schlüssel,
+Quellwerte und die typabhängigen Hersteller-, CV8- oder Symbolangaben. Fahrzeug- oder
+Artikeldatensätze werden dabei nicht durchsucht.
+
+Die Tabelle ist zunächst nach Name sortiert. Mit einer sortierbaren Spalte wird der Sortierschlüssel
+gewechselt, erneutes Auswählen kehrt die Reihenfolge um. Aktive und inaktive Einträge, ihre Herkunft
+**Mitgeliefert** oder **Eigen** und nur die erlaubten Lebenszyklusaktionen bleiben sichtbar.
+
+Nach einer parallelen Änderung durch einen anderen Administrator die Aktualisierungsaktion
+verwenden. Beim Wechsel des Datentyps werden aktueller Entwurf, Suche und Sortierung zurückgesetzt.
+
+## Hersteller verwalten
+
+Der Herstellereintrag steuert sowohl Auswahlnamen als auch Hinweise für die Artikelsuche:
+
+- **Nenngrößen** ordnet die vom Hersteller angebotenen Maßstäbe zu.
+- **Website** enthält die maßgebliche Herstellerseite.
+- **Suchdomains** bevorzugt passende Quellen in der Artikelsuche. Ist die Liste leer und die
+  Website gültig, leitet das Formular deren Domain automatisch ab.
+- **Aliasse** enthalten alternative Schreibweisen für die Zuordnung.
+- **Quell-URL** dokumentiert die Herkunft des Stammdateneintrags selbst.
+
+Mehrere Nenngrößen, Domains oder Aliasse wie im jeweiligen Feld angegeben trennen. In die
+bevorzugten Domains gehören nur Hersteller- oder Katalogquellen. Händler-, Marktplatz-,
+Weiterleitungs- und SEO-Domains verschlechtern die Suchqualität. Eine Warnung in der Tabelle
+kennzeichnet Herstellereinträge, deren Website noch geprüft werden muss.
+
+Das Ändern einer Herstellerbezeichnung schreibt den bereits in Fahrzeugen, Zubehörartikeln oder
+Messeinträgen gespeicherten Freitext nicht um. Bei einer Korrektur eines verwendeten Namens müssen
+diese Datensätze geprüft werden.
+
+## CV8-Hersteller verwalten
+
+CV8 kennzeichnet den Decoderhersteller mit einem Dezimalwert von 0 bis 255. Aus der Dezimalzahl
+leitet RailKeeper die binäre und hexadezimale Darstellung ab. Beide bleiben sichtbar und werden vor
+dem Speichern normalisiert. Der optionale Länderwert wird in Großbuchstaben umgewandelt und ist auf
+acht Zeichen begrenzt.
+
+Neue Einträge erhalten einen unveränderlichen Schlüssel der Form `cv8-NNN`, beispielsweise
+`cv8-151`. Im angezeigten Namen wird eine redundante führende Dezimalzahl entfernt. Oberhalb der
+Liste verlinkt RailKeeper den offiziellen NMRA-Anhang mit Herstellerkennungen. Diese Quelle vor dem
+Anlegen oder Korrigieren verwenden.
+
+## Funktionssymbole verwalten
+
+Ein Symbol besteht aus Name, optionaler Beschreibung und optionalem Bild. Der Upload akzeptiert
+SVG, PNG, JPEG oder WebP und weist Dateien über 1 MiB ab. Das Bild liegt in den Metadaten des
+Eintrags und ist deshalb im Stammdatenexport und in der Anwendungssicherung enthalten.
+
+Das Entfernen der Vorschau löscht das Bild erst beim Speichern des Eintrags. Bestehende
+Fahrzeugfunktionen behalten den Symbolschlüssel. Eine Deaktivierung verhindert neue reguläre
+Auswahlen, vorhandene Verweise bleiben lesbar. Der Messearbeitsbereich kann aktive Symbole abrufen,
+ohne allgemeinen Zugriff auf die Einstellungen zu erhalten.
+
+## Eintrag anlegen, bearbeiten und außer Betrieb nehmen
+
+1. Benötigten Datentyp wählen und nach einem vorhandenen gleichwertigen Eintrag suchen.
+2. Name sowie relevante Quell- oder Spezialwerte eingeben.
+3. **Hinzufügen** wählen. RailKeeper erzeugt einen lokalen Eintrag mit Herkunft **Eigen**.
+4. Zum Korrigieren die Bearbeitungsaktion wählen, Formular ändern und speichern.
+5. Zum Außerbetriebnehmen **Deaktivieren** wählen und bestätigen. Gespeicherte Verwendungen bleiben
+   unverändert.
+6. Den Eintrag reaktivieren, wenn er wieder für neue Auswahlen angeboten werden soll.
+7. Endgültiges Löschen nur verwenden, wenn RailKeeper es für einen ungenutzten eigenen Eintrag
+   anbietet.
+
+Mitgelieferte Einträge lassen sich bearbeiten und deaktivieren, aber nicht löschen. Ein verwendeter
+eigener Eintrag kann ebenfalls nicht gelöscht werden. Wird ein Schreibvorgang für Viewer oder
+Planner abgewiesen, ist ein Admin- oder Editor-Konto erforderlich.
+
+## Verwandte Seiten
+
+- [Stammdaten-Administration](./master-data)
+- [Artikelstammdaten und Lagerorte](./master-data-articles)
+- [Inventarnummernschemata](./master-data-inventory-numbers)
+- [Artikelsuche, Web-Dokumente und Ersatzteile](/de/guide/vehicles/search-and-spares)
+
+## Dokumentierte RailKeeper-Version
+
+Diese Seite dokumentiert RailKeeper **v0.1.18** und wurde zuletzt am 16.08.2026 geprüft.

--- a/docs/site/de/administration/master-data-inventory-numbers.md
+++ b/docs/site/de/administration/master-data-inventory-numbers.md
@@ -1,0 +1,99 @@
+---
+title: Inventarnummernschemata
+description: Automatische Inventarnummern für Fahrzeuge und Zubehörartikel kollisionsfrei konfigurieren.
+audience: admin
+status: stable
+reviewedVersion: 0.1.18
+lastReviewed: 2026-08-16
+---
+
+# Inventarnummernschemata
+
+Unter **Einstellungen > Allgemein > Inventarnummern** werden die automatischen Kennungen für neue
+Fahrzeuge und Zubehörartikel gesteuert. Ein Schema enthält eindeutige Kategorie, Präfix, nächste
+Nummer, Stellenzahl, Aktivstatus und Vorschau.
+
+RailKeeper v0.1.18 stellt normalerweise diese aktiven Schemata bereit:
+
+| Kategorie | Standardpräfix | Standardbeispiel | Verwendung |
+| --- | --- | --- | --- |
+| Fahrzeug | `RK-FAH` | `RK-FAH-000001` | Fahrzeug-Rückfall |
+| Lokomotive | `RK-LOK` | `RK-LOK-000001` | Kategorien mit `lok` |
+| Wagen | `RK-WAG` | `RK-WAG-000001` | Kategorien mit `wagen` oder `waggon` |
+| Artikel | `RK-ART` | `RK-ART-000001` | Zubehörartikel |
+
+## Vergaberegeln
+
+RailKeeper reserviert die Nummer innerhalb derselben Datenbanktransaktion, in der der Datensatz
+angelegt wird. Eine erfolgreiche Reservierung erhöht **Nächste Nummer**. Scheitert das Anlegen,
+wird die Nummer nicht verbraucht.
+
+Bei einem Fahrzeug sucht RailKeeper zuerst ein aktives Schema, dessen Kategorie exakt der gewählten
+Fahrzeugkategorie entspricht. Danach folgen der erkannte Rückfall Lokomotive oder Wagen und zuletzt
+das Fahrzeugschema. Ein Zubehörartikel benötigt das aktive Artikelschema und besitzt keinen
+Rückfall.
+
+Das erzeugte Format lautet immer `PRÄFIX-NUMMER`. RailKeeper wandelt das gespeicherte Präfix in
+Großbuchstaben um, entfernt äußere Leerzeichen und ersetzt Leerzeichen durch Bindestriche. Die
+Stellenzahl muss zwischen 1 und 12 liegen, die nächste Nummer mindestens 1 betragen. Die
+Stellenzahl ist eine Mindestbreite, größere Zahlen werden niemals abgeschnitten.
+
+Vor der Vergabe prüft RailKeeper die passende Datensatztabelle. Ist ein Kandidat bereits belegt,
+wird der nächste Wert versucht und der Zähler über die Kollision hinaus weitergestellt. Nach 500
+Versuchen endet die Suche. Fahrzeug- und Artikelnummern werden in ihren jeweiligen Tabellen und
+nicht in einem gemeinsamen globalen Namensraum geprüft.
+
+## Schema anlegen oder bearbeiten
+
+1. Vor dem Anlegen die vorhandenen Kategorien prüfen. Pro Kategorie ist nur ein Schema erlaubt.
+2. Kategorie, Präfix, nächste Nummer, Stellenzahl und Aktivstatus in der neuen Zeile eingeben.
+3. Vorschau prüfen und **Anlegen** wählen.
+4. Bei einem vorhandenen Schema die Werte direkt ändern und **Speichern** wählen.
+
+In v0.1.18 gibt es keinen Löschendpunkt. Ein ungenutztes Schema stattdessen deaktivieren. Das
+Bearbeiten oder Deaktivieren nummeriert vorhandene Datensätze niemals um.
+
+Nur Admin und Editor dürfen Schemata anlegen oder speichern. Viewer und Planner können die Tabelle
+lesen. Die stabile Oberfläche kann ihnen trotzdem bearbeitbar wirkende Felder zeigen, der Server
+weist den Schreibvorgang jedoch ab.
+
+## Nächste Nummer sicher ändern
+
+Wird **Nächste Nummer** nach vorne gesetzt, entsteht bewusst eine Lücke. Beim Zurücksetzen wird eine
+vorhandene Nummer wegen der Kollisionsprüfung nicht stillschweigend wiederverwendet. Der Vorgang
+kann aber viele Versuche verursachen und Prüfungen erschweren. Eine nur vorwärts laufende Folge ist
+vorzuziehen.
+
+Vor einer Änderung an Präfix oder Kategorie:
+
+1. Anwendungssicherung exportieren.
+2. Aktuelle Vorschau und nächste Nummer notieren.
+3. Prüfen, dass sich das Präfix im selben Datensatzbereich nicht mit einem anderen Schema
+   überschneidet.
+4. Schema speichern und einen Testdatensatz anlegen.
+5. Vergebene Nummer und aktualisierten nächsten Wert kontrollieren.
+
+Kann beim Anlegen eines Artikels keine Nummer vergeben werden, muss das Artikelschema reaktiviert
+oder korrigiert werden. Bei Fahrzeugen das exakte Kategorieschema sowie die Rückfälle Lokomotive,
+Wagen und Fahrzeug prüfen.
+
+## Sicherung und Wiederherstellung
+
+Inventarnummernschemata gehören zur Anwendungsdatenbank und sind in Anwendungssicherung und
+Wiederherstellung enthalten. Der Stammdaten-JSON-Transfer enthält sie nicht. Für ältere
+Artikelzeilen ohne Inventarnummer stellt die Wiederherstellung ein Artikelschema sicher. Fehlende
+Nummern werden nur bei aktivem Schema vergeben, andernfalls wird die Wiederherstellung abgewiesen.
+Dabei entstehen keine Dubletten zu anderen wiederhergestellten Artikelnummern. Das Schema kann
+numerisch hinter vorhandenen Artikelnummern liegen, spätere Artikelanlagen überspringen diese
+Kollisionen sicher.
+
+## Verwandte Seiten
+
+- [Stammdaten-Administration](./master-data)
+- [Stammdatentransfer](./master-data-transfer)
+- [Fahrzeugbestand](/de/guide/vehicles/)
+- [Artikelstammdaten und Fachangaben](/de/guide/accessories/article-records)
+
+## Dokumentierte RailKeeper-Version
+
+Diese Seite dokumentiert RailKeeper **v0.1.18** und wurde zuletzt am 16.08.2026 geprüft.

--- a/docs/site/de/administration/master-data-transfer.md
+++ b/docs/site/de/administration/master-data-transfer.md
@@ -1,0 +1,106 @@
+---
+title: Stammdatentransfer
+description: RailKeeper-Stammdaten mit dem versionierten JSON-Dokument exportieren und abgleichen.
+audience: admin
+status: stable
+reviewedVersion: 0.1.18
+lastReviewed: 2026-08-16
+---
+
+# Stammdatentransfer
+
+Der Bereich **Stammdatentransfer** unter **Einstellungen > Import/Export** überträgt kontrollierte
+Einträge und ihre Beziehungen zwischen RailKeeper-Instanzen. Download und Upload sind ausschließlich
+für Admins erlaubt. Dies ist ein spezieller Konfigurationstransfer, weder eine Anwendungssicherung
+noch der Arbeitsbereich für den Fahrzeugdatei-Import und -Export.
+
+## Inhalt des Dokuments
+
+Die heruntergeladene Datei heißt `railkeeper-stammdaten-YYYYMMDD-HHMMSS.json`. RailKeeper v0.1.18
+exportiert das Format `railkeeper-master-data` in Version 2 mit:
+
+- Erstellungszeitpunkt;
+- allen aktiven und inaktiven allgemeinen und Artikelstammdaten;
+- Schlüsseln, Bezeichnungen, Quell-URLs, Metadaten, Sortierreihenfolge, Herkunft und Zeitstempeln;
+- konfigurierten Stammdatenbeziehungen, beispielsweise Kategorie-Gattung-Zuordnungen;
+- eingebetteten Bildern der Funktionssymbole, weil sie zu den Metadaten gehören.
+
+Nicht enthalten sind Fahrzeuge, Zubehörartikel, Bestand, Lagerorte, Inventarnummernschemata,
+Benutzer, Rollen, Sitzungen oder Anmeldedaten. Für eine wiederherstellbare Übertragung von Bestand
+und Betriebsdaten ist die Anwendungssicherung und -wiederherstellung erforderlich. Lokale
+Anmeldedaten bleiben auch dort getrennt.
+
+## Stammdaten exportieren
+
+1. **Einstellungen > Import/Export** als Admin öffnen.
+2. Unter **Stammdatentransfer** die Downloadaktion wählen.
+3. JSON zusammen mit der zugehörigen RailKeeper-Version und einer kurzen Änderungsnotiz ablegen.
+4. Eine aktuelle Anwendungssicherung getrennt aufbewahren.
+
+Der Export schreibt keine Daten. Er enthält eigene Änderungen und die zum Downloadzeitpunkt
+vorhandenen inaktiven Zustände.
+
+## Importabgleich verstehen
+
+Der Import ist ein vollständiger Sollzustandsabgleich und keine ergänzende Zusammenführung.
+RailKeeper akzeptiert die Dokumentversionen 1 und 2 und prüft das gesamte Dokument, bevor Einträge
+und Beziehungen in einer Datenbanktransaktion ersetzt werden.
+
+Dabei gelten diese Regeln:
+
+- Eine vorhandene passende mitgelieferte Kennung bleibt unabhängig von der importierten Herkunft
+  **Mitgeliefert**.
+- Eine unbekannte Kennung wird **Eigen**, selbst wenn das Dokument sie als mitgeliefert bezeichnet.
+- Im Dokument fehlende mitgelieferte Einträge bleiben mit ihrem aktuellen Zustand erhalten.
+- Im Dokument fehlende ungenutzte eigene Einträge werden entfernt.
+- Wird ein fehlender eigener Eintrag verwendet, scheitert der gesamte Import vor der Änderung.
+- Die Standardschlüssel der Artikelarten bleiben geschützt und müssen eine gültige vollständige
+  Konfiguration bilden.
+- Fehlen Artikelarten oder Zubehörunterarten in älteren Dokumenten, bleiben die aktuellen
+  geschützten Daten nach den Kompatibilitätsregeln erhalten.
+- Beziehungen müssen eindeutig sein und auf Einträge verweisen, die nach dem Abgleich existieren.
+- Eine vorhandene fehlende Beziehung bleibt nur erhalten, wenn beide Endpunkte mitgeliefert sind.
+  Andere im Dokument fehlende Beziehungen werden entfernt.
+- Definitionen eigener Felder und ihre gespeicherten Artikelverweise müssen gültig bleiben.
+
+Erst nach allen erfolgreichen Prüfungen ersetzt RailKeeper die Stammdatentabellen und aktualisiert
+den Laufzeit-Cache. Eine fehlgeschlagene Validierung oder Datenbankoperation lässt den zuvor
+gespeicherten Zustand unverändert.
+
+## Sicher importieren
+
+1. Aktuelle Anwendungssicherung erstellen und prüfen.
+2. Aktuelle Stammdaten zusätzlich als getrennte Rückfallreferenz exportieren.
+3. Eingehende Datei mit dem aktuellen Export vergleichen, besonders fehlende eigene Einträge,
+   Inaktivzustände, Artikelarten, Unterarten und Beziehungen.
+4. JSON-Datei unter **Stammdatentransfer** auswählen.
+5. Upload wählen und den destruktiven Abgleich bestätigen.
+6. Auf die gemeldete Anzahl importierter Einträge und Beziehungen warten.
+7. **Einstellungen > Daten** neu laden und repräsentative allgemeine und Artikelstammdaten prüfen.
+8. Vor der Abnahme ein betroffenes Fahrzeug und einen Zubehörartikel anlegen oder bearbeiten.
+
+Die stabile Oberfläche bietet keine Probelauf-Vorschau. Die Uploadgrenze beträgt 25 MiB. Eine
+fehlerhafte Datei, nicht unterstützte Version, doppelte Kennung, defekte Beziehung, unzulässige
+Änderung der Artikelarten oder ein fehlender verwendeter eigener Eintrag weist den Import ab.
+
+## Abgewiesenen oder falschen Transfer beheben
+
+Nach einer Abweisung die Instanz weiterlaufen lassen, Fehlermeldung lesen, Quelldokument oder
+Quellinstanz korrigieren, erneut exportieren und wiederholen. Referenzierte Werte nicht nur deshalb
+entfernen, damit ein Import erfolgreich ist.
+
+Hat ein technisch gültiger Import den falschen Sollzustand erzeugt, das zuvor exportierte
+Stammdatendokument importieren. Müssen auch Bestandszusammenhang, Nummernschemata, Lagerorte oder
+andere Anwendungsdaten wiederhergestellt werden, stattdessen die geprüfte Anwendungssicherung
+verwenden.
+
+## Verwandte Seiten
+
+- [Stammdaten-Administration](./master-data)
+- [Allgemeine Stammdaten](./master-data-general)
+- [Artikelstammdaten und Lagerorte](./master-data-articles)
+- [Arbeitsbereich Import und Export](/de/guide/import-export/)
+
+## Dokumentierte RailKeeper-Version
+
+Diese Seite dokumentiert RailKeeper **v0.1.18** und wurde zuletzt am 16.08.2026 geprüft.

--- a/docs/site/de/administration/master-data.md
+++ b/docs/site/de/administration/master-data.md
@@ -1,0 +1,88 @@
+---
+title: Stammdaten-Administration
+description: Stammdaten, Inventarnummern, Lagerorte und Transfer in RailKeeper sicher verwalten.
+audience: admin
+status: stable
+reviewedVersion: 0.1.18
+lastReviewed: 2026-08-16
+---
+
+# Stammdaten-Administration
+
+RailKeeper verwendet kontrollierte Stammdaten überall dort, wo Datensätze gemeinsame Namen,
+Klassifizierungen, Symbole oder Nummerierungsregeln benötigen. Der größte Teil wird unter
+**Einstellungen > Daten** verwaltet. Inventarnummernschemata stehen unter
+**Einstellungen > Allgemein**, der JSON-Stammdatentransfer unter
+**Einstellungen > Import/Export**.
+
+Dieser Bereich dokumentiert RailKeeper v0.1.18 und trennt vier administrative Abläufe:
+
+- [Allgemeine Stammdaten](./master-data-general) für Fahrzeuge, Hersteller, CV8-Kennungen und
+  Funktionssymbole.
+- [Artikelstammdaten und Lagerorte](./master-data-articles) für Zubehörkatalog und Bestandsstruktur.
+- [Inventarnummernschemata](./master-data-inventory-numbers) für automatische Fahrzeug- und
+  Artikelkennungen.
+- [Stammdatentransfer](./master-data-transfer) für vollständigen JSON-Export und Abgleich.
+
+## Zugriffsrechte
+
+| Aktion | Admin | Editor | Viewer | Planner | Messe |
+| --- | --- | --- | --- | --- | --- |
+| Einstellungen öffnen und Stammdaten lesen | Ja | Ja | Ja | Ja | Nein |
+| Einträge anlegen, bearbeiten, deaktivieren oder reaktivieren | Ja | Ja | Nein | Nein | Nein |
+| Geeigneten eigenen Eintrag endgültig löschen | Ja | Ja | Nein | Nein | Nein |
+| Lagerorte verwalten | Ja | Ja | Nein | Nein | Nein |
+| Inventarnummernschemata verwalten | Ja | Ja | Nein | Nein | Nein |
+| Stammdatendokument exportieren oder importieren | Ja | Nein | Nein | Nein | Nein |
+
+Viewer und Planner erben den Lesezugriff. Die Artikelverwaltung zeigt ausdrücklich einen
+Nur-Lese-Zustand. Einige Bedienelemente für allgemeine Stammdaten und Inventarnummern können für
+diese Rollen in v0.1.18 trotzdem sichtbar bleiben, der Server weist aber jeden Schreibvorgang ab.
+Ein sichtbares Bedienelement erteilt niemals eine Berechtigung.
+
+Ein reines Messe-Konto kann die Einstellungen nicht öffnen. Es kann nur die aktiven
+Funktionssymbole über den isolierten Messeablauf lesen.
+
+## Herkunft und Lebenszyklus verstehen
+
+Jeder kontrollierte Eintrag besitzt eine Herkunft:
+
+| Herkunft | Bedeutung | Endgültiges Löschen |
+| --- | --- | --- |
+| **Mitgeliefert** | Wird von RailKeeper ausgeliefert und abgeglichen | Niemals erlaubt |
+| **Eigen** | Lokal angelegt oder ohne passende mitgelieferte Kennung importiert | Nur ungenutzt erlaubt |
+
+Einträge beider Herkünfte lassen sich bearbeiten, deaktivieren und reaktivieren. Eine Deaktivierung
+entfernt einen Eintrag aus neuen Auswahlen. Bestehende Datensätze behalten ihren gespeicherten Wert
+und zeigen ihn weiterhin als inaktiv an. So wird ein historisch noch benötigter Wert sicher außer
+Betrieb genommen.
+
+Das endgültige Löschen ist absichtlich enger gefasst. RailKeeper bietet es nur für einen eigenen
+Eintrag an, dessen Datentyp eine bekannte Verwendungsprüfung besitzt und dessen Schlüssel oder
+Bezeichnung nicht referenziert wird. Die Standardschlüssel der Artikelarten sind zusätzlich
+geschützt. Beim Löschen eines geeigneten Eintrags werden auch seine Stammdatenbeziehungen entfernt.
+Der Vorgang lässt sich nicht rückgängig machen.
+
+## Konservativer Änderungsablauf
+
+1. Vor umfangreichen Änderungen eine aktuelle Anwendungssicherung erstellen und prüfen.
+2. Bei vielen Klassifizierungsänderungen zusätzlich das aktuelle Stammdaten-JSON exportieren.
+3. Einen Schreibfehler bevorzugt korrigieren, statt einen nahezu gleichen Eintrag anzulegen.
+4. Einen veralteten Wert zuerst deaktivieren und betroffene Fahrzeug-, Artikel- und Messeansichten
+   prüfen.
+5. Nur einen bestätigt ungenutzten eigenen Eintrag löschen.
+6. Vor weiteren Massenänderungen ein betroffenes Fahrzeug oder einen Artikel testweise anlegen.
+
+Inventarnummernschemata und Lagerorte gehören nicht zum Stammdaten-JSON. Wenn diese Einstellungen
+zusammen mit dem Bestand wiederherstellbar sein müssen, ist eine Anwendungssicherung erforderlich.
+
+## Verwandte Seiten
+
+- [Einstellungen und Berechtigungen](/de/guide/settings/)
+- [Zubehörübersicht](/de/guide/accessories/)
+- [Fahrzeugbestand](/de/guide/vehicles/)
+- [Installation und Administration](./)
+
+## Dokumentierte RailKeeper-Version
+
+Dieser Bereich dokumentiert RailKeeper **v0.1.18** und wurde zuletzt am 16.08.2026 geprüft.

--- a/docs/site/de/guide/settings/index.md
+++ b/docs/site/de/guide/settings/index.md
@@ -40,13 +40,13 @@ entfernt niemals Berechtigungen.
 | --- | --- | --- |
 | **Allgemein** | Sprache, Startseite, Datums- und Zeitvorgaben, Druckvorgabe und Seitenleisten-Reihenfolge | [Persönliche Einstellungen](/de/guide/settings/personal-preferences) |
 | **Darstellung** | System-, Hell- oder Dunkelmodus sowie getrennte Farb- und Stilvarianten | [Darstellung](/de/guide/settings/appearance) |
-| **Allgemein > Inventarnummern** | Nummernschemata für Bestandskategorien | Stammdaten-Administration |
+| **Allgemein > Inventarnummern** | Nummernschemata für Bestandskategorien | [Stammdaten-Administration](/de/administration/master-data) |
 | **Allgemein > Artikelsuche** | Artikelsuche aktivieren und Quellgruppen wählen | [Artikelsuche](/de/guide/vehicles/search-and-spares) |
 | **Allgemein > Updates** | Versionsprüfung und Download des Windows-Pakets | Releases und Support |
 | **Allgemein > Speicher** | Speichernutzung und Optimierung | Systembetrieb |
-| **Daten** | Allgemeine und Zubehör-Stammdaten, Lebenszyklus und Transfer | Stammdaten-Administration |
+| **Daten** | Allgemeine und Zubehör-Stammdaten, Lebenszyklus und Transfer | [Stammdaten-Administration](/de/administration/master-data) |
 | **Digitalzentralen** | ECoS-, Z21-, Intellibox-3- und CS3-Konfiguration | Digitalzentralen-Administration |
-| **Import/Export** | Sicherung, Wiederherstellung und Stammdaten-Transfer innerhalb der Einstellungen | Sicherungs- und Stammdaten-Administration |
+| **Import/Export** | Sicherung, Wiederherstellung und Stammdaten-Transfer innerhalb der Einstellungen | Sicherungs- und [Stammdaten-Administration](/de/administration/master-data) |
 | **Authentifizierung** | Eigenes Passwort und Zwei-Faktor-Einrichtung; Admin-Werkzeuge für Benutzer, Sitzungen, Audit und SMTP | Benutzer, Sitzungen und Sicherheit |
 
 Der allgemeine [Arbeitsbereich Import und Export](/de/guide/import-export/) ist eine andere Seite. Er

--- a/docs/site/guide/settings/index.md
+++ b/docs/site/guide/settings/index.md
@@ -38,13 +38,13 @@ operations on the server. Reordering or hiding a navigation entry never grants o
 | --- | --- | --- |
 | **General** | Language, start page, date and time preferences, printing preference, and sidebar order | [Personal preferences](/guide/settings/personal-preferences) |
 | **Appearance** | System, light, or dark mode plus separate color and style variants | [Appearance](/guide/settings/appearance) |
-| **General > Inventory numbers** | Number schemes for inventory categories | Master data administration |
+| **General > Inventory numbers** | Number schemes for inventory categories | [Master-data administration](/administration/master-data) |
 | **General > Article search** | Enable article search and choose source groups | [Article search](/guide/vehicles/search-and-spares) |
 | **General > Updates** | Release checks and Windows package download | Releases and support |
 | **General > Storage** | Storage usage and optimization | System operations |
-| **Data** | General and accessory master data, lifecycle, and transfer | Master data administration |
+| **Data** | General and accessory master data, lifecycle, and transfer | [Master-data administration](/administration/master-data) |
 | **Command stations** | ECoS, Z21, Intellibox 3, and CS3 configuration | Digital-center administration |
-| **Import/Export** | Backup, restore, and master-data transfer inside Settings | Backup and master-data administration |
+| **Import/Export** | Backup, restore, and master-data transfer inside Settings | Backup and [master-data administration](/administration/master-data) |
 | **Authentication** | Own password and two-factor setup; Admin user, session, audit, and SMTP tools | Users, sessions, and security |
 
 The main [Import and export workspace](/guide/import-export/) is a different page. It exchanges


### PR DESCRIPTION
Adds the complete bilingual stable-v0.1.18 master-data administration section. Covers general and article master data, storage locations, inventory-number schemes, JSON reconciliation, role boundaries, navigation, and coverage. Verification: npm.cmd run check (19 tests, documentation validation, coverage validation, VitePress production build). Independent source review completed with no remaining findings.