### PR TITLE
release: RailKeeper v0.1.19.1

### DIFF
--- a/CHANGELOG.de.md
+++ b/CHANGELOG.de.md
@@ -6,6 +6,25 @@ Diese Datei dokumentiert alle wesentlichen Änderungen an RailKeeper.
 
 ## Unveröffentlicht
 
+## [0.1.19.1] - 2026-08-17
+
+### Geändert
+
+- Der dreistufige Dialog zur Fahrzeuganlage folgt jetzt dem abgestimmten kompakten Desktop- und
+  Mobil-Layout. Dazu gehören eine klarere Schrittnavigation, dezente Aktionen, responsive
+  Suchtreffer und eine fokussierte Prüfung übernommener Artikeldaten.
+- Sets erhalten eine dauerhaft gespeicherte, automatisch vergebene `RK-SET`-Inventarnummer und
+  erscheinen in Tabellen-, Karten- und Mobilansicht als übergeordnete Zeile mit sortierten Wagen.
+
+### Behoben
+
+- Die Setanlage bewahrt geprüfte Artikelfelder und Bilder, validiert jeden Wagen, trennt Entwürfe
+  anhand des exakten Benutzernamens und beachtet die konfigurierten Quellen der Artikelsuche.
+- Gruppierung, Sortierung, optionale Spalten, gefilterter Mitgliederzugriff, Duplizieren, Bearbeiten,
+  Löschen, Wiederherstellung und Bestandsbewertung bleiben auch bei Teil- und Altdaten konsistent.
+- Kompakte Aktionen, Vorschaubild-Platzhalter, Spaltenausrichtung, Suchfeldbreite, Hierarchielinien
+  und schmale Ansichten entsprechen jetzt dem abgestimmten Bestandslayout.
+
 ## [0.1.19] - 2026-08-16
 
 ### Hinzugefügt
@@ -255,6 +274,7 @@ Diese Datei dokumentiert alle wesentlichen Änderungen an RailKeeper.
 - Die Vorprüfung der Backup-Wiederherstellung bleibt konservativ, Authentifizierungsdaten bleiben
   aus Exporten ausgeschlossen.
 
+[0.1.19.1]: https://github.com/ichwars/RailKeeper/compare/v0.1.19...v0.1.19.1
 [0.1.19]: https://github.com/ichwars/RailKeeper/compare/v0.1.18...v0.1.19
 [0.1.18]: https://github.com/ichwars/RailKeeper/compare/v0.1.17.6...v0.1.18
 [0.1.17.6]: https://github.com/ichwars/RailKeeper/compare/v0.1.17.5...v0.1.17.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ All notable changes to RailKeeper are documented in this file.
 
 ## Unreleased
 
+## [0.1.19.1] - 2026-08-17
+
+### Changed
+
+- The three-step vehicle creation dialog now follows the agreed compact desktop and mobile layout,
+  including clearer step navigation, restrained actions, responsive article results, and a focused
+  review of imported data.
+- Sets use a durable, automatically assigned `RK-SET` inventory number and appear as canonical rows
+  with ordered member vehicles across table, card, and mobile inventory views.
+
+### Fixed
+
+- Set creation preserves reviewed article fields and images, validates every member, keeps drafts
+  isolated per exact username, and respects configured article-search sources.
+- Set grouping, sorting, optional columns, filtered member access, duplication, editing, deletion,
+  backup restore, and inventory valuation remain consistent across partial and legacy data paths.
+- Compact action placement, preview placeholders, column alignment, search sizing, hierarchy guides,
+  and narrow-screen behavior now match the approved inventory layout.
+
 ## [0.1.19] - 2026-08-16
 
 ### Added
@@ -241,6 +260,7 @@ All notable changes to RailKeeper are documented in this file.
 - Tightened API validation and protected master-data import invariants.
 - Kept backup restore preflight conservative and authentication data excluded from exports.
 
+[0.1.19.1]: https://github.com/ichwars/RailKeeper/compare/v0.1.19...v0.1.19.1
 [0.1.19]: https://github.com/ichwars/RailKeeper/compare/v0.1.18...v0.1.19
 [0.1.18]: https://github.com/ichwars/RailKeeper/compare/v0.1.17.6...v0.1.18
 [0.1.17.6]: https://github.com/ichwars/RailKeeper/compare/v0.1.17.5...v0.1.17.6

--- a/README.de.md
+++ b/README.de.md
@@ -149,7 +149,7 @@ SQLite-Datenbank, Uploads und lokale Dateien bleiben im Docker-Volume `railkeepe
 Um statt `latest` ein bestimmtes Release festzulegen, trage Folgendes in `.env` ein:
 
 ```env
-RAILKEEPER_IMAGE=ghcr.io/ichwars/railkeeper:v0.1.19
+RAILKEEPER_IMAGE=ghcr.io/ichwars/railkeeper:v0.1.19.1
 ```
 
 Wenn du bewusst den ausgecheckten Quellstand bauen möchtest, verwende:

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ The SQLite database, uploads and local files stay in the `railkeeper_data` Docke
 To pin a specific release instead of `latest`, set this in `.env`:
 
 ```env
-RAILKEEPER_IMAGE=ghcr.io/ichwars/railkeeper:v0.1.19
+RAILKEEPER_IMAGE=ghcr.io/ichwars/railkeeper:v0.1.19.1
 ```
 
 If you intentionally want to build the checked-out source tree, use:

--- a/backend/cmd/railkeeper/main.go
+++ b/backend/cmd/railkeeper/main.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	version               = "0.1.19"
+	version               = "0.1.19.1"
 	defaultUpdateCheckURL = "https://api.github.com/repos/ichwars/RailKeeper/releases/latest"
 )
 

--- a/docs/releases/v0.1.19.1.md
+++ b/docs/releases/v0.1.19.1.md
@@ -1,0 +1,36 @@
+# RailKeeper v0.1.19.1
+
+## Deutsch
+
+RailKeeper 0.1.19.1 schließt die Überarbeitung der Fahrzeuganlage und der Setdarstellung ab. Der
+dreistufige Dialog folgt nun durchgängig dem abgestimmten kompakten Layout und bleibt auch bei
+Suchtreffern, Datenübernahme und vollständigen Fahrzeugdetails auf kleinen Bildschirmen bedienbar.
+
+Sets besitzen eine eigene, dauerhaft gespeicherte `RK-SET`-Inventarnummer. Tabellen-, Karten- und
+Mobilansicht zeigen Sets als übergeordnete Bestandsobjekte mit sortierten Wagen, passenden
+Vorschaubildern, stabilen Spalten und vollständigen Setaktionen.
+
+Zusätzliche Korrekturen sichern Artikelfelder und Bildzuordnungen, benutzerbezogene Entwürfe,
+konfigurierte Suchquellen, Alt-Sicherungen und gefilterte Setansichten ab. Alle beim mehrstufigen
+Review gefundenen Randfälle wurden mit Regressionstests abgedeckt.
+
+Weitere Details stehen im
+[deutschen Änderungsprotokoll](https://github.com/ichwars/RailKeeper/blob/v0.1.19.1/CHANGELOG.de.md).
+
+## English
+
+RailKeeper 0.1.19.1 completes the vehicle-creation and set-inventory redesign. The three-step dialog
+now consistently follows the agreed compact layout and remains usable on small screens throughout
+search results, imported-data review, and complete vehicle details.
+
+Sets have their own durable `RK-SET` inventory number. Table, card, and mobile views present sets as
+canonical inventory objects with ordered member vehicles, appropriate previews, stable columns,
+and complete set actions.
+
+Additional fixes protect article fields and image assignments, user-scoped drafts, configured
+search sources, legacy backups, and filtered set views. Regression tests cover every edge case found
+during the multi-stage review.
+
+See the
+[English changelog](https://github.com/ichwars/RailKeeper/blob/v0.1.19.1/CHANGELOG.md)
+for details.

--- a/docs/site/administration/index.md
+++ b/docs/site/administration/index.md
@@ -3,7 +3,7 @@ title: Installation and Administration
 description: Install, configure, secure, and operate RailKeeper.
 audience: admin
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -13,7 +13,7 @@ This section covers Windows Standalone and Docker installation, runtime configur
 roles, SMTP, backups and restores, updates, TLS, uploads, OCR, printers, operational checks, and
 conservative troubleshooting.
 
-Administration guidance describes the stable v0.1.19 runtime and preserves RailKeeper's
+Administration guidance describes the stable v0.1.19.1 runtime and preserves RailKeeper's
 local-first, self-hosted security model.
 
 ## Administrative workflows

--- a/docs/site/administration/master-data-articles.md
+++ b/docs/site/administration/master-data-articles.md
@@ -3,7 +3,7 @@ title: Article master data and storage locations
 description: Configure accessory units, classifications, custom fields, and hierarchical storage locations.
 audience: admin
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -35,7 +35,7 @@ RailKeeper ships eight protected article-type keys:
 - Lighting
 - Other
 
-Their labels and active states can be maintained, but v0.1.19 does not allow creating or deleting
+Their labels and active states can be maintained, but v0.1.19.1 does not allow creating or deleting
 article-type keys. This protects the matching technical-data contracts. Deactivating a type removes
 it from new article selection without rewriting existing articles.
 
@@ -77,7 +77,7 @@ Names must be unique among siblings without regard to letter case. A location ca
 parent or be moved beneath one of its descendants. The parent picker excludes those invalid
 choices.
 
-There is no permanent-delete action in v0.1.19. Archive a location to retire it and reactivate it
+There is no permanent-delete action in v0.1.19.1. Archive a location to retire it and reactivate it
 when required. Stock and individual items can use a location only when that location and every
 ancestor are active. Archiving a parent therefore makes its entire branch unavailable for new
 stock operations without erasing stored location references.
@@ -112,4 +112,4 @@ stored configuration unchanged.
 
 ## Documented RailKeeper version
 
-This page documents stable RailKeeper **v0.1.19** and was last reviewed on 2026-08-16.
+This page documents stable RailKeeper **v0.1.19.1** and was last reviewed on 2026-08-16.

--- a/docs/site/administration/master-data-general.md
+++ b/docs/site/administration/master-data-general.md
@@ -3,14 +3,14 @@ title: General master data
 description: Maintain vehicle classifications, manufacturers, CV8 identities, and function symbols.
 audience: admin
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
 # General master data
 
 Open **Settings > Data > General** to maintain the shared selections used by vehicles, accessories,
-decoder data, and exhibitions. Stable v0.1.19 provides eight data types.
+decoder data, and exhibitions. Stable v0.1.19.1 provides eight data types.
 
 ## Data-type reference
 
@@ -107,4 +107,4 @@ authority instead of retrying the visible control.
 
 ## Documented RailKeeper version
 
-This page documents stable RailKeeper **v0.1.19** and was last reviewed on 2026-08-16.
+This page documents stable RailKeeper **v0.1.19.1** and was last reviewed on 2026-08-16.

--- a/docs/site/administration/master-data-inventory-numbers.md
+++ b/docs/site/administration/master-data-inventory-numbers.md
@@ -3,7 +3,7 @@ title: Inventory-number schemes
 description: Configure automatic vehicle and accessory article inventory numbers without collisions.
 audience: admin
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -13,7 +13,7 @@ Open **Settings > General > Inventory numbers** to control automatic identities 
 vehicle and accessory-article creation. A scheme contains a unique category, prefix, next number,
 padding width, active state, and preview.
 
-Stable v0.1.19 normally provides these active schemes:
+Stable v0.1.19.1 normally provides these active schemes:
 
 | Category | Default prefix | Default example | Used for |
 | --- | --- | --- | --- |
@@ -50,7 +50,7 @@ article numbers are checked in their respective tables, not as one shared global
 3. Check the preview and select **Create**.
 4. For an existing row, edit its values in place and select **Save**.
 
-There is no delete endpoint in v0.1.19. Deactivate an unused scheme instead. Editing or
+There is no delete endpoint in v0.1.19.1. Deactivate an unused scheme instead. Editing or
 deactivating a scheme never renumbers existing records.
 
 Only Admin and Editor may create or save schemes. Viewer and Planner can read the table. The stable
@@ -93,4 +93,4 @@ article creation safely skips those collisions.
 
 ## Documented RailKeeper version
 
-This page documents stable RailKeeper **v0.1.19** and was last reviewed on 2026-08-16.
+This page documents stable RailKeeper **v0.1.19.1** and was last reviewed on 2026-08-16.

--- a/docs/site/administration/master-data-transfer.md
+++ b/docs/site/administration/master-data-transfer.md
@@ -3,7 +3,7 @@ title: Master-data transfer
 description: Export and reconcile RailKeeper master data with the versioned JSON document.
 audience: admin
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -16,7 +16,7 @@ Import/Export workspace.
 
 ## What the document contains
 
-The downloaded file is named `railkeeper-stammdaten-YYYYMMDD-HHMMSS.json`. Stable v0.1.19 exports
+The downloaded file is named `railkeeper-stammdaten-YYYYMMDD-HHMMSS.json`. Stable v0.1.19.1 exports
 format `railkeeper-master-data`, version 2, with:
 
 - the creation timestamp;
@@ -99,4 +99,4 @@ need recovery, use the validated application backup instead.
 
 ## Documented RailKeeper version
 
-This page documents stable RailKeeper **v0.1.19** and was last reviewed on 2026-08-16.
+This page documents stable RailKeeper **v0.1.19.1** and was last reviewed on 2026-08-16.

--- a/docs/site/administration/master-data.md
+++ b/docs/site/administration/master-data.md
@@ -3,7 +3,7 @@ title: Master-data administration
 description: Govern RailKeeper master data, inventory-number schemes, locations, and transfers safely.
 audience: admin
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -14,7 +14,7 @@ or numbering rules. Most of it is managed under **Settings > Data**. Inventory-n
 under **Settings > General**, and the master-data JSON transfer is under
 **Settings > Import/Export**.
 
-This section documents stable RailKeeper v0.1.19. It separates four administrative workflows:
+This section documents stable RailKeeper v0.1.19.1. It separates four administrative workflows:
 
 - [General master data](./master-data-general) for vehicles, manufacturers, CV8 identities, and
   function symbols.
@@ -37,7 +37,7 @@ This section documents stable RailKeeper v0.1.19. It separates four administrati
 
 Viewer and Planner inherit read access. Article management explicitly displays a read-only state.
 Some controls in the general master-data and inventory-number panels can still remain visible to
-those roles in v0.1.19, but the server rejects every write. Visible controls are never an access
+those roles in v0.1.19.1, but the server rejects every write. Visible controls are never an access
 grant.
 
 A pure Messe account cannot open Settings. It can read the active function-symbol subset only
@@ -82,4 +82,4 @@ application backup when those settings must be recoverable together with the inv
 
 ## Documented RailKeeper version
 
-This section documents stable RailKeeper **v0.1.19** and was last reviewed on 2026-08-16.
+This section documents stable RailKeeper **v0.1.19.1** and was last reviewed on 2026-08-16.

--- a/docs/site/de/administration/index.md
+++ b/docs/site/de/administration/index.md
@@ -3,7 +3,7 @@ title: Installation und Administration
 description: RailKeeper installieren, konfigurieren, absichern und betreiben.
 audience: admin
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -13,7 +13,7 @@ Dieser Bereich behandelt Windows Standalone, Docker, Laufzeitkonfiguration, Benu
 SMTP, Sicherung und Wiederherstellung, Updates, TLS, Uploads, OCR, Drucker,
 Betriebsprüfungen und konservative Fehlerbehebung.
 
-Die Administrationsanleitungen beschreiben die stabile Laufzeit v0.1.19 und erhalten das lokale,
+Die Administrationsanleitungen beschreiben die stabile Laufzeit v0.1.19.1 und erhalten das lokale,
 selbst gehostete Sicherheitsmodell von RailKeeper.
 
 ## Administrative Abläufe

--- a/docs/site/de/administration/master-data-articles.md
+++ b/docs/site/de/administration/master-data-articles.md
@@ -3,7 +3,7 @@ title: Artikelstammdaten und Lagerorte
 description: Bestandseinheiten, Artikelklassifizierung, eigene Felder und hierarchische Lagerorte konfigurieren.
 audience: admin
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -37,7 +37,7 @@ RailKeeper liefert acht geschützte Artikelart-Schlüssel aus:
 - Beleuchtung
 - Sonstiges
 
-Bezeichnungen und Aktivstatus lassen sich verwalten, aber v0.1.19 erlaubt weder neue noch gelöschte
+Bezeichnungen und Aktivstatus lassen sich verwalten, aber v0.1.19.1 erlaubt weder neue noch gelöschte
 Artikelart-Schlüssel. Dadurch bleiben die zugehörigen Verträge für Fachangaben geschützt. Eine
 Deaktivierung entfernt die Art aus neuen Artikelauswahlen, ohne vorhandene Artikel umzuschreiben.
 
@@ -80,7 +80,7 @@ Namen müssen innerhalb derselben Ebene ohne Beachtung der Groß- und Kleinschre
 Ein Lagerort kann weder sein eigener übergeordneter Ort sein noch unter einen seiner Nachfolger
 verschoben werden. Die Elternauswahl blendet diese ungültigen Möglichkeiten aus.
 
-In v0.1.19 gibt es keine endgültige Löschaktion. Einen nicht mehr verwendeten Ort archivieren und
+In v0.1.19.1 gibt es keine endgültige Löschaktion. Einen nicht mehr verwendeten Ort archivieren und
 bei Bedarf reaktivieren. Bestand und Einzelstücke können einen Ort nur verwenden, wenn dieser Ort
 und alle übergeordneten Orte aktiv sind. Das Archivieren eines Elternorts sperrt daher seinen
 gesamten Zweig für neue Bestandsvorgänge, ohne gespeicherte Ortsverweise zu löschen.
@@ -115,4 +115,4 @@ abgewiesener Vorgang lässt die gespeicherte Konfiguration unverändert.
 
 ## Dokumentierte RailKeeper-Version
 
-Diese Seite dokumentiert RailKeeper **v0.1.19** und wurde zuletzt am 16.08.2026 geprüft.
+Diese Seite dokumentiert RailKeeper **v0.1.19.1** und wurde zuletzt am 16.08.2026 geprüft.

--- a/docs/site/de/administration/master-data-general.md
+++ b/docs/site/de/administration/master-data-general.md
@@ -3,14 +3,14 @@ title: Allgemeine Stammdaten
 description: Fahrzeugklassifizierungen, Hersteller, CV8-Kennungen und Funktionssymbole verwalten.
 audience: admin
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
 # Allgemeine Stammdaten
 
 Unter **Einstellungen > Daten > Allgemein** werden die gemeinsamen Auswahlen für Fahrzeuge,
-Zubehör, Decoderdaten und Messen verwaltet. RailKeeper v0.1.19 stellt acht Datentypen bereit.
+Zubehör, Decoderdaten und Messen verwaltet. RailKeeper v0.1.19.1 stellt acht Datentypen bereit.
 
 ## Datentypen
 
@@ -111,4 +111,4 @@ Planner abgewiesen, ist ein Admin- oder Editor-Konto erforderlich.
 
 ## Dokumentierte RailKeeper-Version
 
-Diese Seite dokumentiert RailKeeper **v0.1.19** und wurde zuletzt am 16.08.2026 geprüft.
+Diese Seite dokumentiert RailKeeper **v0.1.19.1** und wurde zuletzt am 16.08.2026 geprüft.

--- a/docs/site/de/administration/master-data-inventory-numbers.md
+++ b/docs/site/de/administration/master-data-inventory-numbers.md
@@ -3,7 +3,7 @@ title: Inventarnummernschemata
 description: Automatische Inventarnummern für Fahrzeuge und Zubehörartikel kollisionsfrei konfigurieren.
 audience: admin
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -13,7 +13,7 @@ Unter **Einstellungen > Allgemein > Inventarnummern** werden die automatischen K
 Fahrzeuge und Zubehörartikel gesteuert. Ein Schema enthält eindeutige Kategorie, Präfix, nächste
 Nummer, Stellenzahl, Aktivstatus und Vorschau.
 
-RailKeeper v0.1.19 stellt normalerweise diese aktiven Schemata bereit:
+RailKeeper v0.1.19.1 stellt normalerweise diese aktiven Schemata bereit:
 
 | Kategorie | Standardpräfix | Standardbeispiel | Verwendung |
 | --- | --- | --- | --- |
@@ -50,7 +50,7 @@ nicht in einem gemeinsamen globalen Namensraum geprüft.
 3. Vorschau prüfen und **Anlegen** wählen.
 4. Bei einem vorhandenen Schema die Werte direkt ändern und **Speichern** wählen.
 
-In v0.1.19 gibt es keinen Löschendpunkt. Ein ungenutztes Schema stattdessen deaktivieren. Das
+In v0.1.19.1 gibt es keinen Löschendpunkt. Ein ungenutztes Schema stattdessen deaktivieren. Das
 Bearbeiten oder Deaktivieren nummeriert vorhandene Datensätze niemals um.
 
 Nur Admin und Editor dürfen Schemata anlegen oder speichern. Viewer und Planner können die Tabelle
@@ -96,4 +96,4 @@ Kollisionen sicher.
 
 ## Dokumentierte RailKeeper-Version
 
-Diese Seite dokumentiert RailKeeper **v0.1.19** und wurde zuletzt am 16.08.2026 geprüft.
+Diese Seite dokumentiert RailKeeper **v0.1.19.1** und wurde zuletzt am 16.08.2026 geprüft.

--- a/docs/site/de/administration/master-data-transfer.md
+++ b/docs/site/de/administration/master-data-transfer.md
@@ -3,7 +3,7 @@ title: Stammdatentransfer
 description: RailKeeper-Stammdaten mit dem versionierten JSON-Dokument exportieren und abgleichen.
 audience: admin
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -16,7 +16,7 @@ noch der Arbeitsbereich für den Fahrzeugdatei-Import und -Export.
 
 ## Inhalt des Dokuments
 
-Die heruntergeladene Datei heißt `railkeeper-stammdaten-YYYYMMDD-HHMMSS.json`. RailKeeper v0.1.19
+Die heruntergeladene Datei heißt `railkeeper-stammdaten-YYYYMMDD-HHMMSS.json`. RailKeeper v0.1.19.1
 exportiert das Format `railkeeper-master-data` in Version 2 mit:
 
 - Erstellungszeitpunkt;
@@ -103,4 +103,4 @@ verwenden.
 
 ## Dokumentierte RailKeeper-Version
 
-Diese Seite dokumentiert RailKeeper **v0.1.19** und wurde zuletzt am 16.08.2026 geprüft.
+Diese Seite dokumentiert RailKeeper **v0.1.19.1** und wurde zuletzt am 16.08.2026 geprüft.

--- a/docs/site/de/administration/master-data.md
+++ b/docs/site/de/administration/master-data.md
@@ -3,7 +3,7 @@ title: Stammdaten-Administration
 description: Stammdaten, Inventarnummern, Lagerorte und Transfer in RailKeeper sicher verwalten.
 audience: admin
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -15,7 +15,7 @@ Klassifizierungen, Symbole oder Nummerierungsregeln benötigen. Der größte Tei
 **Einstellungen > Allgemein**, der JSON-Stammdatentransfer unter
 **Einstellungen > Import/Export**.
 
-Dieser Bereich dokumentiert RailKeeper v0.1.19 und trennt vier administrative Abläufe:
+Dieser Bereich dokumentiert RailKeeper v0.1.19.1 und trennt vier administrative Abläufe:
 
 - [Allgemeine Stammdaten](./master-data-general) für Fahrzeuge, Hersteller, CV8-Kennungen und
   Funktionssymbole.
@@ -37,7 +37,7 @@ Dieser Bereich dokumentiert RailKeeper v0.1.19 und trennt vier administrative Ab
 
 Viewer und Planner erben den Lesezugriff. Die Artikelverwaltung zeigt ausdrücklich einen
 Nur-Lese-Zustand. Einige Bedienelemente für allgemeine Stammdaten und Inventarnummern können für
-diese Rollen in v0.1.19 trotzdem sichtbar bleiben, der Server weist aber jeden Schreibvorgang ab.
+diese Rollen in v0.1.19.1 trotzdem sichtbar bleiben, der Server weist aber jeden Schreibvorgang ab.
 Ein sichtbares Bedienelement erteilt niemals eine Berechtigung.
 
 Ein reines Messe-Konto kann die Einstellungen nicht öffnen. Es kann nur die aktiven
@@ -85,4 +85,4 @@ zusammen mit dem Bestand wiederherstellbar sein müssen, ist eine Anwendungssich
 
 ## Dokumentierte RailKeeper-Version
 
-Dieser Bereich dokumentiert RailKeeper **v0.1.19** und wurde zuletzt am 16.08.2026 geprüft.
+Dieser Bereich dokumentiert RailKeeper **v0.1.19.1** und wurde zuletzt am 16.08.2026 geprüft.

--- a/docs/site/de/guide/accessories/allocations-history.md
+++ b/docs/site/de/guide/accessories/allocations-history.md
@@ -3,7 +3,7 @@ title: Reservierungen, Einbauten und Verwendung
 description: Zubehör reservieren, Einbauten erfassen und die Verwendungshistorie verstehen.
 audience: user
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -202,4 +202,4 @@ verwendet kein zweiter Befehl einen alten Verfügbarkeits- oder Lebenszyklusstan
 
 ## Dokumentierte RailKeeper-Version
 
-Diese Seite dokumentiert RailKeeper **v0.1.19** und wurde zuletzt am 16.08.2026 geprüft.
+Diese Seite dokumentiert RailKeeper **v0.1.19.1** und wurde zuletzt am 16.08.2026 geprüft.

--- a/docs/site/de/guide/accessories/article-records.md
+++ b/docs/site/de/guide/accessories/article-records.md
@@ -3,7 +3,7 @@ title: Artikelstammdaten und Fachangaben
 description: Zubehörartikel anlegen, ihre Identität pflegen und technische Angaben prüfen.
 audience: user
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -12,7 +12,7 @@ lastReviewed: 2026-08-16
 Ein Zubehörartikel ist der gemeinsame Produktdatensatz für Bestand, Einkäufe, Dokumente,
 Reservierungen und Einbauten. Legen Sie ihn einmal für einen Hersteller- und Katalogartikel an und
 erfassen Sie anschließend Mengen oder Einzelstücke dazu. Dieses Kapitel beschreibt die
-Artikelidentität und die artabhängigen Fachangaben in RailKeeper v0.1.19.
+Artikelidentität und die artabhängigen Fachangaben in RailKeeper v0.1.19.1.
 
 ## Zugriffsrechte und Speichern
 
@@ -141,7 +141,7 @@ Der Trefferdialog kann Hersteller, Artikelnummer, Name, EAN, Maßstab, Beschreib
 Spurweite übernehmen. Hersteller oder Spurweite sind nur auswählbar, wenn sie einem aktiven
 bekannten Stammdatenwert entsprechen. Eine gewählte Spurweite wird den vorhandenen hinzugefügt.
 Ungültige allgemeine Werte und Produkt-URLs außerhalb von HTTP oder HTTPS werden ignoriert. In
-v0.1.19 bietet die Trefferauswahl technische Ergebnisfelder nur für **Gleis** an. Andere
+v0.1.19.1 bietet die Trefferauswahl technische Ergebnisfelder nur für **Gleis** an. Andere
 Artikelarten können die allgemeinen Treffergruppen, aber keine Fachangaben übernehmen.
 
 Nur Felder mit aktuell leerem Formularwert sind in der Prüfung vorausgewählt. Vorhandene Werte sind
@@ -231,4 +231,4 @@ rückgängig machen. Prüfen Sie vorher eine aktuelle Sicherung.
 
 ## Dokumentierte RailKeeper-Version
 
-Diese Seite dokumentiert RailKeeper **v0.1.19** und wurde zuletzt am 16.08.2026 geprüft.
+Diese Seite dokumentiert RailKeeper **v0.1.19.1** und wurde zuletzt am 16.08.2026 geprüft.

--- a/docs/site/de/guide/accessories/index.md
+++ b/docs/site/de/guide/accessories/index.md
@@ -3,7 +3,7 @@ title: Zubehörübersicht
 description: Zubehörartikel finden, filtern, prüfen und sicher verwalten.
 audience: user
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -12,7 +12,7 @@ lastReviewed: 2026-08-16
 **Zubehör** ist RailKeepers Katalog- und Bestandsbereich für Gleise, Signale, Decoder, elektrische
 Bauteile, Landschaftsbau, Beleuchtung und weitere Modellbahnartikel. Er verbindet Produktidentität,
 gelagerte und gebundene Mengen, Bilder, Lagerorte und Aktionen im Artikellebenszyklus. Dieses
-Kapitel beschreibt den stabilen RailKeeper-Stand v0.1.19.
+Kapitel beschreibt den stabilen RailKeeper-Stand v0.1.19.1.
 
 Ein Artikel ist der gemeinsame Produktdatensatz. Sein Bestand kann aus austauschbaren Mengen,
 einzeln geführten Stücken oder beidem bestehen. Reservierungen und Einbauten binden einen Teil
@@ -145,7 +145,7 @@ Serversortierung, bieten aber keine eigenen Sortieraktionen.
 
 Kontrollkästchen in der Tabelle wählen eine Zeile oder alle aktuell sichtbaren Zeilen aus. Eine
 Auswahl verschwindet, wenn ein neues Such- oder Filterergebnis den Artikel nicht mehr enthält. Der
-stabile Stand v0.1.19 bietet keine Sammelaktion für diese Auswahl. Sie ist nur visueller Zustand
+stabile Stand v0.1.19.1 bietet keine Sammelaktion für diese Auswahl. Sie ist nur visueller Zustand
 und keine vorgemerkte Archivierung, Auswertung oder Bestandsbuchung.
 
 Öffne über Artikelname, Bild oder **Artikel ansehen** den schreibgeschützten Artikeldialog. Abhängig
@@ -207,5 +207,5 @@ sofortige Bestands- oder Lebenszyklusaktion startest.
 
 ## Dokumentierter RailKeeper-Stand
 
-Diese Seite dokumentiert den stabilen RailKeeper-Stand **v0.1.19** und wurde zuletzt am
+Diese Seite dokumentiert den stabilen RailKeeper-Stand **v0.1.19.1** und wurde zuletzt am
 2026-08-16 geprüft.

--- a/docs/site/de/guide/accessories/stock-purchases-documents.md
+++ b/docs/site/de/guide/accessories/stock-purchases-documents.md
@@ -3,7 +3,7 @@ title: Bestand, Käufe und Dokumente
 description: Zubehörmengen, Einzelstücke, Käufe, Bilder und Dokumente verwalten.
 audience: user
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -12,7 +12,7 @@ lastReviewed: 2026-08-16
 RailKeeper kann austauschbare Zubehöreinheiten als Menge zählen, physische Stücke einzeln verwalten
 oder Einheiten bei Bedarf aus dem Mengenbestand in die Einzelverwaltung überführen. Käufe und
 Dokumente gehören zum selben Artikel, besitzen aber eigene Sofortaktionen zum Speichern. Dieses
-Kapitel beschreibt das stabile Verhalten von RailKeeper v0.1.19.
+Kapitel beschreibt das stabile Verhalten von RailKeeper v0.1.19.1.
 
 Administratoren und Bearbeiter können diese Ressourcen verwalten. Betrachter und Planer können sie
 ansehen. Das Reservierungsrecht eines Planers umfasst jedoch keine Änderungen an Bestand, Käufen,
@@ -137,7 +137,7 @@ Lebenszyklus, Lagerort und Verlauf konsistent bleiben.
 
 ## Käufe erfassen
 
-Die Kaufliste ist eine stabile, absteigend chronologische Historie. RailKeeper v0.1.19 bietet das
+Die Kaufliste ist eine stabile, absteigend chronologische Historie. RailKeeper v0.1.19.1 bietet das
 Hinzufügen, aber keine Aktion zum Bearbeiten oder Löschen eines Kaufs.
 
 | Kauffeld | Stabile Regel |
@@ -249,4 +249,4 @@ bereits aus der Liste entfernten Eintrag folgen. Laden Sie neu, bevor Sie erneut
 
 ## Dokumentierte RailKeeper-Version
 
-Diese Seite dokumentiert RailKeeper **v0.1.19** und wurde zuletzt am 16.08.2026 geprüft.
+Diese Seite dokumentiert RailKeeper **v0.1.19.1** und wurde zuletzt am 16.08.2026 geprüft.

--- a/docs/site/de/guide/exhibition/entries-and-printing.md
+++ b/docs/site/de/guide/exhibition/entries-and-printing.md
@@ -3,7 +3,7 @@ title: Einträge und Drucken
 description: Messeloks erfassen, Adresskonflikte lösen und die Betriebsliste drucken.
 audience: user
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -40,7 +40,7 @@ Wähle eine offene Liste und verwende das Bedienelement zum Anlegen im Eintragsb
 | Lok Bezeichnung | Pflichtfeld. Der Server entfernt führende und nachgestellte Leerzeichen. |
 
 Mit **Bearbeiten** in einer vorhandenen Zeile öffnet sich **Eintrag bearbeiten** mit den aktuellen
-Werten. v0.1.19 bietet in diesem Dialog keine Fahrzeugauswahl und kein sichtbares Feld für eine
+Werten. v0.1.19.1 bietet in diesem Dialog keine Fahrzeugauswahl und kein sichtbares Feld für eine
 Fahrzeugverknüpfung. Der Eintrag bleibt ein Messedatensatz, auch wenn seine Beschreibung einem
 Fahrzeug im allgemeinen Bestand ähnelt.
 
@@ -85,7 +85,7 @@ zuerst mit Admin oder einem Messekonto mit bestandsberechtigter Zusatzrolle.
 Tabelle und Report verbinden DCC und SX unter **Adresse**, zeigen Analog als Ja oder Nein und führen
 Decoder-Typ und Schnittstelle getrennt auf. Leere Werte erscheinen als Strich.
 
-**Baureihe** wird mit dem Eintrag gespeichert, erscheint in v0.1.19 jedoch weder in Tabelle und
+**Baureihe** wird mit dem Eintrag gespeichert, erscheint in v0.1.19.1 jedoch weder in Tabelle und
 Listenansicht noch im gedruckten Report. Öffne **Eintrag bearbeiten**, um den Wert zu prüfen.
 
 ### Nr. / Beschriftung / Merkmale
@@ -160,7 +160,7 @@ Bezeichnung liefert. Prüfe den Namen nach der Symbolauswahl. Beim **Speichern**
 belegte Funktionen als strukturierte Daten ab. Tabelle, Detailansicht und Report zeigen nur diese
 Funktionen.
 
-v0.1.19 kann außerdem frühere Klartextwerte lesen, die durch Kommas, Semikolons oder Zeilen
+v0.1.19.1 kann außerdem frühere Klartextwerte lesen, die durch Kommas, Semikolons oder Zeilen
 getrennt sind und jeweils mit einer Taste wie `F1 Sound` beginnen. Das Öffnen und Speichern eines
 solchen Eintrags schreibt die aktuell konfigurierte strukturierte Darstellung.
 
@@ -233,5 +233,5 @@ Betriebssystem. Eine leere Liste erzeugt eine Reportzeile mit **Keine Einträge.
 
 ## Dokumentierte RailKeeper-Version
 
-Diese Seite beschreibt RailKeeper v0.1.19. Der Entwicklungsstand auf `main` kann abweichen und
+Diese Seite beschreibt RailKeeper v0.1.19.1. Der Entwicklungsstand auf `main` kann abweichen und
 gehört nicht zu diesem Benutzerablauf.

--- a/docs/site/de/guide/exhibition/index.md
+++ b/docs/site/de/guide/exhibition/index.md
@@ -3,7 +3,7 @@ title: Messearbeitsbereich
 description: Messelisten sicher vorbereiten, pflegen, prüfen und drucken.
 audience: user
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -14,7 +14,7 @@ in einer Betriebsansicht. Jede Liste besitzt ein Datum, den Zustand offen oder g
 Lokomotiveinträge. Das Betriebspersonal kann eine offene Liste pflegen, ohne den allgemeinen
 Fahrzeugbestand zu öffnen.
 
-Dieses Kapitel dokumentiert RailKeeper v0.1.19. Benutzer- und Stammdatenverwaltung,
+Dieses Kapitel dokumentiert RailKeeper v0.1.19.1. Benutzer- und Stammdatenverwaltung,
 Backup-Bedienung sowie der Anlagen-Arbeitsbereich gehören nicht zu diesem Kapitel.
 
 ## Zugriffsrechte und Trennung
@@ -131,5 +131,5 @@ versehentlich doppelt ausgeführt.
 
 ## Dokumentierte RailKeeper-Version
 
-Diese Seite beschreibt RailKeeper v0.1.19. Der Entwicklungsstand auf `main` kann abweichen und
+Diese Seite beschreibt RailKeeper v0.1.19.1. Der Entwicklungsstand auf `main` kann abweichen und
 gehört nicht zu diesem Benutzerablauf.

--- a/docs/site/de/guide/exhibition/lists-and-locking.md
+++ b/docs/site/de/guide/exhibition/lists-and-locking.md
@@ -3,7 +3,7 @@ title: Listen und Sperren
 description: Messelisten anlegen, sperren, entsperren und sicher löschen.
 audience: user
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -42,7 +42,7 @@ den Dialog und lädt die Listentabelle neu. Das Anlegen ist ein sofortiger Serve
 bis zum Erfolg sind die Dialogwerte nur lokaler Formularzustand.
 
 Ist eines der Pflichtfelder leer, verhindert der Browser die normale Übermittlung. Der Server weist
-auch Werte zurück, die nach dem Entfernen äußerer Leerzeichen leer sind. In v0.1.19 prüft der
+auch Werte zurück, die nach dem Entfernen äußerer Leerzeichen leer sind. In v0.1.19.1 prüft der
 Server beim Datum, dass der Wert nicht leer ist; das Datumsfeld liefert den normalen Kalenderwert.
 
 ## Listen auswählen, sortieren und prüfen
@@ -132,5 +132,5 @@ nicht erklärt.
 
 ## Dokumentierte RailKeeper-Version
 
-Diese Seite beschreibt RailKeeper v0.1.19. Der Entwicklungsstand auf `main` kann abweichen und
+Diese Seite beschreibt RailKeeper v0.1.19.1. Der Entwicklungsstand auf `main` kann abweichen und
 gehört nicht zu diesem Benutzerablauf.

--- a/docs/site/de/guide/getting-started/index.md
+++ b/docs/site/de/guide/getting-started/index.md
@@ -3,7 +3,7 @@ title: Ersteinrichtung und Anmeldung
 description: Ersten Administrator anlegen, sicher anmelden und den Zugang zu RailKeeper wiederherstellen.
 audience: user
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -11,7 +11,7 @@ lastReviewed: 2026-08-16
 
 Dieses Kapitel erklärt das erste Administratorkonto, die normale Anmeldung und Anmeldung mit
 Zwei-Faktor-Code, die Abmeldung sowie die Passwort-Wiederherstellung. Es beschreibt den stabilen
-RailKeeper-Stand v0.1.19.
+RailKeeper-Stand v0.1.19.1.
 
 ## Voraussetzungen
 
@@ -120,5 +120,5 @@ Reset-Bestätigungen auf zehn innerhalb von zehn Minuten.
 
 ## Dokumentierter RailKeeper-Stand
 
-Diese Seite dokumentiert den stabilen RailKeeper-Stand **v0.1.19** und wurde zuletzt am
+Diese Seite dokumentiert den stabilen RailKeeper-Stand **v0.1.19.1** und wurde zuletzt am
 2026-08-16 mit der Anwendung abgeglichen.

--- a/docs/site/de/guide/import-export/ecos-sync.md
+++ b/docs/site/de/guide/import-export/ecos-sync.md
@@ -3,7 +3,7 @@ title: ECoS-Lokabgleich
 description: Ausgewählte ESU-ECoS-Lokdaten lesen, prüfen, importieren und ausdrücklich schreiben.
 audience: user
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -19,7 +19,7 @@ Port sind im Import-Arbeitsbereich schreibgeschützt.
 
 ## Unterstützte und nicht unterstützte Digitalzentralen
 
-| Aktiver Anbieter | Verhalten unter Import/Export in v0.1.19 |
+| Aktiver Anbieter | Verhalten unter Import/Export in v0.1.19.1 |
 | --- | --- |
 | ESU ECoS | Leseablauf, Fahrzeugübergabe, CV- und statische Funktionsvorschläge sowie geprüfter Schreib-Sync sind verfügbar. |
 | Z21, Intellibox 3 oder Märklin CS3 | RailKeeper zeigt, dass der Importpfad vorbereitet, aber noch nicht umgesetzt ist. |
@@ -124,7 +124,7 @@ werden nicht in die Digitalzentrale geschrieben.
 | Symptom | Prüfen |
 | --- | --- |
 | ECoS-Arbeitsbereich fehlt oder ist deaktiviert | Prüfen, ob ein Admin ECoS aktiviert und unter Digitalzentralen einen nicht leeren Host gespeichert hat. |
-| Ein anderer Anbieter ist aktiv | v0.1.19 setzt diesen Importpfad nur für ECoS um. |
+| Ein anderer Anbieter ist aktiv | v0.1.19.1 setzt diesen Importpfad nur für ECoS um. |
 | Datenabruf scheitert | Netzwerkerreichbarkeit, gespeicherten Host und Port, ECoS-Verfügbarkeit und Admin-Rolle prüfen. |
 | Ein falsches Fahrzeug wird vorgeschlagen | Nicht aktualisieren oder synchronisieren. Zuerst externe Zuordnung oder Decoder-/Namensdaten im Fahrzeugablauf korrigieren. |
 | Eine CV oder Funktion fehlt | Das ECoS-Lokobjekt hat sie nicht bereitgestellt oder RailKeeper hat sie nicht als statischen unterstützten Wert erkannt. Fehlende CVs blockieren das Speichern nicht. |
@@ -133,4 +133,4 @@ werden nicht in die Digitalzentrale geschrieben.
 
 ## Dokumentierte RailKeeper-Version
 
-Diese Seite dokumentiert RailKeeper **v0.1.19** und wurde zuletzt am 16.08.2026 geprüft.
+Diese Seite dokumentiert RailKeeper **v0.1.19.1** und wurde zuletzt am 16.08.2026 geprüft.

--- a/docs/site/de/guide/import-export/exports.md
+++ b/docs/site/de/guide/import-export/exports.md
@@ -3,7 +3,7 @@ title: Bestand exportieren
 description: CSV, RailKeeper-JSON und eine druckbare Fahrzeug-Bestandsausgabe erstellen.
 audience: user
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -49,7 +49,7 @@ Das `vehicles`-Array enthält die Fahrzeugobjekte, welche an diese Seite geliefe
 eignet sich JSON zur Prüfung und für einen verlustärmeren Datenaustausch, ist aber keine
 Anwendungssicherung und kein vollständiges Wiederherstellungsformat.
 
-Der stabile JSON-Import von v0.1.19 liest pro Objekt nur 14 Felder. Er stellt nicht alle im
+Der stabile JSON-Import von v0.1.19.1 liest pro Objekt nur 14 Felder. Er stellt nicht alle im
 exportierten Objekt vorhandenen Eigenschaften, verschachtelten Datensätze oder gespeicherten
 Dateibytes wieder her. Vor einem Rundlauf die genaue
 [JSON-Teilmenge](/de/guide/import-export/file-import#teilmenge-beim-json-import) prüfen.
@@ -85,4 +85,4 @@ enthalten sein.
 
 ## Dokumentierte RailKeeper-Version
 
-Diese Seite dokumentiert RailKeeper **v0.1.19** und wurde zuletzt am 16.08.2026 geprüft.
+Diese Seite dokumentiert RailKeeper **v0.1.19.1** und wurde zuletzt am 16.08.2026 geprüft.

--- a/docs/site/de/guide/import-export/file-import.md
+++ b/docs/site/de/guide/import-export/file-import.md
@@ -3,7 +3,7 @@ title: Fahrzeugdateien importieren
 description: Fahrzeugzeilen aus CSV, TSV, XML oder JSON zuordnen, prüfen und speichern.
 audience: user
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -143,4 +143,4 @@ Wartungen, Ersatzteile oder Decoder-Dateien. Ergänze diese über die jeweiligen
 
 ## Dokumentierte RailKeeper-Version
 
-Diese Seite dokumentiert RailKeeper **v0.1.19** und wurde zuletzt am 16.08.2026 geprüft.
+Diese Seite dokumentiert RailKeeper **v0.1.19.1** und wurde zuletzt am 16.08.2026 geprüft.

--- a/docs/site/de/guide/import-export/index.md
+++ b/docs/site/de/guide/import-export/index.md
@@ -3,7 +3,7 @@ title: Import und Export
 description: Fahrzeugbestand sicher austauschen und den getrennten ECoS-Ablauf verstehen.
 audience: user
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -15,7 +15,7 @@ Exporte erstellen eine CSV-Datei, eine RailKeeper-JSON-Datei oder eine Druckansi
 getrennt kontrollierter ECoS-Ablauf kann Lokdaten lesen und jede Lok einzeln an den Fahrzeugeditor
 übergeben.
 
-Dieses Kapitel dokumentiert RailKeeper v0.1.19. Es behandelt ausschließlich den
+Dieses Kapitel dokumentiert RailKeeper v0.1.19.1. Es behandelt ausschließlich den
 Fahrzeugdatenaustausch. Stammdaten-Transfer, Digitalzentralen-Konfiguration sowie
 Anwendungssicherung und Wiederherstellung bleiben getrennte Administrationsaufgaben.
 
@@ -85,4 +85,4 @@ Editor- oder Admin-Konto.
 
 ## Dokumentierte RailKeeper-Version
 
-Dieses Kapitel dokumentiert RailKeeper **v0.1.19** und wurde zuletzt am 16.08.2026 geprüft.
+Dieses Kapitel dokumentiert RailKeeper **v0.1.19.1** und wurde zuletzt am 16.08.2026 geprüft.

--- a/docs/site/de/guide/index.md
+++ b/docs/site/de/guide/index.md
@@ -3,7 +3,7 @@ title: Benutzerhandbuch
 description: Alle stabilen Arbeitsabläufe in RailKeeper kennenlernen.
 audience: user
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -13,7 +13,7 @@ Dieses Handbuch erklärt den vollständigen veröffentlichten RailKeeper-Arbeits
 Vereine und kleine Werkstätten. Es umfasst Ersteinrichtung, Navigation, Fahrzeuge, Zubehör,
 Decoderdaten, Wartung, Dokumente, Berichte, Ausstellungen sowie kontrollierten Import und Export.
 
-Die Inhalte dieses Bereichs beschreiben RailKeeper v0.1.19. Der Anlagen-Arbeitsbereich befindet
+Die Inhalte dieses Bereichs beschreiben RailKeeper v0.1.19.1. Der Anlagen-Arbeitsbereich befindet
 sich noch in Entwicklung und wird deshalb nicht als stabile Benutzerfunktion dargestellt.
 
 ## Hier beginnen

--- a/docs/site/de/guide/overview/index.md
+++ b/docs/site/de/guide/overview/index.md
@@ -3,7 +3,7 @@ title: Übersicht, Kennzahlen und Datenqualität
 description: RailKeeper-Dashboard auswerten, Datenlücken bearbeiten und Kacheln anordnen.
 audience: user
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -12,7 +12,7 @@ lastReviewed: 2026-08-16
 Die **Übersicht** ist das Arbeits-Dashboard von RailKeeper für Bestandsgröße, erfassten Wert,
 Digitalisierung, Wartung und Datenqualität. Dieses Kapitel erklärt die Bedeutung jeder Kennzahl und
 den Weg von einem Hinweis zu den betroffenen Fahrzeugen. Es beschreibt den stabilen
-RailKeeper-Stand v0.1.19.
+RailKeeper-Stand v0.1.19.1.
 
 Benutzer mit den Rollen Admin, Editor, Viewer oder Planner können die Übersicht öffnen. Ein Konto,
 das ausschließlich die Rolle Messe besitzt, startet unter **Ausstellung** und kann dieses Dashboard
@@ -101,7 +101,7 @@ zu öffnen.
 | **Ohne EAN** | Fahrzeuge ohne EAN |
 | **Digital ohne Decoder-Nr.** | Digitale Fahrzeuge ohne Wert in beiden Decoder-Nummernfeldern |
 
-In v0.1.19 prüft **Ohne Hauptbild** technisch, ob irgendein Bild vorhanden ist. Die Prüfung
+In v0.1.19.1 prüft **Ohne Hauptbild** technisch, ob irgendein Bild vorhanden ist. Die Prüfung
 unterscheidet kein ausdrücklich ausgewähltes Hauptbild. Sind alle vier Werte null, meldet die Kachel,
 dass keine größeren Datenlücken erkannt wurden.
 
@@ -213,5 +213,5 @@ gespeichert.
 
 ## Dokumentierter RailKeeper-Stand
 
-Diese Seite dokumentiert den stabilen RailKeeper-Stand **v0.1.19** und wurde zuletzt am
+Diese Seite dokumentiert den stabilen RailKeeper-Stand **v0.1.19.1** und wurde zuletzt am
 2026-08-16 geprüft.

--- a/docs/site/de/guide/settings/appearance.md
+++ b/docs/site/de/guide/settings/appearance.md
@@ -3,7 +3,7 @@ title: Darstellung
 description: Designmodus wählen und helle sowie dunkle Varianten getrennt konfigurieren.
 audience: user
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -44,7 +44,7 @@ das System helle Farben anfordert, und die konfigurierte dunkle Variante bei dun
 Varianten bleiben deshalb sinnvoll, auch wenn weder Hell noch Dunkel erzwungen wird.
 
 **OLED Schwarz** steht nur für den dunklen Hintergrund bereit und verwendet eine schwarze
-Grundfläche sowie sehr dunkle Panels. **Kompakt** verkleinert in v0.1.19 hauptsächlich die Abstände
+Grundfläche sowie sehr dunkle Panels. **Kompakt** verkleinert in v0.1.19.1 hauptsächlich die Abstände
 zwischen Einstellungskarten; es ist keine globale Tabellendichte. **Kontrast** verstärkt Trennlinien
 und zurückgenommene Texte, ersetzt aber nicht Browser-Zoom oder Bedienungshilfen des Betriebssystems.
 
@@ -70,9 +70,9 @@ Darstellungsvorgaben gehören daher nicht zur Anwendungssicherung.
 | Systemmodus wechselt unerwartet | Farbmodus des Betriebssystems oder Browsers prüfen. Der Systemmodus folgt diesem Signal. |
 | Hintergrund oder Akzent scheinen wirkungslos | Prüfen, ob die Anwendung gerade die bearbeitete helle oder dunkle Variante verwendet. |
 | Ein anderer Browser zeigt ein früheres Design | Einstellungen mit demselben Benutzer öffnen und neu laden. Nach einem Verbindungsfehler den Modus oder die Variante bei Bedarf erneut wählen. |
-| Kompakt verdichtet die Bestandstabellen nicht | In v0.1.19 verkleinert der Stil hauptsächlich Abstände zwischen Einstellungskarten. |
+| Kompakt verdichtet die Bestandstabellen nicht | In v0.1.19.1 verkleinert der Stil hauptsächlich Abstände zwischen Einstellungskarten. |
 | Kontrast reicht weiterhin nicht aus | Kontrast-Stil mit Browser-Zoom und Bedienungshilfen des Betriebssystems kombinieren. |
 
 ## Dokumentierte RailKeeper-Version
 
-Diese Seite dokumentiert RailKeeper **v0.1.19** und wurde zuletzt am 16.08.2026 geprüft.
+Diese Seite dokumentiert RailKeeper **v0.1.19.1** und wurde zuletzt am 16.08.2026 geprüft.

--- a/docs/site/de/guide/settings/index.md
+++ b/docs/site/de/guide/settings/index.md
@@ -3,7 +3,7 @@ title: Einstellungen
 description: Persönliche Einstellungen, Darstellung und die Abgrenzung zur Administration verstehen.
 audience: user
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -15,7 +15,7 @@ Darstellung eines einzelnen Benutzers. Stammdaten, Digitalzentralen, Anwendungss
 Updates, Benutzer, Sitzungen und Authentifizierung sind eigene Themen, obwohl RailKeeper sie im
 selben Arbeitsbereich anzeigt.
 
-Dieses Kapitel dokumentiert RailKeeper v0.1.19.
+Dieses Kapitel dokumentiert RailKeeper v0.1.19.1.
 
 ## Zugriffsrechte
 
@@ -62,7 +62,7 @@ Vorgaben.
 
 Dabei gelten wichtige Ausnahmen und Grenzen:
 
-- Die Oberflächensprache ist in v0.1.19 nur im Browser gespeichert und wird nicht in das
+- Die Oberflächensprache ist in v0.1.19.1 nur im Browser gespeichert und wird nicht in das
   Serverprofil geschrieben.
 - Der ein- oder ausgeklappte Zustand der Hauptseitenleiste ist browserlokal. Reihenfolge und
   ausgeblendete Einträge sind Profileinstellungen.
@@ -80,8 +80,8 @@ Dabei gelten wichtige Ausnahmen und Grenzen:
 4. Helle und dunkle Variante bei Bedarf getrennt anpassen.
 5. RailKeeper einmal neu laden, um die Wiederherstellung einer Vorgabe zu prüfen.
 6. Bei einem anderen Browser mit demselben Benutzer anmelden. Die Oberflächensprache erneut setzen,
-   weil sie in v0.1.19 nicht über das Profil synchronisiert wird.
+   weil sie in v0.1.19.1 nicht über das Profil synchronisiert wird.
 
 ## Dokumentierte RailKeeper-Version
 
-Dieses Kapitel dokumentiert RailKeeper **v0.1.19** und wurde zuletzt am 16.08.2026 geprüft.
+Dieses Kapitel dokumentiert RailKeeper **v0.1.19.1** und wurde zuletzt am 16.08.2026 geprüft.

--- a/docs/site/de/guide/settings/personal-preferences.md
+++ b/docs/site/de/guide/settings/personal-preferences.md
@@ -3,7 +3,7 @@ title: Persönliche Einstellungen
 description: Sprache, Startseite, Datum, Zeit, Druckausgabe und Seitenleisten-Reihenfolge konfigurieren.
 audience: user
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -17,7 +17,7 @@ sofort; eine getrennte Speichern-Schaltfläche gibt es nicht.
 **Deutsch** oder **English** wählen. RailKeeper ändert sofort die Oberflächentexte und die vom
 Browser verwendete Dokumentensprache.
 
-Die Sprachwahl wird in RailKeeper v0.1.19 nur im aktuellen Browser gespeichert. Sie folgt dem
+Die Sprachwahl wird in RailKeeper v0.1.19.1 nur im aktuellen Browser gespeichert. Sie folgt dem
 Benutzerprofil nicht in einen anderen Browser oder auf ein anderes Gerät. Ein Browser ohne
 gespeicherte Auswahl startet auf Deutsch.
 
@@ -34,7 +34,7 @@ Dabei gelten folgende Grenzen:
   Arbeitsbereich. Die Standardansicht umgeht diese rollenabhängige Entscheidung nicht.
 - Darf die aktuelle Rolle ein gespeichertes Ziel nicht öffnen, verwendet RailKeeper die erste
   zulässige Ansicht.
-- **Anlage** ist in v0.1.19 auswählbar, bleibt aber ein unveröffentlichter Entwicklungsbereich und
+- **Anlage** ist in v0.1.19.1 auswählbar, bleibt aber ein unveröffentlichter Entwicklungsbereich und
   wird in der normalen Seitenleiste nicht angezeigt. Für den stabilen Benutzerablauf eine andere
   Startseite wählen.
 
@@ -43,7 +43,7 @@ Dabei gelten folgende Grenzen:
 Beim Datum stehen **Systemstandard**, ein deutsches Tag-Monat-Jahr-Format und das ISO-Format
 Jahr-Monat-Tag zur Auswahl. Für die Zeit gibt es **Systemstandard**, 24 Stunden und 12 Stunden.
 
-RailKeeper speichert und synchronisiert beide Vorgaben. In v0.1.19 sind sie noch nicht mit allen
+RailKeeper speichert und synchronisiert beide Vorgaben. In v0.1.19.1 sind sie noch nicht mit allen
 Datums- und Zeitausgaben der Anwendung verbunden. Viele Ansichten formatieren Werte weiterhin nach
 der gewählten Oberflächensprache oder mit einem eigenen festen Formatierer. Die Auswahl ist daher
 eine vorbereitete Vorgabe und noch keine verlässliche globale Überschreibung.
@@ -63,7 +63,7 @@ ermitteln, speichert es den gefundenen Druckernamen als Vorgabe. Die Druckererke
 nur für Admins zugänglich. Andere Rollen können die allgemeine Druckvorgabe weiterhin behalten und
 ändern.
 
-RailKeeper v0.1.19 speichert diesen Wert, leitet aber noch nicht jeden Druckvorgang automatisch an
+RailKeeper v0.1.19.1 speichert diesen Wert, leitet aber noch nicht jeden Druckvorgang automatisch an
 das gewählte Ziel. Fahrzeugbestandsdruck, Messeberichte und die Druckausgabe unter Import/Export
 öffnen weiterhin den Browser-Druckdialog. Browser und Betriebssystem bestimmen dort den
 tatsächlichen Drucker oder das Ziel **Als PDF speichern**.
@@ -81,7 +81,7 @@ Das Ausblenden entfernt nur den Link aus der Seitenleiste. Mit der erforderliche
 die zugrunde liegende Seite weiterhin direkt öffnen. Für die aktuelle Rolle unzulässige Einträge
 bleiben unabhängig von ihrer gespeicherten Position herausgefiltert.
 
-Die Liste kann **Anlage** enthalten, obwohl RailKeeper v0.1.19 diesen Arbeitsbereich nicht in der
+Die Liste kann **Anlage** enthalten, obwohl RailKeeper v0.1.19.1 diesen Arbeitsbereich nicht in der
 normalen Seitenleiste veröffentlicht. Verschieben oder Einblenden macht ihn nicht zu einer
 veröffentlichten Benutzerfunktion.
 
@@ -94,12 +94,12 @@ aktuellen Browser ein oder aus; dieser Zustand gehört nicht zu den Profileinste
 | Symptom | Prüfen |
 | --- | --- |
 | Eine Vorgabe änderte sich lokal, aber nicht in einem anderen Browser | Einstellungen mit demselben Benutzer neu laden. Der Hintergrundzugriff auf das Profil kann gescheitert sein, obwohl der lokale Wert aktiv blieb. |
-| Die Oberflächensprache unterscheidet sich auf einem anderen Gerät | Dort erneut einstellen. Die Sprache ist in v0.1.19 browserlokal. |
+| Die Oberflächensprache unterscheidet sich auf einem anderen Gerät | Dort erneut einstellen. Die Sprache ist in v0.1.19.1 browserlokal. |
 | Die gewählte Startseite öffnet sich nach der Anmeldung nicht | Rollenabhängige Anmeldung und direkte URLs haben Vorrang. Zum Testen der Vorgabe die Stammadresse öffnen. |
 | Eine ausgeblendete Seite lässt sich weiterhin öffnen | Ausblenden ändert nur die Navigation, nicht Berechtigung oder Routing. |
 | Es erscheinen keine benannten Drucker | Die Systemdrucker-Erkennung erfordert Admin und hängt vom Server-Betriebssystem oder der Druckerkonfiguration ab. |
-| Gewählter Drucker oder Datumsformat zeigen keine Wirkung | Die Vorgaben werden gespeichert, aber in v0.1.19 noch nicht von jedem Arbeitsablauf global verwendet. |
+| Gewählter Drucker oder Datumsformat zeigen keine Wirkung | Die Vorgaben werden gespeichert, aber in v0.1.19.1 noch nicht von jedem Arbeitsablauf global verwendet. |
 
 ## Dokumentierte RailKeeper-Version
 
-Diese Seite dokumentiert RailKeeper **v0.1.19** und wurde zuletzt am 16.08.2026 geprüft.
+Diese Seite dokumentiert RailKeeper **v0.1.19.1** und wurde zuletzt am 16.08.2026 geprüft.

--- a/docs/site/de/guide/vehicles/decoder-cv.md
+++ b/docs/site/de/guide/vehicles/decoder-cv.md
@@ -3,7 +3,7 @@ title: Decoder, Funktionen und CV-Daten
 description: Digitalfunktionen zuordnen, Fahrkurven prüfen, CV-Werte pflegen und Decoder-Dateien speichern.
 audience: user
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -322,5 +322,5 @@ nacheinander ausgeführten Aktion rückgängig.
 
 ## Dokumentierte RailKeeper-Version
 
-Diese Seite dokumentiert die stabile RailKeeper-Version **v0.1.19** und wurde zuletzt am
+Diese Seite dokumentiert die stabile RailKeeper-Version **v0.1.19.1** und wurde zuletzt am
 16.08.2026 geprüft.

--- a/docs/site/de/guide/vehicles/index.md
+++ b/docs/site/de/guide/vehicles/index.md
@@ -3,7 +3,7 @@ title: Fahrzeugbestand und Grunddaten
 description: Fahrzeuge suchen, filtern, anlegen, pflegen, ausgeben und sicher löschen.
 audience: user
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-17
 ---
 
@@ -11,10 +11,10 @@ lastReviewed: 2026-08-17
 
 Der **Fahrzeugbestand** ist der zentrale Arbeitsbereich für Modellbahnfahrzeuge. Er verbindet
 Bestandsstatus, Suche, Filter, Tabellen- und Kartenansicht, Fahrzeuggrunddaten, QR-Etiketten und
-druckbare Reports. Dieses Kapitel beschreibt den für RailKeeper v0.1.20 vorbereiteten Fahrzeugablauf.
+druckbare Reports. Dieses Kapitel beschreibt den mit RailKeeper v0.1.19.1 veröffentlichten Fahrzeugablauf.
 
 Admin, Editor, Viewer und Planner können den Bestand einsehen. Fahrzeuge anlegen, ändern und
-löschen dürfen nur Admin und Editor. In v0.1.19 können Schreibfunktionen für Viewer und Planner
+löschen dürfen nur Admin und Editor. In v0.1.19.1 können Schreibfunktionen für Viewer und Planner
 trotzdem sichtbar sein. Der Server lehnt ihre Schreibversuche ab und RailKeeper zeigt den
 Fehler an.
 
@@ -54,7 +54,7 @@ Suche ignoriert Leerzeichen am Anfang und Ende und findet Teilzeichenfolgen in d
 - Höchstgeschwindigkeit
 
 Beschreibungen, Bahngesellschaften, Epochen, Kategorien, Decodernummern, EANs und andere
-Detailfelder durchsucht v0.1.19 nicht. Die nachfolgenden Filter wirken im Browser auf die vom
+Detailfelder durchsucht v0.1.19.1 nicht. Die nachfolgenden Filter wirken im Browser auf die vom
 Server gelieferten Suchergebnisse. Suche und Filter werden daher kombiniert.
 
 Schlägt das Laden fehl, erscheint der Fehler über der Liste. Bereits geladene Zeilen können sichtbar
@@ -64,7 +64,7 @@ bleiben. Behebe den Fehler oder aktualisiere die Liste, bevor du sie als aktuell
 
 Filtergruppen sind UND-verknüpft. Ein Fahrzeug muss jede aktive Gruppe erfüllen.
 
-| Gruppe | Stabile Auswahl in v0.1.19 |
+| Gruppe | Stabile Auswahl in v0.1.19.1 |
 | --- | --- |
 | Bestandsstatus | **Alle**, **Digital**, **Analog**, **Mit Bild**, **Ohne Bild** |
 | Wartung | **Alle**, **Wartung fällig**, **Ohne Wartung** |
@@ -73,7 +73,7 @@ Filtergruppen sind UND-verknüpft. Ein Fahrzeug muss jede aktive Gruppe erfülle
 | Betriebsmerkmal | **Messe tauglich** |
 | Datenlücke aus der Übersicht | **Ohne Artikel-Nr.**, **Ohne EAN** oder **Digital ohne Decoder-Nr.**, wenn der Bestand aus der **Übersicht** geöffnet wurde |
 
-Die Bezeichnung **Ohne Wartung** ist in v0.1.19 ungenau. Der Filter zeigt Fahrzeuge ohne fälligen
+Die Bezeichnung **Ohne Wartung** ist in v0.1.19.1 ungenau. Der Filter zeigt Fahrzeuge ohne fälligen
 Wartungseintrag. Dazu können Fahrzeuge mit erledigten oder noch nicht fälligen Wartungen gehören.
 
 Eine ausgewählte Kategorie beschränkt die Gattungen auf die unterschiedlichen Werte der aktuell vom
@@ -220,7 +220,7 @@ nicht verfügbar. Artikelsuchdaten werden ohne Benutzerauswahl nie verbindlich �
 
 ## Stabile Auswahllisten
 
-Die folgenden Werte sind in v0.1.19 statisch. Sie bleiben in beiden Oberflächensprachen auf
+Die folgenden Werte sind in v0.1.19.1 statisch. Sie bleiben in beiden Oberflächensprachen auf
 Deutsch gespeichert.
 
 | Feld | Werte |
@@ -266,7 +266,7 @@ Decoder-Nr.: <Decodernummer, nur wenn vorhanden>
 RailKeeper verwendet zuerst die primäre digitale Decodernummer, danach die DT-Decodernummer. Der
 QR-Dialog kann PNG oder SVG herunterladen und ein druckbares Etikett öffnen. Schnellmenü und
 Fahrzeugansicht können bei vorhandenen Identitätsdaten immer einen QR-Code erzeugen. Der Schalter
-**QR-Code erstellen** steuert in v0.1.19 nur die QR-Schaltfläche im Detailbereich des
+**QR-Code erstellen** steuert in v0.1.19.1 nur die QR-Schaltfläche im Detailbereich des
 Bearbeitungsformulars.
 
 Ist Inventarnummer oder Bezeichnung leer, schreibt die Nutzlast für dieses Feld `-`. Mindestens eines
@@ -310,7 +310,7 @@ bereits vorhandenen Ausstellungslisteneintrag.
 ## Fahrzeug löschen
 
 Admin und Editor können **Löschen** wählen und das durch Inventarnummer und Bezeichnung
-identifizierte Fahrzeug bestätigen. v0.1.19 bietet weder Rückgängig noch eine Eingabebestätigung.
+identifizierte Fahrzeug bestätigen. v0.1.19.1 bietet weder Rückgängig noch eine Eingabebestätigung.
 
 Das Löschen entfernt das Fahrzeug und seine abhängigen Datenbankeinträge, darunter
 Inventarnummernhistorie, Bilder, Anhangsmetadaten, Wartungen, Funktionen, CV-Daten, externe
@@ -351,5 +351,5 @@ Datei physisch zu entfernen.
 
 ## Dokumentierte RailKeeper-Version
 
-Diese Seite dokumentiert den für RailKeeper **v0.1.20** vorbereiteten Fahrzeugablauf und wurde zuletzt am
+Diese Seite dokumentiert den mit RailKeeper **v0.1.19.1** veröffentlichten Fahrzeugablauf und wurde zuletzt am
 17.08.2026 geprüft.

--- a/docs/site/de/guide/vehicles/maintenance.md
+++ b/docs/site/de/guide/vehicles/maintenance.md
@@ -3,7 +3,7 @@ title: Fahrzeugwartung und Zustand
 description: Fahrzeugwartungen erfassen, planen, abschließen, prüfen und sicher entfernen.
 audience: user
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -105,7 +105,7 @@ getrennte Zähler für Bilder und Beilagen. Bildverknüpfungen werden im Tab **U
 Auswahl **Keine Wartung** an einem Bild bleibt eine ausstehende Metadatenänderung, bis du
 **Änderungen speichern** am Fahrzeug verwendest.
 
-RailKeeper v0.1.19 kann Beilagen anzeigen, die bereits eine Wartungsreferenz enthalten. Die
+RailKeeper v0.1.19.1 kann Beilagen anzeigen, die bereits eine Wartungsreferenz enthalten. Die
 normale Beilagenzeile bietet jedoch keine Funktion zum Zuweisen oder Ändern dieser Referenz. Nutze
 keinen erfundenen Zuordnungsablauf, den die Oberfläche nicht bereitstellt.
 
@@ -122,7 +122,7 @@ Vor dem Löschen eines Eintrags:
 3. Wähle im Tab **Uploads** für jedes verknüpfte Bild **Keine Wartung** und nutze
    **Änderungen speichern**.
 4. Muss eine verknüpfte Beilage ihre Zuordnung behalten, behalte auch den Wartungseintrag.
-   RailKeeper v0.1.19 besitzt keinen Editor für Beilagenverknüpfungen. Entferne eine Beilage erst
+   RailKeeper v0.1.19.1 besitzt keinen Editor für Beilagenverknüpfungen. Entferne eine Beilage erst
    nach Sicherungs- und Inhaltsprüfung, wenn die Datei tatsächlich nicht mehr benötigt wird.
 5. Kehre zu **Wartung** zurück, prüfe, dass **Verknüpfte Medien** nicht mehr erscheint, und lösche
    erst danach den Eintrag.
@@ -176,5 +176,5 @@ Medienaktion nicht rückgängig.
 
 ## Dokumentierte RailKeeper-Version
 
-Diese Seite dokumentiert die stabile RailKeeper-Version **v0.1.19** und wurde zuletzt am
+Diese Seite dokumentiert die stabile RailKeeper-Version **v0.1.19.1** und wurde zuletzt am
 16.08.2026 geprüft.

--- a/docs/site/de/guide/vehicles/media.md
+++ b/docs/site/de/guide/vehicles/media.md
@@ -3,7 +3,7 @@ title: Fahrzeugbilder und Beilagen
 description: Fahrzeugbilder und Beilagen hochladen, ordnen, anzeigen, herunterladen und sicher entfernen.
 audience: user
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -118,7 +118,7 @@ Metadaten entfernt wurden.
 ## Rollen-, Speicher- und Sicherungsgrenzen
 
 Medien sind lokale und private RailKeeper-Daten, keine öffentlichen Website-Inhalte.
-Anwendungssicherungen enthalten gespeicherte Fahrzeugmedien. RailKeeper akzeptiert in v0.1.19
+Anwendungssicherungen enthalten gespeicherte Fahrzeugmedien. RailKeeper akzeptiert in v0.1.19.1
 jedoch nur Sicherungsdateien bis 250 MiB für Prüfung und Wiederherstellung. Exportiere vor
 umfangreichen Aufräumarbeiten eine Sicherung und bitte einen Admin, diese Datei im
 Wiederherstellungsbereich auszuwählen. Verlasse dich erst darauf, wenn RailKeeper sie als kompatibel
@@ -158,4 +158,4 @@ das Bearbeiten von Wartungen bleiben Fachgrenzen, die auf dieser Seite nicht erk
 
 ## Dokumentierte RailKeeper-Version
 
-Diese Seite dokumentiert die stabile RailKeeper-Version **v0.1.19** und wurde zuletzt am 16.08.2026 geprüft.
+Diese Seite dokumentiert die stabile RailKeeper-Version **v0.1.19.1** und wurde zuletzt am 16.08.2026 geprüft.

--- a/docs/site/de/guide/vehicles/search-and-spares.md
+++ b/docs/site/de/guide/vehicles/search-and-spares.md
@@ -3,7 +3,7 @@ title: Artikelsuche, Web-Dokumente und Ersatzteile
 description: Externe Artikeldaten prüfen, Web-Dokumente importieren und Fahrzeugersatzteile pflegen.
 audience: user
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -316,5 +316,5 @@ was bereits geschrieben worden sein kann.
 
 ## Dokumentierte RailKeeper-Version
 
-Diese Seite dokumentiert die stabile RailKeeper-Version **v0.1.19** und wurde zuletzt am
+Diese Seite dokumentiert die stabile RailKeeper-Version **v0.1.19.1** und wurde zuletzt am
 16.08.2026 geprüft.

--- a/docs/site/de/index.md
+++ b/docs/site/de/index.md
@@ -4,12 +4,12 @@ title: RailKeeper-Dokumentation
 description: Vollständige Benutzer-, Administrations- und Entwicklungsdokumentation für RailKeeper.
 audience: reference
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-15
 hero:
   name: RailKeeper-Dokumentation
   text: Werkstattwissen direkt beim Projekt
-  tagline: Das Handbuch folgt v0.1.19, die Entwicklungsdokumentation dem Stand von main.
+  tagline: Das Handbuch folgt v0.1.19.1, die Entwicklungsdokumentation dem Stand von main.
   image:
     src: /brand/railkeeper-logo.png
     alt: RailKeeper

--- a/docs/site/guide/accessories/allocations-history.md
+++ b/docs/site/guide/accessories/allocations-history.md
@@ -3,7 +3,7 @@ title: Reservations, installations, and usage
 description: Reserve accessory stock, record installations, and understand usage history.
 audience: user
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -198,4 +198,4 @@ availability or lifecycle state.
 
 ## Documented RailKeeper version
 
-This page documents stable RailKeeper **v0.1.19** and was last reviewed on 2026-08-16.
+This page documents stable RailKeeper **v0.1.19.1** and was last reviewed on 2026-08-16.

--- a/docs/site/guide/accessories/article-records.md
+++ b/docs/site/guide/accessories/article-records.md
@@ -3,7 +3,7 @@ title: Article records and technical data
 description: Create accessory records, maintain their identity, and verify technical data.
 audience: user
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -12,7 +12,7 @@ lastReviewed: 2026-08-16
 An accessory article is the shared product record behind stock, purchases, documents,
 reservations, and installations. Create it once for a manufacturer and catalogue article, then
 record quantities or individual items against it. This chapter covers the article identity and the
-type-specific data in stable RailKeeper v0.1.19.
+type-specific data in stable RailKeeper v0.1.19.1.
 
 ## Access rights and persistence
 
@@ -135,7 +135,7 @@ Settings, the command stops without changing the article.
 The result dialog can apply manufacturer, article number, name, EAN, scale, description, product
 URL, and gauge. A manufacturer or gauge is selectable only when it matches an active known master-
 data value. A selected gauge is added to the existing gauges. Invalid common values and non-HTTP(S)
-product URLs are ignored. In stable v0.1.19, selectable technical result fields are exposed only
+product URLs are ignored. In stable v0.1.19.1, selectable technical result fields are exposed only
 for **Track** articles; other article types can apply the common result groups but not their
 technical attributes.
 
@@ -216,4 +216,4 @@ unreferenced stored blobs. Deletion has no undo, so validate a current backup fi
 
 ## Documented RailKeeper version
 
-This page documents stable RailKeeper **v0.1.19** and was last reviewed on 2026-08-16.
+This page documents stable RailKeeper **v0.1.19.1** and was last reviewed on 2026-08-16.

--- a/docs/site/guide/accessories/index.md
+++ b/docs/site/guide/accessories/index.md
@@ -3,7 +3,7 @@ title: Accessories overview
 description: Find, filter, inspect, and safely manage accessory articles.
 audience: user
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -12,7 +12,7 @@ lastReviewed: 2026-08-16
 **Accessories** is RailKeeper's catalogue and inventory workspace for track, signals, decoders,
 electrical components, scenery, lighting, and other model railway articles. It combines product
 identity, stored and allocated quantities, images, storage locations, and article lifecycle actions.
-This chapter describes stable RailKeeper v0.1.19.
+This chapter describes stable RailKeeper v0.1.19.1.
 
 An article is the common product record. Its stock can consist of interchangeable quantities,
 individually tracked items, or both. Reservations and installations bind some of that stock to a
@@ -51,7 +51,7 @@ Four metric cards appear above the article list:
 | **Care hints** | Total number of incomplete-data hints across active articles. It is informative and has no filter action. |
 
 **Care hints** is a count of missing fields, not a count of affected articles. One article can
-contribute several hints. Stable v0.1.19 checks for missing manufacturer, article number, article
+contribute several hints. Stable v0.1.19.1 checks for missing manufacturer, article number, article
 type, and stock unit. Track, signal, decoder, electrical/control, building/equipment, and lighting
 articles also contribute a hint when they have no gauge. Landscape consumables and **Other** do not
 require a gauge for this metric.
@@ -140,7 +140,7 @@ sort controls.
 ## Select, open, and manage an article
 
 Table checkboxes select one row or all currently visible rows. Selection is removed when a new
-search or filter result no longer contains the article. Stable v0.1.19 provides no bulk action for
+search or filter result no longer contains the article. Stable v0.1.19.1 provides no bulk action for
 this selection. It is visual state only and must not be treated as a pending archive, report, or
 stock command.
 
@@ -202,4 +202,4 @@ write.
 
 ## Documented RailKeeper version
 
-This page documents stable RailKeeper **v0.1.19** and was last reviewed on 2026-08-16.
+This page documents stable RailKeeper **v0.1.19.1** and was last reviewed on 2026-08-16.

--- a/docs/site/guide/accessories/stock-purchases-documents.md
+++ b/docs/site/guide/accessories/stock-purchases-documents.md
@@ -3,7 +3,7 @@ title: Stock, purchases, and documents
 description: Manage accessory quantities, individual items, purchases, images, and documents.
 audience: user
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -12,7 +12,7 @@ lastReviewed: 2026-08-16
 RailKeeper can count interchangeable accessory units, track physical items individually, or move
 units from counted stock into individual tracking when needed. Purchases and documents belong to
 the same article but have their own immediate save actions. This chapter describes the stable
-behavior of RailKeeper v0.1.19.
+behavior of RailKeeper v0.1.19.1.
 
 Admin and Editor users can manage these resources. Viewer and Planner users can inspect them, but a
 Planner's reservation authority does not include stock, purchase, item, or document changes. Save
@@ -130,7 +130,7 @@ that lifecycle, location, and history remain consistent.
 
 ## Record purchases
 
-The purchase list is a stable, newest-first history. Stable v0.1.19 provides an add action but no
+The purchase list is a stable, newest-first history. Stable v0.1.19.1 provides an add action but no
 purchase edit or delete action.
 
 | Purchase field | Stable rule |
@@ -237,4 +237,4 @@ Reload before attempting to delete again.
 
 ## Documented RailKeeper version
 
-This page documents stable RailKeeper **v0.1.19** and was last reviewed on 2026-08-16.
+This page documents stable RailKeeper **v0.1.19.1** and was last reviewed on 2026-08-16.

--- a/docs/site/guide/exhibition/entries-and-printing.md
+++ b/docs/site/guide/exhibition/entries-and-printing.md
@@ -3,7 +3,7 @@ title: Entries and printing
 description: Record exhibition locomotives, resolve address conflicts, and print the operating list.
 audience: user
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -36,7 +36,7 @@ Select an open list and use the add-entry control in the entry panel. **Create e
 | Owner | Required. Leading and trailing whitespace is removed on the server. |
 | Locomotive name | Required. Leading and trailing whitespace is removed on the server. |
 
-Use **Edit** on an existing row to open **Edit entry** with its current values. Stable v0.1.19
+Use **Edit** on an existing row to open **Edit entry** with its current values. Stable v0.1.19.1
 does not expose a vehicle picker or a visible vehicle-link field in this dialog. The entry remains
 an exhibition record even when its description resembles a vehicle in general inventory.
 
@@ -151,7 +151,7 @@ Selecting a symbol applies the symbol label as the function name when the picker
 Review the name after choosing a symbol. On **Save**, RailKeeper stores only configured functions as
 structured data. The table, detail view, and report show only those functions.
 
-Stable v0.1.19 can also read earlier plain-text values separated by commas, semicolons, or lines
+Stable v0.1.19.1 can also read earlier plain-text values separated by commas, semicolons, or lines
 when each item starts with a key such as `F1 Sound`. Opening and saving such an entry writes the
 currently configured structured representation.
 
@@ -222,5 +222,5 @@ An empty list produces a report row reading **No entries.**
 
 ## Documented RailKeeper version
 
-This page describes stable RailKeeper v0.1.19. Development behavior on `main` may differ and is
+This page describes stable RailKeeper v0.1.19.1. Development behavior on `main` may differ and is
 not part of this user workflow.

--- a/docs/site/guide/exhibition/index.md
+++ b/docs/site/guide/exhibition/index.md
@@ -3,7 +3,7 @@ title: Exhibition workspace
 description: Prepare, maintain, review, and print exhibition lists safely.
 audience: user
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -13,7 +13,7 @@ The **Exhibition list** workspace keeps the information needed for an exhibition
 one operational view. Each list has a date, an open or locked state, and its own locomotive
 entries. Operators can maintain an open list without entering the general vehicle inventory.
 
-This chapter documents stable RailKeeper v0.1.19. It does not explain user administration,
+This chapter documents stable RailKeeper v0.1.19.1. It does not explain user administration,
 master-data administration, backup operation, or the layout workspace.
 
 ## Access rights and isolation
@@ -122,5 +122,5 @@ already have succeeded before the refresh failed.
 
 ## Documented RailKeeper version
 
-This page describes stable RailKeeper v0.1.19. Development behavior on `main` may differ and is
+This page describes stable RailKeeper v0.1.19.1. Development behavior on `main` may differ and is
 not part of this user workflow.

--- a/docs/site/guide/exhibition/lists-and-locking.md
+++ b/docs/site/guide/exhibition/lists-and-locking.md
@@ -3,7 +3,7 @@ title: Lists and locking
 description: Create exhibition lists, control their lock state, and remove them safely.
 audience: user
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -41,7 +41,7 @@ reloads the list table. The create operation is an immediate server write; the d
 only local form state until it succeeds.
 
 If either required field is empty, the browser prevents normal submission. The server also rejects
-blank values after trimming them. In stable v0.1.19 the server checks that the date value is not
+blank values after trimming them. In stable v0.1.19.1 the server checks that the date value is not
 empty; the date control supplies the normal calendar value.
 
 ## Select, sort, and inspect lists
@@ -126,5 +126,5 @@ log. Audit-log operation belongs to administration and is not documented on this
 
 ## Documented RailKeeper version
 
-This page describes stable RailKeeper v0.1.19. Development behavior on `main` may differ and is
+This page describes stable RailKeeper v0.1.19.1. Development behavior on `main` may differ and is
 not part of this user workflow.

--- a/docs/site/guide/getting-started/index.md
+++ b/docs/site/guide/getting-started/index.md
@@ -3,14 +3,14 @@ title: First setup and sign-in
 description: Create the first administrator, sign in securely, and recover access to RailKeeper.
 audience: user
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
 # First setup and sign-in
 
 This chapter covers the first administrator account, normal and two-factor sign-in, sign-out, and
-password recovery. It describes stable RailKeeper v0.1.19.
+password recovery. It describes stable RailKeeper v0.1.19.1.
 
 ## Before you start
 
@@ -116,5 +116,5 @@ confirmations to ten within ten minutes.
 
 ## Documented RailKeeper version
 
-This page documents stable RailKeeper **v0.1.19** and was last checked against the application on
+This page documents stable RailKeeper **v0.1.19.1** and was last checked against the application on
 2026-08-16.

--- a/docs/site/guide/import-export/ecos-sync.md
+++ b/docs/site/guide/import-export/ecos-sync.md
@@ -3,7 +3,7 @@ title: ECoS locomotive sync
 description: Read, review, import, and explicitly write selected ESU ECoS locomotive data.
 audience: user
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -19,7 +19,7 @@ workspace.
 
 ## Supported and unsupported command stations
 
-| Active provider | Import/Export behavior in v0.1.19 |
+| Active provider | Import/Export behavior in v0.1.19.1 |
 | --- | --- |
 | ESU ECoS | Read workflow, vehicle handoff, CV and static-function suggestions, and reviewed write sync are available. |
 | Z21, Intellibox 3, or Märklin CS3 | RailKeeper shows that the import path is prepared but not implemented. |
@@ -118,7 +118,7 @@ layout objects to the command station.
 | Symptom | Check |
 | --- | --- |
 | The ECoS workspace is absent or disabled | Confirm an Admin enabled ECoS and stored a non-empty host under Digital command stations. |
-| Another provider is active | v0.1.19 only implements this import path for ECoS. |
+| Another provider is active | v0.1.19.1 only implements this import path for ECoS. |
 | Fetching fails | Check network reachability, stored host and port, ECoS availability, and Admin role. |
 | A wrong vehicle is suggested | Do not update or sync it. Correct the external mapping or decoder/name data through the vehicle workflow first. |
 | A CV or function is missing | The ECoS locomotive object did not expose it, or RailKeeper did not recognize it as a static supported value. Missing CVs do not block saving. |
@@ -127,4 +127,4 @@ layout objects to the command station.
 
 ## Documented RailKeeper version
 
-This page documents stable RailKeeper **v0.1.19** and was last reviewed on 2026-08-16.
+This page documents stable RailKeeper **v0.1.19.1** and was last reviewed on 2026-08-16.

--- a/docs/site/guide/import-export/exports.md
+++ b/docs/site/guide/import-export/exports.md
@@ -3,7 +3,7 @@ title: Export inventory
 description: Create CSV, RailKeeper JSON, and printable vehicle inventory output.
 audience: user
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -49,7 +49,7 @@ The `vehicles` array contains the vehicle objects returned to this page. This ma
 inspection and lower-loss data exchange, but it is not an application backup or a complete restore
 format.
 
-The stable v0.1.19 JSON importer reads only 14 fields from each object. It does not restore all
+The stable v0.1.19.1 JSON importer reads only 14 fields from each object. It does not restore all
 properties present in the exported object, nested records, or stored file bytes. See the exact
 [JSON import subset](/guide/import-export/file-import#json-import-subset) before relying on a
 round trip.
@@ -85,4 +85,4 @@ JSON.
 
 ## Documented RailKeeper version
 
-This page documents stable RailKeeper **v0.1.19** and was last reviewed on 2026-08-16.
+This page documents stable RailKeeper **v0.1.19.1** and was last reviewed on 2026-08-16.

--- a/docs/site/guide/import-export/file-import.md
+++ b/docs/site/guide/import-export/file-import.md
@@ -3,7 +3,7 @@ title: Import vehicle files
 description: Map, validate, review, and save vehicle rows from CSV, TSV, XML, or JSON.
 audience: user
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -137,4 +137,4 @@ maintenance, spare parts, or decoder files. Add those through their dedicated ve
 
 ## Documented RailKeeper version
 
-This page documents stable RailKeeper **v0.1.19** and was last reviewed on 2026-08-16.
+This page documents stable RailKeeper **v0.1.19.1** and was last reviewed on 2026-08-16.

--- a/docs/site/guide/import-export/index.md
+++ b/docs/site/guide/import-export/index.md
@@ -3,7 +3,7 @@ title: Import and export
 description: Exchange vehicle inventory safely and understand the separate ECoS workflow.
 audience: user
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -14,7 +14,7 @@ validation and permissions. File imports first become a review table. Exports cr
 RailKeeper JSON file, or a browser print view. An independently controlled ECoS workflow can read
 locomotive data and hand one locomotive at a time to the vehicle editor.
 
-This chapter documents stable RailKeeper v0.1.19. It covers vehicle exchange only. Master-data
+This chapter documents stable RailKeeper v0.1.19.1. It covers vehicle exchange only. Master-data
 transfer, command-station configuration, and application backup and restore remain separate
 administrative tasks.
 
@@ -81,4 +81,4 @@ API nevertheless rejects their write. Use an Editor or Admin account for an actu
 
 ## Documented RailKeeper version
 
-This chapter documents stable RailKeeper **v0.1.19** and was last reviewed on 2026-08-16.
+This chapter documents stable RailKeeper **v0.1.19.1** and was last reviewed on 2026-08-16.

--- a/docs/site/guide/index.md
+++ b/docs/site/guide/index.md
@@ -3,7 +3,7 @@ title: User Guide
 description: Learn every stable RailKeeper workflow.
 audience: user
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -13,7 +13,7 @@ This guide explains the complete published RailKeeper workflow for collectors, c
 workshops. It covers first setup, navigation, vehicles, accessories, decoder data, maintenance,
 documents, reports, exhibitions, and controlled import and export.
 
-Content in this section describes stable RailKeeper v0.1.19. The layout workspace is still under
+Content in this section describes stable RailKeeper v0.1.19.1. The layout workspace is still under
 development and is therefore not presented as a stable user feature.
 
 ## Start here

--- a/docs/site/guide/overview/index.md
+++ b/docs/site/guide/overview/index.md
@@ -3,7 +3,7 @@ title: Overview, metrics, and data quality
 description: Read the RailKeeper dashboard, follow data gaps, and arrange its widgets.
 audience: user
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -11,7 +11,7 @@ lastReviewed: 2026-08-16
 
 The **Overview** is RailKeeper's working dashboard for inventory size, recorded value,
 digitalization, maintenance, and data quality. This chapter explains what each number means and how
-to continue from an indicator to the affected vehicles. It describes stable RailKeeper v0.1.19.
+to continue from an indicator to the affected vehicles. It describes stable RailKeeper v0.1.19.1.
 
 Admin, Editor, Viewer, and Planner users can open the overview. An account with only the Messe role
 starts in **Exhibition** and cannot open this dashboard.
@@ -94,7 +94,7 @@ heading is **Inventory**, with the matching filter active.
 | **Without EAN** | Vehicles without an EAN |
 | **Digital without decoder no.** | Digital vehicles without a value in either decoder-number field |
 
-In v0.1.19, **Without main image** technically checks whether any image exists. It does not
+In v0.1.19.1, **Without main image** technically checks whether any image exists. It does not
 distinguish a specifically selected main image. When all four counts are zero, the widget reports
 that no major data gaps were detected.
 
@@ -201,4 +201,4 @@ shared with other browsers or saved as account-wide dashboard settings.
 
 ## Documented RailKeeper version
 
-This page documents stable RailKeeper **v0.1.19** and was last reviewed on 2026-08-16.
+This page documents stable RailKeeper **v0.1.19.1** and was last reviewed on 2026-08-16.

--- a/docs/site/guide/settings/appearance.md
+++ b/docs/site/guide/settings/appearance.md
@@ -3,7 +3,7 @@ title: Appearance
 description: Choose the theme mode and configure light and dark variants independently.
 audience: user
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -42,7 +42,7 @@ system requests light colors and the configured dark variant while it requests d
 variant cards therefore remain useful even when neither Light nor Dark is forced.
 
 **OLED Black** is available only for the dark background. It uses a black base and very dark panel
-surfaces. **Compact** in v0.1.19 primarily tightens spacing between Settings cards; it is not a
+surfaces. **Compact** in v0.1.19.1 primarily tightens spacing between Settings cards; it is not a
 global table-density control. **Contrast** strengthens separators and muted text but does not
 replace browser zoom or operating-system accessibility settings.
 
@@ -67,9 +67,9 @@ therefore not part of an application backup.
 | System mode changes unexpectedly | Check the operating-system or browser color preference. System mode follows that signal. |
 | A background or accent appears to have no effect | Confirm whether the application currently uses the light or dark variant you edited. |
 | Another browser shows a previous theme | Open Settings with the same user and reload. If needed, choose the mode or variant again after server connectivity returns. |
-| Compact does not make inventory tables denser | In v0.1.19 it mainly reduces gaps between Settings cards. |
+| Compact does not make inventory tables denser | In v0.1.19.1 it mainly reduces gaps between Settings cards. |
 | Contrast is still insufficient | Combine the Contrast style with browser zoom and operating-system accessibility controls. |
 
 ## Documented RailKeeper version
 
-This page documents stable RailKeeper **v0.1.19** and was last reviewed on 2026-08-16.
+This page documents stable RailKeeper **v0.1.19.1** and was last reviewed on 2026-08-16.

--- a/docs/site/guide/settings/index.md
+++ b/docs/site/guide/settings/index.md
@@ -3,7 +3,7 @@ title: Settings
 description: Understand personal preferences, appearance, and the boundaries between user and administration settings.
 audience: user
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -14,7 +14,7 @@ chapter covers the settings that shape an individual user's navigation and appea
 command stations, application backup, storage, updates, users, sessions, and authentication are
 separate topics even though RailKeeper presents them in the same workspace.
 
-This chapter documents stable RailKeeper v0.1.19.
+This chapter documents stable RailKeeper v0.1.19.1.
 
 ## Access rights
 
@@ -59,7 +59,7 @@ preferences. Opening Settings restores the other synchronized preferences.
 
 There are important exceptions and limits:
 
-- Interface language is browser-local in v0.1.19 and is not written to the server profile.
+- Interface language is browser-local in v0.1.19.1 and is not written to the server profile.
 - The collapsed or expanded state of the main sidebar is browser-local. Sidebar order and hidden
   entries are profile settings.
 - Profile saving runs in the background. The page does not show a success or failure message for
@@ -76,8 +76,8 @@ There are important exceptions and limits:
 4. Adjust the light and dark variants independently when required.
 5. Reload RailKeeper once when verifying that a preference was restored.
 6. When moving to another browser, sign in with the same user. Set the interface language again
-   because language is not profile-synchronized in v0.1.19.
+   because language is not profile-synchronized in v0.1.19.1.
 
 ## Documented RailKeeper version
 
-This chapter documents stable RailKeeper **v0.1.19** and was last reviewed on 2026-08-16.
+This chapter documents stable RailKeeper **v0.1.19.1** and was last reviewed on 2026-08-16.

--- a/docs/site/guide/settings/personal-preferences.md
+++ b/docs/site/guide/settings/personal-preferences.md
@@ -3,7 +3,7 @@ title: Personal preferences
 description: Configure language, start page, date and time choices, printing, and sidebar order.
 audience: user
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -17,7 +17,7 @@ there is no separate Save button.
 Choose **Deutsch** or **English**. RailKeeper immediately changes the interface text and the
 document language marker used by the browser.
 
-The language choice is stored only in the current browser in stable v0.1.19. It does not follow the
+The language choice is stored only in the current browser in stable v0.1.19.1. It does not follow the
 user profile to another browser or device. A browser without a stored choice starts in German.
 
 ## Default view
@@ -32,7 +32,7 @@ Keep these boundaries in mind:
 - Signing in initially routes the account to its first permitted workspace. The default does not
   bypass that role-based decision.
 - A stored destination that the current role cannot open is replaced by the first allowed view.
-- **Layout** is selectable in v0.1.19 but remains an unpublished development workspace and is not
+- **Layout** is selectable in v0.1.19.1 but remains an unpublished development workspace and is not
   shown in the normal sidebar. Choose another start page for the stable user workflow.
 
 ## Date and time format
@@ -40,7 +40,7 @@ Keep these boundaries in mind:
 The date preference offers **System default**, a German day-month-year format, and ISO
 year-month-day. The time preference offers **System default**, 24-hour, and 12-hour time.
 
-RailKeeper stores and synchronizes both choices. Stable v0.1.19 does not yet connect these settings
+RailKeeper stores and synchronizes both choices. Stable v0.1.19.1 does not yet connect these settings
 to all date and time output across the application. Many current views continue to format values
 from the selected interface language or their own fixed formatter. Treat the controls as prepared
 preferences, not as a guaranteed global override.
@@ -58,7 +58,7 @@ When RailKeeper can discover a system default while **System dialog / default pr
 it stores the detected named printer as the preference. Printer discovery itself is Admin-only.
 Other roles can still retain and change the general print preference.
 
-Stable v0.1.19 stores this value but does not route all print actions to the chosen destination.
+Stable v0.1.19.1 stores this value but does not route all print actions to the chosen destination.
 Vehicle inventory printing, exhibition reports, and Import/Export printing still open the browser
 print dialog. The browser and operating system remain responsible for choosing the real printer or
 **Save as PDF** destination.
@@ -76,7 +76,7 @@ only its sidebar link. The underlying page can still be opened directly when the
 required role. Entries unavailable to the current role remain filtered out regardless of their
 saved position.
 
-The list can include **Layout** even though stable v0.1.19 does not publish that workspace in the
+The list can include **Layout** even though stable v0.1.19.1 does not publish that workspace in the
 normal sidebar. Ordering or showing it here does not turn it into a published user feature.
 
 Sidebar order and hidden entries are stored separately for each username and synchronized through
@@ -88,12 +88,12 @@ sidebar in the current browser; that collapsed state is not part of these profil
 | Symptom | Check |
 | --- | --- |
 | A preference changed locally but not on another browser | Reload Settings while signed in as the same user. The background profile write may have failed even though the local value remained active. |
-| The interface language differs on another device | Set it again there. Language is browser-local in v0.1.19. |
+| The interface language differs on another device | Set it again there. Language is browser-local in v0.1.19.1. |
 | The selected start page is not opened after sign-in | Role-based login routing and direct URLs take precedence. Open the root address to test the stored default. |
 | A hidden page can still be opened | Hiding changes navigation only, not authorization or routing. |
 | Named printers do not appear | System-printer discovery requires Admin and depends on the server operating system or printer configuration. |
-| The selected printer or date format has no effect | These preferences are stored but are not yet used globally by every v0.1.19 workflow. |
+| The selected printer or date format has no effect | These preferences are stored but are not yet used globally by every v0.1.19.1 workflow. |
 
 ## Documented RailKeeper version
 
-This page documents stable RailKeeper **v0.1.19** and was last reviewed on 2026-08-16.
+This page documents stable RailKeeper **v0.1.19.1** and was last reviewed on 2026-08-16.

--- a/docs/site/guide/vehicles/decoder-cv.md
+++ b/docs/site/guide/vehicles/decoder-cv.md
@@ -3,7 +3,7 @@ title: Decoder, functions, and CV data
 description: Map digital functions, inspect speed curves, manage CV values, and store decoder files.
 audience: user
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -302,4 +302,4 @@ No failed later request rolls back an earlier successful request in the same seq
 
 ## Documented RailKeeper version
 
-This page documents stable RailKeeper **v0.1.19** and was last reviewed on 2026-08-16.
+This page documents stable RailKeeper **v0.1.19.1** and was last reviewed on 2026-08-16.

--- a/docs/site/guide/vehicles/index.md
+++ b/docs/site/guide/vehicles/index.md
@@ -3,7 +3,7 @@ title: Vehicle inventory and core records
 description: Search, filter, create, maintain, report, and safely delete RailKeeper vehicle records.
 audience: user
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-17
 ---
 
@@ -11,10 +11,10 @@ lastReviewed: 2026-08-17
 
 **Vehicle inventory** is the central workspace for model railway vehicles. It combines inventory
 status, search, filters, table and card views, core vehicle data, QR labels, and printable reports.
-This chapter describes the vehicle workflow prepared for RailKeeper v0.1.20.
+This chapter describes the vehicle workflow shipped with RailKeeper v0.1.19.1.
 
 Admin, Editor, Viewer, and Planner users can inspect the inventory. Creating, changing, and deleting
-vehicle records requires Admin or Editor. In v0.1.19, write controls can still be visible to Viewer
+vehicle records requires Admin or Editor. In v0.1.19.1, write controls can still be visible to Viewer
 and Planner users. The server rejects their write requests, and RailKeeper displays the error.
 
 Media, maintenance, decoder/CV data, article-data lookup, and spare parts have their own workflows.
@@ -52,7 +52,7 @@ and trailing spaces are ignored, and the search matches substrings in these fiel
 - Maximum speed
 
 It does not search descriptions, railway companies, epochs, categories, decoder numbers, EANs, or
-other detail fields in v0.1.19. The filters below are applied in the browser to the vehicles
+other detail fields in v0.1.19.1. The filters below are applied in the browser to the vehicles
 returned by the server search. Search and filters therefore combine.
 
 If loading fails, the error appears above the list. Previously loaded rows can remain visible, so
@@ -62,7 +62,7 @@ resolve the error or refresh before treating them as current.
 
 Filter groups combine with AND logic. A vehicle must satisfy every active group.
 
-| Group | Stable v0.1.19 choices |
+| Group | Stable v0.1.19.1 choices |
 | --- | --- |
 | Inventory state | **All**, **Digital**, **Analog**, **With image**, **Without image** |
 | Maintenance | **All**, **Maintenance due**, **Without maintenance** |
@@ -71,7 +71,7 @@ Filter groups combine with AND logic. A vehicle must satisfy every active group.
 | Operational flag | **Exhibition ready** |
 | Overview data gap | **Without article no.**, **Without EAN**, or **Digital without decoder no.** when opened from **Overview** |
 
-The **Without maintenance** label is imprecise in v0.1.19. It selects vehicles without a due
+The **Without maintenance** label is imprecise in v0.1.19.1. It selects vehicles without a due
 maintenance entry, including vehicles that have completed or non-due maintenance history.
 
 Selecting a category limits the subtype choices to distinct subtypes among the currently loaded
@@ -104,7 +104,7 @@ before `...10`. Select the active header again to reverse its direction. Card an
 follow the current table sort but do not expose separate sort controls. Mobile cards use the
 configured column selection and reveal additional fields in the configured order when expanded.
 
-In the English locale, the table/card and refresh tooltips remain German in v0.1.19. This is a
+In the English locale, the table/card and refresh tooltips remain German in v0.1.19.1. This is a
 localization limitation, not a different operation.
 
 ## Select vehicles
@@ -212,7 +212,7 @@ authoritative without user selection.
 
 ## Stable select choices
 
-The following choices are static in v0.1.19. Their stored values remain German in both UI
+The following choices are static in v0.1.19.1. Their stored values remain German in both UI
 locales.
 
 | Field | Choices |
@@ -257,7 +257,7 @@ Decoder-Nr.: <decoder number, only when available>
 RailKeeper uses the primary digital decoder number first, then the DT decoder number. The QR dialog
 can download PNG or SVG and open a printable label. The quick menu and read-only view can generate a
 QR code whenever identity data exists. The **Create QR code** switch controls only the QR button in
-the edit-form Details section in v0.1.19.
+the edit-form Details section in v0.1.19.1.
 
 When either inventory number or designation is empty, the payload writes `-` for that field. At
 least one of the two fields must contain a value before RailKeeper creates the QR code.
@@ -283,7 +283,7 @@ maintenance, CV data, images, attachments, and external mappings. Printing one v
 quick menu or read-only view always creates a detail report with QR code and images enabled.
 
 Reports and some report labels are generated in German even under the English locale in
-v0.1.19. If no matching vehicle exists, RailKeeper does not create a report. Allow the print window
+v0.1.19.1. If no matching vehicle exists, RailKeeper does not create a report. Allow the print window
 if the browser blocks popups.
 
 ## Exhibition switch boundary
@@ -299,7 +299,7 @@ vehicle flag, but it does not delete an existing exhibition-list entry.
 ## Delete a vehicle
 
 Admin and Editor users can select **Delete** and confirm the vehicle identified by inventory number
-and designation. There is no undo or typed confirmation in v0.1.19.
+and designation. There is no undo or typed confirmation in v0.1.19.1.
 
 Deletion removes the vehicle and cascades through its vehicle-owned database records, including
 inventory-number history, images, attachment metadata, maintenance, functions, CV data, external
@@ -339,4 +339,4 @@ important records; the application does not promise physical cleanup of every re
 
 ## Documented RailKeeper version
 
-This page documents the vehicle workflow prepared for RailKeeper **v0.1.20** and was last reviewed on 2026-08-17.
+This page documents the vehicle workflow shipped with RailKeeper **v0.1.19.1** and was last reviewed on 2026-08-17.

--- a/docs/site/guide/vehicles/maintenance.md
+++ b/docs/site/guide/vehicles/maintenance.md
@@ -3,7 +3,7 @@ title: Vehicle maintenance and condition
 description: Record, schedule, complete, review, and safely remove vehicle maintenance entries.
 audience: user
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -100,7 +100,7 @@ When at least one link exists, the maintenance card shows image and attachment c
 **Linked media**. Manage image links in **Uploads**. Selecting **No maintenance** for an image is
 pending metadata until you use the vehicle's **Save changes** action.
 
-Stable v0.1.19 can display attachments that already contain a maintenance reference, but the
+Stable v0.1.19.1 can display attachments that already contain a maintenance reference, but the
 normal attachment row cannot assign or change that reference. Do not invent a reassignment flow
 that the interface does not provide.
 
@@ -116,7 +116,7 @@ Before deleting an entry:
 2. Check its linked image and attachment counts.
 3. In **Uploads**, select **No maintenance** for every linked image and use **Save changes**.
 4. If a linked attachment must retain the association, keep the maintenance entry. Stable
-   v0.1.19 has no attachment-link editor. Remove an attachment only after backup and content
+   v0.1.19.1 has no attachment-link editor. Remove an attachment only after backup and content
    review when the file is genuinely no longer needed.
 5. Return to **Maintenance**, confirm that **Linked media** no longer appears, then delete the entry.
 
@@ -163,4 +163,4 @@ A failed action does not undo an earlier successful independent maintenance or m
 
 ## Documented RailKeeper version
 
-This page documents stable RailKeeper **v0.1.19** and was last reviewed on 2026-08-16.
+This page documents stable RailKeeper **v0.1.19.1** and was last reviewed on 2026-08-16.

--- a/docs/site/guide/vehicles/media.md
+++ b/docs/site/guide/vehicles/media.md
@@ -3,7 +3,7 @@ title: Vehicle images and attachments
 description: Upload, organize, preview, download, and safely remove vehicle images and attachments.
 audience: user
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -105,7 +105,7 @@ name. If deletion fails, reload the record and do not assume the file or metadat
 ## Roles, storage, and backup boundaries
 
 Media is local and private RailKeeper data, not public website content. Application backups include
-stored vehicle media. In v0.1.19, however, RailKeeper accepts backup files up to 250 MiB for
+stored vehicle media. In v0.1.19.1, however, RailKeeper accepts backup files up to 250 MiB for
 validation and restore. Before extensive cleanup, export a backup and ask an Admin to select that
 file in the restore panel. Rely on it only after RailKeeper accepts it as compatible. This page
 makes no promise about copies downloaded or created outside RailKeeper.
@@ -143,4 +143,4 @@ editing maintenance records remain specialist boundaries that are not explained 
 
 ## Documented RailKeeper version
 
-This page documents stable RailKeeper **v0.1.19** and was last reviewed on 2026-08-16.
+This page documents stable RailKeeper **v0.1.19.1** and was last reviewed on 2026-08-16.

--- a/docs/site/guide/vehicles/search-and-spares.md
+++ b/docs/site/guide/vehicles/search-and-spares.md
@@ -3,7 +3,7 @@ title: Article search, web documents, and spare parts
 description: Verify external article data, import web documents, and maintain vehicle spare parts.
 audience: user
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-16
 ---
 
@@ -296,4 +296,4 @@ have been stored.
 
 ## Documented RailKeeper version
 
-This page documents stable RailKeeper **v0.1.19** and was last reviewed on 2026-08-16.
+This page documents stable RailKeeper **v0.1.19.1** and was last reviewed on 2026-08-16.

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -4,12 +4,12 @@ title: RailKeeper Documentation
 description: Complete user, administration, and development documentation for RailKeeper.
 audience: reference
 status: stable
-reviewedVersion: 0.1.19
+reviewedVersion: 0.1.19.1
 lastReviewed: 2026-08-15
 hero:
   name: RailKeeper Documentation
   text: Workshop knowledge, kept with the project
-  tagline: User guidance follows stable v0.1.19. Development documentation follows main.
+  tagline: User guidance follows stable v0.1.19.1. Development documentation follows main.
   image:
     src: /brand/railkeeper-logo.png
     alt: RailKeeper

--- a/docs/versions.json
+++ b/docs/versions.json
@@ -1,4 +1,4 @@
 {
-  "stable": "0.1.19",
+  "stable": "0.1.19.1",
   "development": "main"
 }


### PR DESCRIPTION
## Deutsch

Bereitet RailKeeper `v0.1.19.1` als Korrektur-Release für die überarbeitete Fahrzeuganlage und Setdarstellung vor.

- Versionskennung auf `0.1.19.1` aktualisiert
- deutsche und englische Changelogs ergänzt
- zweisprachige Release-Notiz hinzugefügt
- feste Docker-Beispiele auf den neuen Tag aktualisiert

### Prüfung

- `go test ./...`
- `npm.cmd run build`
- `docs: npm.cmd run check`

## English

Prepares RailKeeper `v0.1.19.1` as a corrective release for the redesigned vehicle-creation flow and set inventory presentation.

- updates the application version to `0.1.19.1`
- adds German and English changelog entries
- adds bilingual release notes
- updates pinned Docker examples to the new tag

### Verification

- `go test ./...`
- `npm.cmd run build`
- `docs: npm.cmd run check`