### PR TITLE
Fahrzeugsets vollständig übertragen / Transfer vehicle sets end to end

### DIFF
--- a/backend/internal/api/data_transfer_handlers_test.go
+++ b/backend/internal/api/data_transfer_handlers_test.go
@@ -130,7 +130,7 @@ func TestDataTransferImportRoutesUploadResolveAndCancelPersistentPreview(t *test
 	if preview.ErrorRecords != 1 || len(preview.Issues) != 1 {
 		t.Fatalf("unexpected import preview: %#v", preview)
 	}
-	if len(preview.CSVMapping) != 6 || len(preview.VehicleFields) != 62 ||
+	if len(preview.CSVMapping) != 6 || len(preview.VehicleFields) != len(application.VehicleCSVTransferFields()) ||
 		preview.CSVMapping[0].SourceHeader != "Inventarnummer" {
 		t.Fatalf("missing CSV mapping contract: %#v, fields=%d", preview.CSVMapping, len(preview.VehicleFields))
 	}

--- a/backend/internal/api/data_transfer_openapi_test.go
+++ b/backend/internal/api/data_transfer_openapi_test.go
@@ -102,3 +102,21 @@ func TestOpenAPIDataTransferIssueResolutionIncludesMesseMerge(t *testing.T) {
 		t.Fatalf("data transfer issue resolution omits Messe merge: %s", resolution)
 	}
 }
+
+func TestOpenAPIDataTransferPreviewDocumentsVehicleSets(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "..", "..", "openapi", "railkeeper.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	contract := string(data)
+	preview := openAPIIndentedBlock(t, contract, "DataTransferPreview", 4)
+	if !strings.Contains(preview, "vehicleSets:") ||
+		!strings.Contains(contract, "DataTransferVehicleSetPreview:") ||
+		!strings.Contains(contract, "DataTransferVehicleSetMember:") {
+		t.Fatalf("vehicle set preview contract missing: %s", preview)
+	}
+	area := openAPIIndentedBlock(t, contract, "TransferArea", 4)
+	if !strings.Contains(area, "enum: [vehicles, accessories, exhibitionLists]") {
+		t.Fatalf("transfer areas changed unexpectedly: %s", area)
+	}
+}

--- a/backend/internal/application/data_transfer_export.go
+++ b/backend/internal/application/data_transfer_export.go
@@ -383,8 +383,16 @@ func marshalDataTransferCSV(area TransferArea, snapshot DataTransferSnapshot) ([
 		if err := writer.Write(transferVehicleCSVHeaders()); err != nil {
 			return nil, err
 		}
+		membersByID, membersByInventory, err := transferVehicleSetCSVMemberLookups(snapshot.VehicleSets)
+		if err != nil {
+			return nil, err
+		}
 		for _, vehicle := range snapshot.Vehicles {
-			if err := writer.Write(safeDataTransferCSVRow(transferVehicleCSVValues(vehicle))); err != nil {
+			member := membersByID[vehicle.ID]
+			if member == nil {
+				member = membersByInventory[transferIdentity(vehicle.InventoryNumber)]
+			}
+			if err := writer.Write(safeDataTransferCSVRow(transferVehicleCSVValues(vehicle, member))); err != nil {
 				return nil, err
 			}
 		}
@@ -426,7 +434,7 @@ func marshalDataTransferCSV(area TransferArea, snapshot DataTransferSnapshot) ([
 }
 
 func transferVehicleCSVHeaders() []string {
-	fields := VehicleTransferFields()
+	fields := VehicleCSVTransferFields()
 	headers := make([]string, len(fields))
 	for index, field := range fields {
 		headers[index] = field.LabelDE
@@ -434,13 +442,110 @@ func transferVehicleCSVHeaders() []string {
 	return headers
 }
 
-func transferVehicleCSVValues(vehicle TransferVehicle) []string {
-	fields := VehicleTransferFields()
+type transferVehicleSetCSVMember struct {
+	Set    TransferVehicleSet
+	Member TransferVehicleSetMember
+}
+
+func transferVehicleSetCSVMemberLookups(
+	sets []TransferVehicleSet,
+) (map[string]*transferVehicleSetCSVMember, map[string]*transferVehicleSetCSVMember, error) {
+	byID := map[string]*transferVehicleSetCSVMember{}
+	byInventory := map[string]*transferVehicleSetCSVMember{}
+	for _, set := range sets {
+		for _, member := range set.Members {
+			value := &transferVehicleSetCSVMember{Set: set, Member: member}
+			if member.SourceVehicleID != "" {
+				if byID[member.SourceVehicleID] != nil {
+					return nil, nil, fmt.Errorf("%w: vehicle belongs to multiple exported sets", ErrDataTransferValidation)
+				}
+				byID[member.SourceVehicleID] = value
+			}
+			inventoryKey := transferIdentity(member.VehicleInventoryNumber)
+			if inventoryKey != "" {
+				if byInventory[inventoryKey] != nil {
+					return nil, nil, fmt.Errorf("%w: vehicle belongs to multiple exported sets", ErrDataTransferValidation)
+				}
+				byInventory[inventoryKey] = value
+			}
+		}
+	}
+	return byID, byInventory, nil
+}
+
+func transferVehicleCSVValues(vehicle TransferVehicle, setMember *transferVehicleSetCSVMember) []string {
+	fields := VehicleCSVTransferFields()
 	values := make([]string, len(fields))
 	for index, field := range fields {
-		values[index] = transferVehicleCSVValue(vehicle, field.Key)
+		if strings.HasPrefix(field.Key, "vehicleSet") {
+			values[index] = transferVehicleSetCSVValue(setMember, field.Key)
+		} else {
+			values[index] = transferVehicleCSVValue(vehicle, field.Key)
+		}
 	}
 	return values
+}
+
+func transferVehicleSetCSVValue(member *transferVehicleSetCSVMember, field string) string {
+	if member == nil {
+		return ""
+	}
+	set := member.Set
+	switch field {
+	case "vehicleSetInventoryNumber":
+		return set.InventoryNumber
+	case "vehicleSetName":
+		return set.Name
+	case "vehicleSetManufacturer":
+		return set.Manufacturer
+	case "vehicleSetArticleNumber":
+		return set.ArticleNumber
+	case "vehicleSetArticleSourceUrl":
+		return set.ArticleSourceURL
+	case "vehicleSetGauge":
+		return set.Gauge
+	case "vehicleSetEpoch":
+		return set.Epoch
+	case "vehicleSetRailwayCompany":
+		return set.RailwayCompany
+	case "vehicleSetCategory":
+		return set.Category
+	case "vehicleSetGattung":
+		return set.Gattung
+	case "vehicleSetDescription":
+		return set.Description
+	case "vehicleSetEAN":
+		return set.EAN
+	case "vehicleSetProductionPeriod":
+		return set.ProductionPeriod
+	case "vehicleSetListPrice":
+		return set.ListPrice
+	case "vehicleSetAcquisitionType":
+		return set.AcquisitionType
+	case "vehicleSetAcquiredFrom":
+		return set.AcquiredFrom
+	case "vehicleSetPurchasePrice":
+		return set.PurchasePrice
+	case "vehicleSetPurchaseDate":
+		return set.PurchaseDate
+	case "vehicleSetStorageLocation":
+		return set.StorageLocation
+	case "vehicleSetStorageDetails":
+		return set.StorageDetails
+	case "vehicleSetCondition":
+		return set.Condition
+	case "vehicleSetConditionDetails":
+		return set.ConditionDetails
+	case "vehicleSetPackaging":
+		return set.Packaging
+	case "vehicleSetPosition":
+		return strconv.Itoa(member.Member.Position)
+	case "vehicleSetMemberCount":
+		return strconv.Itoa(len(set.Members))
+	case "vehicleSetMemberLabel":
+		return member.Member.Label
+	}
+	return ""
 }
 
 func transferVehicleCSVValue(vehicle TransferVehicle, field string) string {

--- a/backend/internal/application/data_transfer_export.go
+++ b/backend/internal/application/data_transfer_export.go
@@ -598,6 +598,20 @@ func sortDataTransferSnapshot(snapshot *DataTransferSnapshot) {
 	slices.SortStableFunc(snapshot.Vehicles, func(left, right TransferVehicle) int {
 		return compareTransferKeys(left.InventoryNumber, right.InventoryNumber, left.ID, right.ID)
 	})
+	slices.SortStableFunc(snapshot.VehicleSets, func(left, right TransferVehicleSet) int {
+		return compareTransferKeys(left.InventoryNumber, right.InventoryNumber, left.ID, right.ID)
+	})
+	for index := range snapshot.VehicleSets {
+		slices.SortStableFunc(snapshot.VehicleSets[index].Members, func(left, right TransferVehicleSetMember) int {
+			if left.Position != right.Position {
+				return left.Position - right.Position
+			}
+			return compareTransferKeys(
+				left.VehicleInventoryNumber, right.VehicleInventoryNumber,
+				left.SourceVehicleID, right.SourceVehicleID,
+			)
+		})
+	}
 	slices.SortStableFunc(snapshot.Accessories, func(left, right TransferAccessory) int {
 		return compareTransferKeys(left.InventoryNumber, right.InventoryNumber, left.ID, right.ID)
 	})

--- a/backend/internal/application/data_transfer_export_test.go
+++ b/backend/internal/application/data_transfer_export_test.go
@@ -200,6 +200,31 @@ func TestDataTransferExportCombinedJSONHasStableOrdering(t *testing.T) {
 	}
 }
 
+func TestDataTransferExportJSONSortsVehicleSetsAndMembers(t *testing.T) {
+	snapshot := DataTransferSnapshot{
+		Vehicles: []TransferVehicle{{ID: "v-1", InventoryNumber: "RK-1"}},
+		VehicleSets: []TransferVehicleSet{
+			{ID: "set-z", InventoryNumber: "Set-010", Members: []TransferVehicleSetMember{
+				{SourceVehicleID: "v-2", VehicleInventoryNumber: "RK-2", Position: 2},
+				{SourceVehicleID: "v-1", VehicleInventoryNumber: "RK-1", Position: 1},
+			}},
+			{ID: "set-a", InventoryNumber: "Set-002"},
+		},
+	}
+	payload, err := marshalDataTransferPackage(snapshot, "2026-08-27T10:00:00Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+	document, err := decodeDataTransferPackage(bytes.NewReader(payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if document.Areas.VehicleSets[0].ID != "set-a" ||
+		document.Areas.VehicleSets[1].Members[0].Position != 1 {
+		t.Fatalf("unstable vehicle set ordering: %#v", document.Areas.VehicleSets)
+	}
+}
+
 func TestDataTransferExportWritesConfinedArtifactWithSHA256(t *testing.T) {
 	repository := &dataTransferExportRepositoryStub{
 		profile: DataTransferProfile{

--- a/backend/internal/application/data_transfer_export_test.go
+++ b/backend/internal/application/data_transfer_export_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"strings"
 	"testing"
@@ -32,8 +33,40 @@ func TestCombinedTransferPackageExcludesMasterData(t *testing.T) {
 		t.Fatalf("feature package leaked master data: %s", payload)
 	}
 	if !bytes.Contains(payload, []byte(`"format":"railkeeper-transfer"`)) ||
-		!bytes.Contains(payload, []byte(`"version":2`)) {
+		!bytes.Contains(payload, []byte(`"version":3`)) {
 		t.Fatalf("missing package identity: %s", payload)
+	}
+}
+
+func TestDataTransferPackageVersionThreeRoundTripsVehicleSet(t *testing.T) {
+	snapshot := DataTransferSnapshot{
+		Vehicles: []TransferVehicle{
+			{ID: "source-a", InventoryNumber: "RK-1", Manufacturer: "Roco", Name: "A", Gauge: "H0",
+				Category: "Wagen", Gattung: "Reisezugwagen"},
+			{ID: "source-b", InventoryNumber: "RK-2", Manufacturer: "Roco", Name: "B", Gauge: "H0",
+				Category: "Wagen", Gattung: "Reisezugwagen"},
+		},
+		VehicleSets: []TransferVehicleSet{{
+			ID: "source-set", InventoryNumber: "Set-1",
+			VehicleSetInput: VehicleSetInput{
+				Name: "Rheingold", Manufacturer: "Roco", Gauge: "H0", Category: "Set", Gattung: "Reisezug",
+			},
+			Members: []TransferVehicleSetMember{
+				{SourceVehicleID: "source-a", VehicleInventoryNumber: "RK-1", Position: 1, Label: "A-Wagen"},
+				{SourceVehicleID: "source-b", VehicleInventoryNumber: "RK-2", Position: 2, Label: "B-Wagen"},
+			},
+		}},
+	}
+	payload, err := marshalDataTransferPackage(snapshot, "2026-08-27T10:00:00Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+	document, err := decodeDataTransferPackage(bytes.NewReader(payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if document.Version != 3 || !reflect.DeepEqual(document.Areas.VehicleSets, snapshot.VehicleSets) {
+		t.Fatalf("vehicle set round trip = %#v", document)
 	}
 }
 

--- a/backend/internal/application/data_transfer_export_test.go
+++ b/backend/internal/application/data_transfer_export_test.go
@@ -98,7 +98,7 @@ func TestDataTransferExportVehicleCSVUsesStableSemicolonColumns(t *testing.T) {
 	}
 }
 
-func TestDataTransferExportVehicleCSVContainsAll62ScalarFields(t *testing.T) {
+func TestDataTransferExportVehicleCSVContainsAllScalarAndSetFields(t *testing.T) {
 	payload, err := marshalDataTransferCSV(TransferVehicles, DataTransferSnapshot{Vehicles: []TransferVehicle{{
 		InventoryNumber: "RK-001", Manufacturer: "Roco", Name: "BR 01", Gauge: "H0",
 	}}})
@@ -111,8 +111,8 @@ func TestDataTransferExportVehicleCSVContainsAll62ScalarFields(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(rows) != 2 || len(rows[0]) != 62 || len(rows[1]) != 62 {
-		t.Fatalf("vehicle CSV dimensions = %d rows, %d/%d columns, want 2 rows and 62 columns", len(rows), len(rows[0]), len(rows[1]))
+	if len(rows) != 2 || len(rows[0]) != 88 || len(rows[1]) != 88 {
+		t.Fatalf("vehicle CSV dimensions = %d rows, %d/%d columns, want 2 rows and 88 columns", len(rows), len(rows[0]), len(rows[1]))
 	}
 	for _, header := range []string{"Länge (mm)", "Kupplung hinten", "Zusatzinformationen", "QR-Code erstellen"} {
 		if !slices.Contains(rows[0], header) {

--- a/backend/internal/application/data_transfer_import.go
+++ b/backend/internal/application/data_transfer_import.go
@@ -681,7 +681,9 @@ func decodeDataTransferPackage(reader io.Reader) (DataTransferPackage, error) {
 		return DataTransferPackage{}, fmt.Errorf("%w: invalid transfer package: %v", ErrDataTransferValidation, err)
 	}
 	if envelope.Format != DataTransferPackageFormat ||
-		(envelope.Version != DataTransferPackageLegacyVersion && envelope.Version != DataTransferPackageVersion) {
+		(envelope.Version != DataTransferPackageLegacyVersion &&
+			envelope.Version != DataTransferPackagePreviousVersion &&
+			envelope.Version != DataTransferPackageVersion) {
 		return DataTransferPackage{}, fmt.Errorf("%w: unsupported transfer package format or version", ErrDataTransferValidation)
 	}
 	document := DataTransferPackage{
@@ -690,6 +692,17 @@ func decodeDataTransferPackage(reader io.Reader) (DataTransferPackage, error) {
 	if envelope.Version == DataTransferPackageVersion {
 		if err := decodeStrictTransferJSON(bytes.NewReader(envelope.Areas), &document.Areas); err != nil {
 			return DataTransferPackage{}, fmt.Errorf("%w: invalid transfer package: %v", ErrDataTransferValidation, err)
+		}
+		return document, nil
+	}
+	if envelope.Version == DataTransferPackagePreviousVersion {
+		previousAreas := dataTransferPackageAreasV2{}
+		if err := decodeStrictTransferJSON(bytes.NewReader(envelope.Areas), &previousAreas); err != nil {
+			return DataTransferPackage{}, fmt.Errorf("%w: invalid transfer package: %v", ErrDataTransferValidation, err)
+		}
+		document.Areas = DataTransferPackageAreas{
+			Vehicles: previousAreas.Vehicles, Accessories: previousAreas.Accessories,
+			ExhibitionLists: previousAreas.ExhibitionLists,
 		}
 		return document, nil
 	}
@@ -722,6 +735,9 @@ func decodeStrictTransferJSON(reader io.Reader, target any) error {
 }
 
 func validateDataTransferPackageSelection(areas DataTransferPackageAreas, selected []TransferArea) error {
+	if areas.VehicleSets != nil && (areas.Vehicles == nil || !slices.Contains(selected, TransferVehicles)) {
+		return fmt.Errorf("%w: vehicle sets require the vehicles area", ErrDataTransferValidation)
+	}
 	present := []TransferArea{}
 	if areas.Vehicles != nil {
 		present = append(present, TransferVehicles)

--- a/backend/internal/application/data_transfer_import.go
+++ b/backend/internal/application/data_transfer_import.go
@@ -244,7 +244,7 @@ func (s *DataTransferService) UploadAndPreviewReader(
 	}
 	vehicleFields := []VehicleTransferField(nil)
 	if job.Format == TransferCSV && slices.Contains(job.Areas, TransferVehicles) {
-		vehicleFields = VehicleTransferFields()
+		vehicleFields = VehicleCSVTransferFields()
 	}
 	job.Preview, err = dataTransferPreviewMap(digest, records, csvMapping, vehicleFields)
 	if err != nil {

--- a/backend/internal/application/data_transfer_import.go
+++ b/backend/internal/application/data_transfer_import.go
@@ -27,15 +27,16 @@ var (
 )
 
 type DataTransferPreview struct {
-	Job            DataTransferJob                `json:"job"`
-	Records        []DataTransferPreviewRecord    `json:"records"`
-	Issues         []DataTransferIssue            `json:"issues"`
-	TotalRecords   int                            `json:"totalRecords"`
-	ReadyRecords   int                            `json:"readyRecords"`
-	WarningRecords int                            `json:"warningRecords"`
-	ErrorRecords   int                            `json:"errorRecords"`
-	CSVMapping     []DataTransferCSVColumnMapping `json:"csvMapping,omitempty"`
-	VehicleFields  []VehicleTransferField         `json:"vehicleFields,omitempty"`
+	Job            DataTransferJob                 `json:"job"`
+	Records        []DataTransferPreviewRecord     `json:"records"`
+	Issues         []DataTransferIssue             `json:"issues"`
+	TotalRecords   int                             `json:"totalRecords"`
+	ReadyRecords   int                             `json:"readyRecords"`
+	WarningRecords int                             `json:"warningRecords"`
+	ErrorRecords   int                             `json:"errorRecords"`
+	CSVMapping     []DataTransferCSVColumnMapping  `json:"csvMapping,omitempty"`
+	VehicleFields  []VehicleTransferField          `json:"vehicleFields,omitempty"`
+	VehicleSets    []DataTransferVehicleSetPreview `json:"vehicleSets,omitempty"`
 }
 
 type DataTransferPreviewRecord struct {
@@ -221,6 +222,9 @@ func (s *DataTransferService) UploadAndPreviewReader(
 		return DataTransferPreview{}, fmt.Errorf("load current transfer rows: %w", err)
 	}
 	records, issues := classifyDataTransferImport(job.ID, incoming, current, rowNumbers)
+	vehicleSets, vehicleSetIssues := classifyDataTransferVehicleSets(job.ID, incoming, current, records)
+	issues = append(issues, vehicleSetIssues...)
+	records, issues = suppressDataTransferVehicleSetMemberConflicts(records, issues, vehicleSets)
 	records, issues, err = validateTransferAccessoryPreviewReferences(ctx, repository, job.ID, records, issues)
 	if err != nil {
 		return DataTransferPreview{}, err
@@ -246,7 +250,7 @@ func (s *DataTransferService) UploadAndPreviewReader(
 	if job.Format == TransferCSV && slices.Contains(job.Areas, TransferVehicles) {
 		vehicleFields = VehicleCSVTransferFields()
 	}
-	job.Preview, err = dataTransferPreviewMap(digest, records, csvMapping, vehicleFields)
+	job.Preview, err = dataTransferPreviewMap(digest, records, vehicleSets, csvMapping, vehicleFields)
 	if err != nil {
 		return DataTransferPreview{}, err
 	}
@@ -273,7 +277,7 @@ func (s *DataTransferService) UploadAndPreviewReader(
 	if err != nil {
 		return DataTransferPreview{}, err
 	}
-	return newDataTransferPreview(job, records, issues, csvMapping, vehicleFields), nil
+	return newDataTransferPreview(job, records, issues, vehicleSets, csvMapping, vehicleFields), nil
 }
 
 func validateTransferAccessoryPreviewReferences(
@@ -654,7 +658,8 @@ func parseDataTransferUpload(
 			return DataTransferSnapshot{}, 0, nil, nil, err
 		}
 		return DataTransferSnapshot{
-			Vehicles: packageDocument.Areas.Vehicles, Accessories: packageDocument.Areas.Accessories,
+			Vehicles: packageDocument.Areas.Vehicles, VehicleSets: packageDocument.Areas.VehicleSets,
+			Accessories:     packageDocument.Areas.Accessories,
 			ExhibitionLists: packageDocument.Areas.ExhibitionLists,
 		}, packageDocument.Version, nil, nil, nil
 	case TransferCSV:
@@ -762,17 +767,19 @@ func validateDataTransferPackageSelection(areas DataTransferPackageAreas, select
 func dataTransferPreviewMap(
 	sourceSHA256 string,
 	records []DataTransferPreviewRecord,
+	vehicleSets []DataTransferVehicleSetPreview,
 	csvMapping []DataTransferCSVColumnMapping,
 	vehicleFields []VehicleTransferField,
 ) (map[string]any, error) {
 	payload, err := json.Marshal(struct {
-		SourceSHA256       string                         `json:"sourceSha256"`
-		FingerprintVersion int                            `json:"fingerprintVersion"`
-		Records            []DataTransferPreviewRecord    `json:"records"`
-		CSVMapping         []DataTransferCSVColumnMapping `json:"csvMapping,omitempty"`
-		VehicleFields      []VehicleTransferField         `json:"vehicleFields,omitempty"`
+		SourceSHA256       string                          `json:"sourceSha256"`
+		FingerprintVersion int                             `json:"fingerprintVersion"`
+		Records            []DataTransferPreviewRecord     `json:"records"`
+		VehicleSets        []DataTransferVehicleSetPreview `json:"vehicleSets,omitempty"`
+		CSVMapping         []DataTransferCSVColumnMapping  `json:"csvMapping,omitempty"`
+		VehicleFields      []VehicleTransferField          `json:"vehicleFields,omitempty"`
 	}{SourceSHA256: sourceSHA256, FingerprintVersion: DataTransferTargetFingerprintVersion,
-		Records: records, CSVMapping: csvMapping, VehicleFields: vehicleFields})
+		Records: records, VehicleSets: vehicleSets, CSVMapping: csvMapping, VehicleFields: vehicleFields})
 	if err != nil {
 		return nil, fmt.Errorf("encode transfer preview: %w", err)
 	}
@@ -787,33 +794,36 @@ func newDataTransferPreview(
 	job DataTransferJob,
 	records []DataTransferPreviewRecord,
 	issues []DataTransferIssue,
+	vehicleSets []DataTransferVehicleSetPreview,
 	csvMapping []DataTransferCSVColumnMapping,
 	vehicleFields []VehicleTransferField,
 ) DataTransferPreview {
 	return DataTransferPreview{
 		Job: job, Records: records, Issues: issues, TotalRecords: job.TotalRecords,
 		ReadyRecords: job.ReadyRecords, WarningRecords: job.WarningRecords, ErrorRecords: job.ErrorRecords,
-		CSVMapping: csvMapping, VehicleFields: vehicleFields,
+		CSVMapping: csvMapping, VehicleFields: vehicleFields, VehicleSets: vehicleSets,
 	}
 }
 
 func validDataTransferResolution(issue DataTransferIssue, resolution string) bool {
 	allowed := map[string]map[string]bool{
-		"missing_inventory_number":             {"skip": true},
-		"missing_manufacturer":                 {"skip": true},
-		"missing_name":                         {"skip": true},
-		"missing_gauge":                        {"skip": true},
-		"missing_category":                     {"skip": true},
-		"missing_gattung":                      {"skip": true},
-		"invalid_vehicle":                      {"skip": true},
-		"invalid_accessory":                    {"skip": true},
-		"duplicate_inventory_number":           {"replace": true, "copy": true, "skip": true},
-		"matching_manufacturer_article_number": {"use_existing": true, "create": true, "skip": true},
-		"duplicate_exhibition_list":            {"replace": true, "merge": true, "copy": true, "skip": true},
-		"locked_exhibition_list":               {"copy": true, "skip": true},
-		"exhibition_vehicle_reference":         {"link": true, "skip": true},
-		"missing_vehicle_reference":            {"skip": true},
-		"duplicate_input_inventory_number":     {"skip": true},
+		"missing_inventory_number":               {"skip": true},
+		"missing_manufacturer":                   {"skip": true},
+		"missing_name":                           {"skip": true},
+		"missing_gauge":                          {"skip": true},
+		"missing_category":                       {"skip": true},
+		"missing_gattung":                        {"skip": true},
+		"invalid_vehicle":                        {"skip": true},
+		"invalid_accessory":                      {"skip": true},
+		"duplicate_inventory_number":             {"replace": true, "copy": true, "skip": true},
+		"matching_manufacturer_article_number":   {"use_existing": true, "create": true, "skip": true},
+		"duplicate_exhibition_list":              {"replace": true, "merge": true, "copy": true, "skip": true},
+		"locked_exhibition_list":                 {"copy": true, "skip": true},
+		"exhibition_vehicle_reference":           {"link": true, "skip": true},
+		"missing_vehicle_reference":              {"skip": true},
+		"duplicate_input_inventory_number":       {"skip": true},
+		"duplicate_vehicle_set_inventory_number": {"replace": true, "copy": true, "skip": true},
+		"vehicle_set_member_external_conflict":   {"copy": true, "skip": true},
 	}
 	return resolution != "" && allowed[issue.Code][resolution]
 }

--- a/backend/internal/application/data_transfer_import_csv.go
+++ b/backend/internal/application/data_transfer_import_csv.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"slices"
 	"strconv"
 	"strings"
 	"unicode"
@@ -107,6 +108,7 @@ func parseDataTransferCSVWithMapping(
 	}
 	snapshot := DataTransferSnapshot{}
 	rowNumbers := []int{}
+	vehicleSetIndexes := map[string]int{}
 	for index, values := range rows[1:] {
 		rowNumber := index + 2
 		if transferCSVRowEmpty(values) {
@@ -131,6 +133,29 @@ func parseDataTransferCSVWithMapping(
 				return DataTransferSnapshot{}, nil, nil, err
 			}
 			snapshot.Vehicles = append(snapshot.Vehicles, vehicle)
+			set, found, err := transferVehicleSetFromCSV(row, rowNumber, vehicle)
+			if err != nil {
+				return DataTransferSnapshot{}, nil, nil, err
+			}
+			if found {
+				setKey := transferIdentity(set.InventoryNumber)
+				if setKey == "" {
+					setKey = fmt.Sprintf("row-%d", rowNumber)
+				}
+				if setIndex, exists := vehicleSetIndexes[setKey]; exists {
+					snapshot.VehicleSets[setIndex].Members = append(
+						snapshot.VehicleSets[setIndex].Members,
+						set.Members...,
+					)
+					snapshot.VehicleSets[setIndex].Diagnostics = append(
+						snapshot.VehicleSets[setIndex].Diagnostics,
+						set.Diagnostics...,
+					)
+				} else {
+					vehicleSetIndexes[setKey] = len(snapshot.VehicleSets)
+					snapshot.VehicleSets = append(snapshot.VehicleSets, set)
+				}
+			}
 		case TransferAccessories:
 			accessory, err := transferAccessoryFromCSV(row, rowNumber)
 			if err != nil {
@@ -140,7 +165,86 @@ func parseDataTransferCSVWithMapping(
 		}
 		rowNumbers = append(rowNumbers, rowNumber)
 	}
+	for index := range snapshot.VehicleSets {
+		slices.SortStableFunc(snapshot.VehicleSets[index].Members, func(left, right TransferVehicleSetMember) int {
+			if left.Position != right.Position {
+				return left.Position - right.Position
+			}
+			return strings.Compare(left.VehicleInventoryNumber, right.VehicleInventoryNumber)
+		})
+	}
 	return snapshot, rowNumbers, mapping, nil
+}
+
+func transferVehicleSetFromCSV(
+	row map[string]string,
+	rowNumber int,
+	vehicle TransferVehicle,
+) (TransferVehicleSet, bool, error) {
+	hasSetValue := false
+	for _, field := range vehicleSetTransferFields {
+		if strings.TrimSpace(row[field.Key]) != "" {
+			hasSetValue = true
+			break
+		}
+	}
+	if !hasSetValue {
+		return TransferVehicleSet{}, false, nil
+	}
+	position, positionDiagnostic := parseTransferCSVSetInteger(
+		row["vehicleSetPosition"], rowNumber, "vehicleSetPosition", "invalid_vehicle_set_position",
+	)
+	memberCount, memberCountDiagnostic := parseTransferCSVSetInteger(
+		row["vehicleSetMemberCount"], rowNumber, "vehicleSetMemberCount", "invalid_vehicle_set_member_count",
+	)
+	diagnostics := []TransferVehicleSetDiagnostic{}
+	if positionDiagnostic != nil {
+		diagnostics = append(diagnostics, *positionDiagnostic)
+	}
+	if memberCountDiagnostic != nil {
+		diagnostics = append(diagnostics, *memberCountDiagnostic)
+	}
+	return TransferVehicleSet{
+		InventoryNumber: row["vehicleSetInventoryNumber"],
+		VehicleSetInput: VehicleSetInput{
+			Name: row["vehicleSetName"], Manufacturer: row["vehicleSetManufacturer"],
+			ArticleNumber: row["vehicleSetArticleNumber"], ArticleSourceURL: row["vehicleSetArticleSourceUrl"],
+			Gauge: row["vehicleSetGauge"], Epoch: row["vehicleSetEpoch"],
+			RailwayCompany: row["vehicleSetRailwayCompany"], Category: row["vehicleSetCategory"],
+			Gattung: row["vehicleSetGattung"], Description: row["vehicleSetDescription"],
+			EAN: row["vehicleSetEAN"], ProductionPeriod: row["vehicleSetProductionPeriod"],
+			ListPrice: row["vehicleSetListPrice"], AcquisitionType: row["vehicleSetAcquisitionType"],
+			AcquiredFrom: row["vehicleSetAcquiredFrom"], PurchasePrice: row["vehicleSetPurchasePrice"],
+			PurchaseDate: row["vehicleSetPurchaseDate"], StorageLocation: row["vehicleSetStorageLocation"],
+			StorageDetails: row["vehicleSetStorageDetails"], Condition: row["vehicleSetCondition"],
+			ConditionDetails: row["vehicleSetConditionDetails"], Packaging: row["vehicleSetPackaging"],
+		},
+		Members: []TransferVehicleSetMember{{
+			VehicleInventoryNumber: vehicle.InventoryNumber,
+			Position:               position,
+			Label:                  row["vehicleSetMemberLabel"],
+			SourceRowNumber:        rowNumber,
+			DeclaredMemberCount:    memberCount,
+		}},
+		Diagnostics: diagnostics,
+	}, true, nil
+}
+
+func parseTransferCSVSetInteger(
+	value string,
+	rowNumber int,
+	field string,
+	code string,
+) (int, *TransferVehicleSetDiagnostic) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0, nil
+	}
+	parsed, err := strconv.Atoi(value)
+	if err == nil {
+		return parsed, nil
+	}
+	return 0, &TransferVehicleSetDiagnostic{RowNumber: rowNumber, Field: field, Code: code}
 }
 
 func detectDataTransferCSVDelimiter(payload []byte) (rune, error) {

--- a/backend/internal/application/data_transfer_import_csv.go
+++ b/backend/internal/application/data_transfer_import_csv.go
@@ -204,27 +204,29 @@ func transferVehicleSetFromCSV(
 	if memberCountDiagnostic != nil {
 		diagnostics = append(diagnostics, *memberCountDiagnostic)
 	}
+	setInput := VehicleSetInput{
+		Name: row["vehicleSetName"], Manufacturer: row["vehicleSetManufacturer"],
+		ArticleNumber: row["vehicleSetArticleNumber"], ArticleSourceURL: row["vehicleSetArticleSourceUrl"],
+		Gauge: row["vehicleSetGauge"], Epoch: row["vehicleSetEpoch"],
+		RailwayCompany: row["vehicleSetRailwayCompany"], Category: row["vehicleSetCategory"],
+		Gattung: row["vehicleSetGattung"], Description: row["vehicleSetDescription"],
+		EAN: row["vehicleSetEAN"], ProductionPeriod: row["vehicleSetProductionPeriod"],
+		ListPrice: row["vehicleSetListPrice"], AcquisitionType: row["vehicleSetAcquisitionType"],
+		AcquiredFrom: row["vehicleSetAcquiredFrom"], PurchasePrice: row["vehicleSetPurchasePrice"],
+		PurchaseDate: row["vehicleSetPurchaseDate"], StorageLocation: row["vehicleSetStorageLocation"],
+		StorageDetails: row["vehicleSetStorageDetails"], Condition: row["vehicleSetCondition"],
+		ConditionDetails: row["vehicleSetConditionDetails"], Packaging: row["vehicleSetPackaging"],
+	}
 	return TransferVehicleSet{
 		InventoryNumber: row["vehicleSetInventoryNumber"],
-		VehicleSetInput: VehicleSetInput{
-			Name: row["vehicleSetName"], Manufacturer: row["vehicleSetManufacturer"],
-			ArticleNumber: row["vehicleSetArticleNumber"], ArticleSourceURL: row["vehicleSetArticleSourceUrl"],
-			Gauge: row["vehicleSetGauge"], Epoch: row["vehicleSetEpoch"],
-			RailwayCompany: row["vehicleSetRailwayCompany"], Category: row["vehicleSetCategory"],
-			Gattung: row["vehicleSetGattung"], Description: row["vehicleSetDescription"],
-			EAN: row["vehicleSetEAN"], ProductionPeriod: row["vehicleSetProductionPeriod"],
-			ListPrice: row["vehicleSetListPrice"], AcquisitionType: row["vehicleSetAcquisitionType"],
-			AcquiredFrom: row["vehicleSetAcquiredFrom"], PurchasePrice: row["vehicleSetPurchasePrice"],
-			PurchaseDate: row["vehicleSetPurchaseDate"], StorageLocation: row["vehicleSetStorageLocation"],
-			StorageDetails: row["vehicleSetStorageDetails"], Condition: row["vehicleSetCondition"],
-			ConditionDetails: row["vehicleSetConditionDetails"], Packaging: row["vehicleSetPackaging"],
-		},
+		VehicleSetInput: setInput,
 		Members: []TransferVehicleSetMember{{
 			VehicleInventoryNumber: vehicle.InventoryNumber,
 			Position:               position,
 			Label:                  row["vehicleSetMemberLabel"],
 			SourceRowNumber:        rowNumber,
 			DeclaredMemberCount:    memberCount,
+			SourceSetInput:         setInput,
 		}},
 		Diagnostics: diagnostics,
 	}, true, nil

--- a/backend/internal/application/data_transfer_import_test.go
+++ b/backend/internal/application/data_transfer_import_test.go
@@ -171,8 +171,7 @@ func TestDataTransferVehicleSetCSVRoundTripIgnoresRowOrder(t *testing.T) {
 	var reordered bytes.Buffer
 	writer := csv.NewWriter(&reordered)
 	writer.Comma = ';'
-	writer.WriteAll(rows)
-	if err := writer.Error(); err != nil {
+	if err := writer.WriteAll(rows); err != nil {
 		t.Fatal(err)
 	}
 	got, _, err := parseDataTransferCSV(TransferVehicles, strings.NewReader(reordered.String()))

--- a/backend/internal/application/data_transfer_import_test.go
+++ b/backend/internal/application/data_transfer_import_test.go
@@ -190,7 +190,7 @@ func TestTransferImportRejectsUnknownMasterDataAndUnsupportedVersion(t *testing.
 		},
 		{
 			name:    "unsupported package version",
-			payload: `{"format":"railkeeper-transfer","version":3,"areas":{"vehicles":[]}}`,
+			payload: `{"format":"railkeeper-transfer","version":4,"areas":{"vehicles":[]}}`,
 		},
 		{
 			name:    "empty areas",
@@ -220,6 +220,25 @@ func TestTransferImportAcceptsLegacyPackageVersionOne(t *testing.T) {
 	}
 	if document.Version != DataTransferPackageLegacyVersion || document.Areas.Vehicles == nil {
 		t.Fatalf("legacy package decoded incorrectly: %#v", document)
+	}
+}
+
+func TestTransferImportAcceptsPreviousPackageVersionTwo(t *testing.T) {
+	document, err := decodeDataTransferPackage(strings.NewReader(
+		`{"format":"railkeeper-transfer","version":2,"createdAt":"2026-01-01T00:00:00Z",` +
+			`"areas":{"vehicles":[{"inventoryNumber":"RK-2","manufacturer":"Roco",` +
+			`"name":"BR 218","gauge":"H0","category":"Lokomotive","gattung":"Diesellokomotive",` +
+			`"digital":false,"dtDecoder":false,"exhibitionReady":false,"exhibition":false,` +
+			`"abcBrakes":false,"couplingSame":false,"driveEnabled":false,"headlightsEnabled":false,` +
+			`"lightingEnabled":false,"soundGeneratorEnabled":false,"smokeGeneratorEnabled":false,` +
+			`"qrCodeEnabled":false}]}}`,
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if document.Version != DataTransferPackagePreviousVersion || len(document.Areas.Vehicles) != 1 ||
+		document.Areas.VehicleSets != nil {
+		t.Fatalf("version two package decoded incorrectly: %#v", document)
 	}
 }
 

--- a/backend/internal/application/data_transfer_import_test.go
+++ b/backend/internal/application/data_transfer_import_test.go
@@ -1,7 +1,9 @@
 package application
 
 import (
+	"bytes"
 	"context"
+	"encoding/csv"
 	"encoding/json"
 	"errors"
 	"strings"
@@ -56,7 +58,7 @@ func TestPreviewImportReturnsAndAppliesVehicleCSVMapping(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(automatic.CSVMapping) != 6 || automatic.CSVMapping[0].SourceHeader != "Eigene Nummer" ||
-		automatic.CSVMapping[0].Origin != CSVMappingUnmapped || len(automatic.VehicleFields) != 62 {
+		automatic.CSVMapping[0].Origin != CSVMappingUnmapped || len(automatic.VehicleFields) != 88 {
 		t.Fatalf("unexpected automatic mapping: %#v, fields=%d", automatic.CSVMapping, len(automatic.VehicleFields))
 	}
 
@@ -129,6 +131,97 @@ func TestDataTransferVehicleCSVFullFieldRoundTrip(t *testing.T) {
 		!got.SoundGeneratorEnabled || got.AdditionalInfo != want.AdditionalInfo || !got.QRCodeEnabled ||
 		got.MaximumSpeedKmh == nil || *got.MaximumSpeedKmh != maximumSpeed {
 		t.Fatalf("vehicle round trip lost extended fields: %#v", got)
+	}
+}
+
+func TestDataTransferVehicleSetCSVRoundTripIgnoresRowOrder(t *testing.T) {
+	snapshot := DataTransferSnapshot{
+		Vehicles: []TransferVehicle{
+			{ID: "vehicle-a", InventoryNumber: "RK-A", Manufacturer: "Roco", Name: "Wagen A", Gauge: "H0",
+				Category: "Wagen", Gattung: "Reisezugwagen"},
+			{ID: "vehicle-b", InventoryNumber: "RK-B", Manufacturer: "Roco", Name: "Wagen B", Gauge: "H0",
+				Category: "Wagen", Gattung: "Reisezugwagen"},
+		},
+		VehicleSets: []TransferVehicleSet{{
+			ID: "set-source", InventoryNumber: "Set-001",
+			VehicleSetInput: VehicleSetInput{
+				Name: "Rheingold", Manufacturer: "Roco", ArticleNumber: "43000", Gauge: "H0", Epoch: "III",
+				RailwayCompany: "DB", Category: "Set", Gattung: "Reisezug", StorageLocation: "Vitrine",
+			},
+			Members: []TransferVehicleSetMember{
+				{SourceVehicleID: "vehicle-a", VehicleInventoryNumber: "RK-A", Position: 1, Label: "Steuerwagen"},
+				{SourceVehicleID: "vehicle-b", VehicleInventoryNumber: "RK-B", Position: 2, Label: "Speisewagen"},
+			},
+		}},
+	}
+	payload, err := marshalDataTransferCSV(TransferVehicles, snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reader := csv.NewReader(bytes.NewReader(payload))
+	reader.Comma = ';'
+	rows, err := reader.ReadAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows[0]) != 88 {
+		t.Fatalf("vehicle set CSV columns = %d, want 88", len(rows[0]))
+	}
+	rows[1], rows[2] = rows[2], rows[1]
+	var reordered bytes.Buffer
+	writer := csv.NewWriter(&reordered)
+	writer.Comma = ';'
+	writer.WriteAll(rows)
+	if err := writer.Error(); err != nil {
+		t.Fatal(err)
+	}
+	got, _, err := parseDataTransferCSV(TransferVehicles, strings.NewReader(reordered.String()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.VehicleSets) != 1 || len(got.VehicleSets[0].Members) != 2 {
+		t.Fatalf("vehicle set CSV round trip = %#v", got.VehicleSets)
+	}
+	set := got.VehicleSets[0]
+	if set.InventoryNumber != "Set-001" || set.Name != "Rheingold" || set.ArticleNumber != "43000" ||
+		set.StorageLocation != "Vitrine" || set.Members[0].Position != 1 ||
+		set.Members[0].VehicleInventoryNumber != "RK-A" || set.Members[0].Label != "Steuerwagen" ||
+		set.Members[1].Position != 2 {
+		t.Fatalf("vehicle set CSV values = %#v", set)
+	}
+}
+
+func TestDataTransferVehicleCSVWithoutSetColumnsCreatesNoSet(t *testing.T) {
+	payload := strings.Join([]string{
+		"Inventarnummer;Hersteller;Bezeichnung;Spurweite;Kategorie;Gattung",
+		"RK-SOLO;Roco;BR 218;H0;Lokomotive;Diesellokomotive",
+	}, "\n")
+	snapshot, _, err := parseDataTransferCSV(TransferVehicles, strings.NewReader(payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snapshot.Vehicles) != 1 || len(snapshot.VehicleSets) != 0 {
+		t.Fatalf("single vehicle CSV snapshot = %#v", snapshot)
+	}
+}
+
+func TestDataTransferVehicleSetCSVPreservesInvalidIntegersForReview(t *testing.T) {
+	payload := strings.Join([]string{
+		"Inventarnummer;Hersteller;Bezeichnung;Spurweite;Kategorie;Gattung;" +
+			"Set-Inventarnummer;Set-Bezeichnung;Set-Hersteller;Set-Spurweite;Set-Kategorie;Set-Gattung;" +
+			"Set-Position;Set-Mitgliederzahl",
+		"RK-A;Roco;Wagen A;H0;Wagen;Reisezugwagen;Set-001;Rheingold;Roco;H0;Set;Reisezug;x;zwei",
+	}, "\n")
+	snapshot, _, err := parseDataTransferCSV(TransferVehicles, strings.NewReader(payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snapshot.VehicleSets) != 1 || len(snapshot.VehicleSets[0].Diagnostics) != 2 {
+		t.Fatalf("vehicle set diagnostics = %#v", snapshot.VehicleSets)
+	}
+	if snapshot.VehicleSets[0].Diagnostics[0].Code != "invalid_vehicle_set_position" ||
+		snapshot.VehicleSets[0].Diagnostics[1].Code != "invalid_vehicle_set_member_count" {
+		t.Fatalf("unexpected diagnostics = %#v", snapshot.VehicleSets[0].Diagnostics)
 	}
 }
 

--- a/backend/internal/application/data_transfer_package.go
+++ b/backend/internal/application/data_transfer_package.go
@@ -3,9 +3,10 @@ package application
 import "encoding/json"
 
 const (
-	DataTransferPackageFormat        = "railkeeper-transfer"
-	DataTransferPackageLegacyVersion = 1
-	DataTransferPackageVersion       = 2
+	DataTransferPackageFormat          = "railkeeper-transfer"
+	DataTransferPackageLegacyVersion   = 1
+	DataTransferPackagePreviousVersion = 2
+	DataTransferPackageVersion         = 3
 )
 
 type DataTransferPackage struct {
@@ -16,6 +17,13 @@ type DataTransferPackage struct {
 }
 
 type DataTransferPackageAreas struct {
+	Vehicles        []TransferVehicle        `json:"vehicles,omitempty"`
+	VehicleSets     []TransferVehicleSet     `json:"vehicleSets,omitempty"`
+	Accessories     []TransferAccessory      `json:"accessories,omitempty"`
+	ExhibitionLists []TransferExhibitionList `json:"exhibitionLists,omitempty"`
+}
+
+type dataTransferPackageAreasV2 struct {
 	Vehicles        []TransferVehicle        `json:"vehicles,omitempty"`
 	Accessories     []TransferAccessory      `json:"accessories,omitempty"`
 	ExhibitionLists []TransferExhibitionList `json:"exhibitionLists,omitempty"`
@@ -31,12 +39,16 @@ type dataTransferPackageAreasV1 struct {
 func (areas DataTransferPackageAreas) MarshalJSON() ([]byte, error) {
 	type areaDocument struct {
 		Vehicles        *[]TransferVehicle        `json:"vehicles,omitempty"`
+		VehicleSets     *[]TransferVehicleSet     `json:"vehicleSets,omitempty"`
 		Accessories     *[]TransferAccessory      `json:"accessories,omitempty"`
 		ExhibitionLists *[]TransferExhibitionList `json:"exhibitionLists,omitempty"`
 	}
 	document := areaDocument{}
 	if areas.Vehicles != nil {
 		document.Vehicles = &areas.Vehicles
+	}
+	if areas.VehicleSets != nil {
+		document.VehicleSets = &areas.VehicleSets
 	}
 	if areas.Accessories != nil {
 		document.Accessories = &areas.Accessories
@@ -49,8 +61,25 @@ func (areas DataTransferPackageAreas) MarshalJSON() ([]byte, error) {
 
 type DataTransferSnapshot struct {
 	Vehicles        []TransferVehicle
+	VehicleSets     []TransferVehicleSet
 	Accessories     []TransferAccessory
 	ExhibitionLists []TransferExhibitionList
+}
+
+type TransferVehicleSetMember struct {
+	SourceVehicleID        string `json:"vehicleId"`
+	VehicleInventoryNumber string `json:"vehicleInventoryNumber"`
+	Position               int    `json:"position"`
+	Label                  string `json:"label,omitempty"`
+}
+
+type TransferVehicleSet struct {
+	ID              string `json:"id,omitempty"`
+	InventoryNumber string `json:"inventoryNumber"`
+	VehicleSetInput
+	Members   []TransferVehicleSetMember `json:"members"`
+	CreatedAt string                     `json:"createdAt,omitempty"`
+	UpdatedAt string                     `json:"updatedAt,omitempty"`
 }
 
 type TransferVehicle struct {

--- a/backend/internal/application/data_transfer_package.go
+++ b/backend/internal/application/data_transfer_package.go
@@ -67,12 +67,13 @@ type DataTransferSnapshot struct {
 }
 
 type TransferVehicleSetMember struct {
-	SourceVehicleID        string `json:"vehicleId"`
-	VehicleInventoryNumber string `json:"vehicleInventoryNumber"`
-	Position               int    `json:"position"`
-	Label                  string `json:"label,omitempty"`
-	SourceRowNumber        int    `json:"-"`
-	DeclaredMemberCount    int    `json:"-"`
+	SourceVehicleID        string          `json:"vehicleId"`
+	VehicleInventoryNumber string          `json:"vehicleInventoryNumber"`
+	Position               int             `json:"position"`
+	Label                  string          `json:"label,omitempty"`
+	SourceRowNumber        int             `json:"-"`
+	DeclaredMemberCount    int             `json:"-"`
+	SourceSetInput         VehicleSetInput `json:"-"`
 }
 
 type TransferVehicleSetDiagnostic struct {

--- a/backend/internal/application/data_transfer_package.go
+++ b/backend/internal/application/data_transfer_package.go
@@ -71,15 +71,24 @@ type TransferVehicleSetMember struct {
 	VehicleInventoryNumber string `json:"vehicleInventoryNumber"`
 	Position               int    `json:"position"`
 	Label                  string `json:"label,omitempty"`
+	SourceRowNumber        int    `json:"-"`
+	DeclaredMemberCount    int    `json:"-"`
+}
+
+type TransferVehicleSetDiagnostic struct {
+	RowNumber int    `json:"rowNumber"`
+	Field     string `json:"field"`
+	Code      string `json:"code"`
 }
 
 type TransferVehicleSet struct {
 	ID              string `json:"id,omitempty"`
 	InventoryNumber string `json:"inventoryNumber"`
 	VehicleSetInput
-	Members   []TransferVehicleSetMember `json:"members"`
-	CreatedAt string                     `json:"createdAt,omitempty"`
-	UpdatedAt string                     `json:"updatedAt,omitempty"`
+	Members     []TransferVehicleSetMember     `json:"members"`
+	Diagnostics []TransferVehicleSetDiagnostic `json:"-"`
+	CreatedAt   string                         `json:"createdAt,omitempty"`
+	UpdatedAt   string                         `json:"updatedAt,omitempty"`
 }
 
 type TransferVehicle struct {

--- a/backend/internal/application/data_transfer_vehicle_fields.go
+++ b/backend/internal/application/data_transfer_vehicle_fields.go
@@ -126,8 +126,12 @@ func vehicleTransferField(
 }
 
 func VehicleTransferFields() []VehicleTransferField {
-	fields := make([]VehicleTransferField, len(vehicleTransferFields))
-	copy(fields, vehicleTransferFields)
+	return cloneVehicleTransferFields(vehicleTransferFields)
+}
+
+func cloneVehicleTransferFields(source []VehicleTransferField) []VehicleTransferField {
+	fields := make([]VehicleTransferField, len(source))
+	copy(fields, source)
 	for index := range fields {
 		fields[index].Aliases = append([]string(nil), fields[index].Aliases...)
 	}
@@ -207,7 +211,7 @@ func defaultDataTransferCSVMapping(
 		normalized := normalizeTransferCSVHeader(sourceHeader)
 		target, hasProfileDefault := profileDefaults[normalized]
 		if hasProfileDefault && target != dataTransferCSVIgnoreTarget {
-			if _, valid := VehicleTransferFieldByKey(target); !valid {
+			if _, valid := VehicleCSVTransferFieldByKey(target); !valid {
 				hasProfileDefault = false
 				target = ""
 			}
@@ -280,8 +284,9 @@ func dataTransferOptionsWithCSVMapping(
 }
 
 func vehicleTransferCSVAliases() map[string]string {
-	aliases := make(map[string]string, len(vehicleTransferFields)*3)
-	for _, field := range vehicleTransferFields {
+	fields := VehicleCSVTransferFields()
+	aliases := make(map[string]string, len(fields)*3)
+	for _, field := range fields {
 		for _, alias := range field.Aliases {
 			aliases[normalizeTransferCSVHeader(alias)] = field.Key
 		}
@@ -320,7 +325,7 @@ func validateDataTransferCSVMapping(header []string, mapping []DataTransferCSVCo
 		if column.TargetField == "" {
 			return fmt.Errorf("%w: mapped CSV column must have a target", ErrDataTransferValidation)
 		}
-		if _, ok := VehicleTransferFieldByKey(column.TargetField); !ok {
+		if _, ok := VehicleCSVTransferFieldByKey(column.TargetField); !ok {
 			return fmt.Errorf("%w: unsupported CSV target %q", ErrDataTransferValidation, column.TargetField)
 		}
 		if seenTargets[column.TargetField] {

--- a/backend/internal/application/data_transfer_vehicle_fields_test.go
+++ b/backend/internal/application/data_transfer_vehicle_fields_test.go
@@ -23,6 +23,30 @@ func TestVehicleTransferFieldCatalogContainsStable62Fields(t *testing.T) {
 	}
 }
 
+func TestVehicleSetTransferFieldCatalogContainsStable26Fields(t *testing.T) {
+	fields := VehicleSetTransferFields()
+	if len(fields) != 26 {
+		t.Fatalf("set transfer fields = %d, want 26", len(fields))
+	}
+	if len(VehicleCSVTransferFields()) != 88 {
+		t.Fatalf("combined vehicle CSV fields = %d, want 88", len(VehicleCSVTransferFields()))
+	}
+	for _, key := range []string{
+		"vehicleSetInventoryNumber",
+		"vehicleSetName",
+		"vehicleSetPosition",
+		"vehicleSetMemberCount",
+		"vehicleSetMemberLabel",
+	} {
+		if _, ok := VehicleCSVTransferFieldByKey(key); !ok {
+			t.Fatalf("missing vehicle set transfer field %q", key)
+		}
+	}
+	if len(VehicleTransferFields()) != 62 {
+		t.Fatalf("vehicle transfer catalog changed to %d fields", len(VehicleTransferFields()))
+	}
+}
+
 func TestDataTransferCSVMappingRecognizesAliasesAndLeavesUnknownColumnsOpen(t *testing.T) {
 	mapping := defaultDataTransferCSVMapping([]string{"Inventarnummer", "Vereinsnotiz"}, nil)
 	if len(mapping) != 2 {

--- a/backend/internal/application/data_transfer_vehicle_set_fields.go
+++ b/backend/internal/application/data_transfer_vehicle_set_fields.go
@@ -48,3 +48,51 @@ func VehicleCSVTransferFieldByKey(key string) (VehicleTransferField, bool) {
 	}
 	return VehicleTransferField{}, false
 }
+
+func PreserveUnmappedTransferVehicleSetFields(
+	incoming TransferVehicleSet,
+	existing TransferVehicleSet,
+	mapping []DataTransferCSVColumnMapping,
+) TransferVehicleSet {
+	mappedFields := make(map[string]bool, len(mapping))
+	for _, column := range mapping {
+		if column.TargetField != "" {
+			mappedFields[column.TargetField] = true
+		}
+	}
+	fields := []struct {
+		key      string
+		incoming *string
+		existing string
+	}{
+		{"vehicleSetInventoryNumber", &incoming.InventoryNumber, existing.InventoryNumber},
+		{"vehicleSetName", &incoming.Name, existing.Name},
+		{"vehicleSetManufacturer", &incoming.Manufacturer, existing.Manufacturer},
+		{"vehicleSetArticleNumber", &incoming.ArticleNumber, existing.ArticleNumber},
+		{"vehicleSetArticleSourceUrl", &incoming.ArticleSourceURL, existing.ArticleSourceURL},
+		{"vehicleSetGauge", &incoming.Gauge, existing.Gauge},
+		{"vehicleSetEpoch", &incoming.Epoch, existing.Epoch},
+		{"vehicleSetRailwayCompany", &incoming.RailwayCompany, existing.RailwayCompany},
+		{"vehicleSetCategory", &incoming.Category, existing.Category},
+		{"vehicleSetGattung", &incoming.Gattung, existing.Gattung},
+		{"vehicleSetDescription", &incoming.Description, existing.Description},
+		{"vehicleSetEAN", &incoming.EAN, existing.EAN},
+		{"vehicleSetProductionPeriod", &incoming.ProductionPeriod, existing.ProductionPeriod},
+		{"vehicleSetListPrice", &incoming.ListPrice, existing.ListPrice},
+		{"vehicleSetAcquisitionType", &incoming.AcquisitionType, existing.AcquisitionType},
+		{"vehicleSetAcquiredFrom", &incoming.AcquiredFrom, existing.AcquiredFrom},
+		{"vehicleSetPurchasePrice", &incoming.PurchasePrice, existing.PurchasePrice},
+		{"vehicleSetPurchaseDate", &incoming.PurchaseDate, existing.PurchaseDate},
+		{"vehicleSetStorageLocation", &incoming.StorageLocation, existing.StorageLocation},
+		{"vehicleSetStorageDetails", &incoming.StorageDetails, existing.StorageDetails},
+		{"vehicleSetCondition", &incoming.Condition, existing.Condition},
+		{"vehicleSetConditionDetails", &incoming.ConditionDetails, existing.ConditionDetails},
+		{"vehicleSetPackaging", &incoming.Packaging, existing.Packaging},
+	}
+	for _, field := range fields {
+		if !mappedFields[field.key] {
+			*field.incoming = field.existing
+		}
+	}
+	return incoming
+}

--- a/backend/internal/application/data_transfer_vehicle_set_fields.go
+++ b/backend/internal/application/data_transfer_vehicle_set_fields.go
@@ -1,0 +1,50 @@
+package application
+
+var vehicleSetTransferFields = []VehicleTransferField{
+	vehicleTransferField("vehicleSetInventoryNumber", "Set-Inventarnummer", "Set inventory number", VehicleTransferString),
+	vehicleTransferField("vehicleSetName", "Set-Bezeichnung", "Set name", VehicleTransferString),
+	vehicleTransferField("vehicleSetManufacturer", "Set-Hersteller", "Set manufacturer", VehicleTransferString),
+	vehicleTransferField("vehicleSetArticleNumber", "Set-Artikelnummer", "Set article number", VehicleTransferString),
+	vehicleTransferField("vehicleSetArticleSourceUrl", "Set-Artikelquelle", "Set article source URL", VehicleTransferString),
+	vehicleTransferField("vehicleSetGauge", "Set-Spurweite", "Set gauge", VehicleTransferString),
+	vehicleTransferField("vehicleSetEpoch", "Set-Epoche", "Set epoch", VehicleTransferString),
+	vehicleTransferField("vehicleSetRailwayCompany", "Set-Bahngesellschaft", "Set railway company", VehicleTransferString),
+	vehicleTransferField("vehicleSetCategory", "Set-Kategorie", "Set category", VehicleTransferString),
+	vehicleTransferField("vehicleSetGattung", "Set-Gattung", "Set class", VehicleTransferString),
+	vehicleTransferField("vehicleSetDescription", "Set-Beschreibung", "Set description", VehicleTransferString),
+	vehicleTransferField("vehicleSetEAN", "Set-EAN", "Set EAN", VehicleTransferString),
+	vehicleTransferField("vehicleSetProductionPeriod", "Set-Produktionszeit", "Set production period", VehicleTransferString),
+	vehicleTransferField("vehicleSetListPrice", "Set-Listenpreis", "Set list price", VehicleTransferString),
+	vehicleTransferField("vehicleSetAcquisitionType", "Set-Erwerbsart", "Set acquisition type", VehicleTransferString),
+	vehicleTransferField("vehicleSetAcquiredFrom", "Set-Erworben von/bei", "Set acquired from", VehicleTransferString),
+	vehicleTransferField("vehicleSetPurchasePrice", "Set-Kaufpreis", "Set purchase price", VehicleTransferString),
+	vehicleTransferField("vehicleSetPurchaseDate", "Set-Kaufdatum", "Set purchase date", VehicleTransferString),
+	vehicleTransferField("vehicleSetStorageLocation", "Set-Lagerort", "Set storage location", VehicleTransferString),
+	vehicleTransferField("vehicleSetStorageDetails", "Set-Lagerdetails", "Set storage details", VehicleTransferString),
+	vehicleTransferField("vehicleSetCondition", "Set-Zustand", "Set condition", VehicleTransferString),
+	vehicleTransferField("vehicleSetConditionDetails", "Set-Zustandsdetails", "Set condition details", VehicleTransferString),
+	vehicleTransferField("vehicleSetPackaging", "Set-Verpackung", "Set packaging", VehicleTransferString),
+	vehicleTransferField("vehicleSetPosition", "Set-Position", "Set position", VehicleTransferInteger),
+	vehicleTransferField("vehicleSetMemberCount", "Set-Mitgliederzahl", "Set member count", VehicleTransferInteger),
+	vehicleTransferField("vehicleSetMemberLabel", "Set-Mitgliedsbezeichnung", "Set member label", VehicleTransferString),
+}
+
+func VehicleSetTransferFields() []VehicleTransferField {
+	return cloneVehicleTransferFields(vehicleSetTransferFields)
+}
+
+func VehicleCSVTransferFields() []VehicleTransferField {
+	fields := make([]VehicleTransferField, 0, len(vehicleTransferFields)+len(vehicleSetTransferFields))
+	fields = append(fields, cloneVehicleTransferFields(vehicleTransferFields)...)
+	fields = append(fields, cloneVehicleTransferFields(vehicleSetTransferFields)...)
+	return fields
+}
+
+func VehicleCSVTransferFieldByKey(key string) (VehicleTransferField, bool) {
+	for _, field := range VehicleCSVTransferFields() {
+		if field.Key == key {
+			return field, true
+		}
+	}
+	return VehicleTransferField{}, false
+}

--- a/backend/internal/application/data_transfer_vehicle_sets.go
+++ b/backend/internal/application/data_transfer_vehicle_sets.go
@@ -117,6 +117,9 @@ func classifyDataTransferVehicleSets(
 			target, hasTarget := currentSetsByInventory[transferIdentity(set.InventoryNumber)]
 			targetMemberIDs := map[string]bool{}
 			if hasTarget {
+				preview.TargetID = target.ID
+				preview.TargetUpdatedAt = target.UpdatedAt
+				preview.TargetFingerprint = DataTransferTargetFingerprint(target)
 				for _, member := range target.Members {
 					targetMemberIDs[member.SourceVehicleID] = true
 				}
@@ -136,9 +139,6 @@ func classifyDataTransferVehicleSets(
 					"A set member conflicts with a vehicle outside the target set.", "copy",
 				))
 			} else if hasTarget {
-				preview.TargetID = target.ID
-				preview.TargetUpdatedAt = target.UpdatedAt
-				preview.TargetFingerprint = DataTransferTargetFingerprint(target)
 				preview.ProposedAction = "replace"
 				issues = append(issues, newTransferIssue(
 					jobID, TransferVehicles, recordKey, nil, "inventoryNumber", TransferIssueWarning,

--- a/backend/internal/application/data_transfer_vehicle_sets.go
+++ b/backend/internal/application/data_transfer_vehicle_sets.go
@@ -166,6 +166,9 @@ func validateTransferVehicleSetStructure(set TransferVehicleSet) []TransferVehic
 	if len(set.Members) < 2 {
 		diagnostics = append(diagnostics, TransferVehicleSetDiagnostic{Field: "members", Code: "vehicle_set_too_small"})
 	}
+	if len(set.Members) > maxVehicleSetMembers {
+		diagnostics = append(diagnostics, TransferVehicleSetDiagnostic{Field: "members", Code: "vehicle_set_too_large"})
+	}
 	positions := make(map[int]bool, len(set.Members))
 	members := make(map[string]bool, len(set.Members))
 	for index, member := range set.Members {
@@ -291,6 +294,7 @@ func transferVehicleSetDiagnosticMessage(code string) string {
 		"missing_vehicle_set_inventory_number": "Vehicle set inventory number is required.",
 		"invalid_vehicle_set":                  "Vehicle set data violates aggregate validation.",
 		"vehicle_set_too_small":                "A vehicle set requires at least two members.",
+		"vehicle_set_too_large":                "A vehicle set cannot contain more than 100 members.",
 		"invalid_vehicle_set_position":         "Vehicle set member position must be a positive integer.",
 		"duplicate_vehicle_set_position":       "Vehicle set member positions must be unique.",
 		"non_contiguous_vehicle_set_positions": "Vehicle set member positions must be contiguous.",

--- a/backend/internal/application/data_transfer_vehicle_sets.go
+++ b/backend/internal/application/data_transfer_vehicle_sets.go
@@ -1,0 +1,358 @@
+package application
+
+import (
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+type DataTransferVehicleSetPreview struct {
+	RecordKey         string                         `json:"recordKey"`
+	Classification    string                         `json:"classification"`
+	ProposedAction    string                         `json:"proposedAction"`
+	TargetID          string                         `json:"targetId,omitempty"`
+	TargetUpdatedAt   string                         `json:"targetUpdatedAt,omitempty"`
+	TargetFingerprint string                         `json:"targetFingerprint,omitempty"`
+	MemberRecordKeys  []string                       `json:"memberRecordKeys"`
+	RowNumbers        []int                          `json:"rowNumbers,omitempty"`
+	Diagnostics       []TransferVehicleSetDiagnostic `json:"diagnostics,omitempty"`
+	Data              TransferVehicleSet             `json:"data"`
+}
+
+func ValidateTransferVehicleSet(set TransferVehicleSet) error {
+	if len(validateTransferVehicleSetStructure(set)) != 0 {
+		return ErrDataTransferValidation
+	}
+	return nil
+}
+
+func classifyDataTransferVehicleSets(
+	jobID string,
+	incoming DataTransferSnapshot,
+	current DataTransferSnapshot,
+	vehicleRecords []DataTransferPreviewRecord,
+) ([]DataTransferVehicleSetPreview, []DataTransferIssue) {
+	previews := make([]DataTransferVehicleSetPreview, 0, len(incoming.VehicleSets))
+	issues := []DataTransferIssue{}
+	vehiclesByID := map[string]TransferVehicle{}
+	vehiclesByInventory := map[string]TransferVehicle{}
+	recordsByID := map[string]DataTransferPreviewRecord{}
+	recordsByInventory := map[string]DataTransferPreviewRecord{}
+	for index, vehicle := range incoming.Vehicles {
+		if vehicle.ID != "" {
+			vehiclesByID[vehicle.ID] = vehicle
+		}
+		vehiclesByInventory[transferIdentity(vehicle.InventoryNumber)] = vehicle
+		if index < len(vehicleRecords) {
+			record := vehicleRecords[index]
+			if vehicle.ID != "" {
+				recordsByID[vehicle.ID] = record
+			}
+			recordsByInventory[transferIdentity(vehicle.InventoryNumber)] = record
+		}
+	}
+
+	currentSetsByInventory := map[string]TransferVehicleSet{}
+	for _, set := range current.VehicleSets {
+		currentSetsByInventory[transferIdentity(set.InventoryNumber)] = set
+	}
+	seenMembers := map[string]string{}
+	for index, set := range incoming.VehicleSets {
+		recordKey := transferVehicleSetRecordKey(set, index)
+		preview := DataTransferVehicleSetPreview{
+			RecordKey: recordKey, Classification: "ready", ProposedAction: "create", Data: set,
+		}
+		preview.Diagnostics = append(preview.Diagnostics, validateTransferVehicleSetStructure(set)...)
+		memberTargetIDs := make([]string, 0, len(set.Members))
+		for memberIndex, member := range set.Members {
+			if member.SourceRowNumber > 0 {
+				preview.RowNumbers = append(preview.RowNumbers, member.SourceRowNumber)
+			}
+			vehicle, record, found := resolveTransferVehicleSetMember(
+				member, vehiclesByID, vehiclesByInventory, recordsByID, recordsByInventory,
+			)
+			if !found {
+				preview.Diagnostics = append(preview.Diagnostics, TransferVehicleSetDiagnostic{
+					RowNumber: member.SourceRowNumber,
+					Field:     transferVehicleSetMemberField(memberIndex),
+					Code:      "missing_vehicle_set_member_reference",
+				})
+				continue
+			}
+			identity := transferVehicleSetMemberIdentity(vehicle)
+			if previousSet, duplicate := seenMembers[identity]; duplicate && previousSet != recordKey {
+				preview.Diagnostics = append(preview.Diagnostics, TransferVehicleSetDiagnostic{
+					RowNumber: member.SourceRowNumber,
+					Field:     transferVehicleSetMemberField(memberIndex),
+					Code:      "vehicle_set_member_in_multiple_sets",
+				})
+			} else if identity != "" {
+				seenMembers[identity] = recordKey
+			}
+			preview.MemberRecordKeys = append(preview.MemberRecordKeys, record.RecordKey)
+			if record.TargetID != "" {
+				memberTargetIDs = append(memberTargetIDs, record.TargetID)
+			}
+			if record.Classification == "error" {
+				preview.Diagnostics = append(preview.Diagnostics, TransferVehicleSetDiagnostic{
+					RowNumber: member.SourceRowNumber,
+					Field:     transferVehicleSetMemberField(memberIndex),
+					Code:      "invalid_vehicle_set_member",
+				})
+			}
+		}
+		slices.Sort(preview.RowNumbers)
+		preview.RowNumbers = slices.Compact(preview.RowNumbers)
+
+		start := len(issues)
+		for _, diagnostic := range preview.Diagnostics {
+			rowNumber := transferVehicleSetDiagnosticRow(diagnostic.RowNumber)
+			issues = append(issues, newTransferIssue(
+				jobID, TransferVehicles, recordKey, rowNumber, diagnostic.Field, TransferIssueError,
+				diagnostic.Code, transferVehicleSetDiagnosticMessage(diagnostic.Code), "",
+			))
+		}
+		if len(preview.Diagnostics) == 0 {
+			target, hasTarget := currentSetsByInventory[transferIdentity(set.InventoryNumber)]
+			targetMemberIDs := map[string]bool{}
+			if hasTarget {
+				for _, member := range target.Members {
+					targetMemberIDs[member.SourceVehicleID] = true
+				}
+			}
+			externalConflict := false
+			for _, targetID := range memberTargetIDs {
+				if !hasTarget || !targetMemberIDs[targetID] {
+					externalConflict = true
+					break
+				}
+			}
+			if externalConflict {
+				preview.ProposedAction = "copy"
+				issues = append(issues, newTransferIssue(
+					jobID, TransferVehicles, recordKey, nil, "members", TransferIssueWarning,
+					"vehicle_set_member_external_conflict",
+					"A set member conflicts with a vehicle outside the target set.", "copy",
+				))
+			} else if hasTarget {
+				preview.TargetID = target.ID
+				preview.TargetUpdatedAt = target.UpdatedAt
+				preview.TargetFingerprint = DataTransferTargetFingerprint(target)
+				preview.ProposedAction = "replace"
+				issues = append(issues, newTransferIssue(
+					jobID, TransferVehicles, recordKey, nil, "inventoryNumber", TransferIssueWarning,
+					"duplicate_vehicle_set_inventory_number", "Vehicle set inventory number already exists.",
+					"replace_or_copy",
+				))
+			}
+		}
+		finalizeDataTransferVehicleSetPreview(&preview, issues[start:])
+		previews = append(previews, preview)
+	}
+	return previews, issues
+}
+
+func validateTransferVehicleSetStructure(set TransferVehicleSet) []TransferVehicleSetDiagnostic {
+	diagnostics := slices.Clone(set.Diagnostics)
+	if strings.TrimSpace(set.InventoryNumber) == "" {
+		diagnostics = append(diagnostics, TransferVehicleSetDiagnostic{
+			Field: "inventoryNumber", Code: "missing_vehicle_set_inventory_number",
+		})
+	}
+	if !isValidVehicleSetInput(cleanVehicleSetInput(set.VehicleSetInput)) {
+		diagnostics = append(diagnostics, TransferVehicleSetDiagnostic{Field: "record", Code: "invalid_vehicle_set"})
+	}
+	if len(set.Members) < 2 {
+		diagnostics = append(diagnostics, TransferVehicleSetDiagnostic{Field: "members", Code: "vehicle_set_too_small"})
+	}
+	positions := make(map[int]bool, len(set.Members))
+	members := make(map[string]bool, len(set.Members))
+	for index, member := range set.Members {
+		field := transferVehicleSetMemberField(index)
+		if member.Position <= 0 {
+			diagnostics = append(diagnostics, TransferVehicleSetDiagnostic{
+				RowNumber: member.SourceRowNumber, Field: field + ".position", Code: "invalid_vehicle_set_position",
+			})
+		} else if positions[member.Position] {
+			diagnostics = append(diagnostics, TransferVehicleSetDiagnostic{
+				RowNumber: member.SourceRowNumber, Field: field + ".position", Code: "duplicate_vehicle_set_position",
+			})
+		}
+		positions[member.Position] = true
+		memberIdentity := transferIdentity(member.SourceVehicleID)
+		if memberIdentity == "" {
+			memberIdentity = transferIdentity(member.VehicleInventoryNumber)
+		}
+		if memberIdentity != "" && members[memberIdentity] {
+			diagnostics = append(diagnostics, TransferVehicleSetDiagnostic{
+				RowNumber: member.SourceRowNumber, Field: field, Code: "duplicate_vehicle_set_member",
+			})
+		}
+		members[memberIdentity] = true
+		if member.SourceRowNumber > 0 {
+			if member.DeclaredMemberCount != len(set.Members) {
+				diagnostics = append(diagnostics, TransferVehicleSetDiagnostic{
+					RowNumber: member.SourceRowNumber, Field: "vehicleSetMemberCount",
+					Code: "vehicle_set_member_count_mismatch",
+				})
+			}
+			if member.SourceSetInput != set.VehicleSetInput {
+				diagnostics = append(diagnostics, TransferVehicleSetDiagnostic{
+					RowNumber: member.SourceRowNumber, Field: "vehicleSet", Code: "conflicting_vehicle_set_metadata",
+				})
+			}
+		}
+	}
+	for position := 1; position <= len(set.Members); position++ {
+		if !positions[position] {
+			diagnostics = append(diagnostics, TransferVehicleSetDiagnostic{
+				Field: "members.position", Code: "non_contiguous_vehicle_set_positions",
+			})
+			break
+		}
+	}
+	return compactTransferVehicleSetDiagnostics(diagnostics)
+}
+
+func resolveTransferVehicleSetMember(
+	member TransferVehicleSetMember,
+	vehiclesByID map[string]TransferVehicle,
+	vehiclesByInventory map[string]TransferVehicle,
+	recordsByID map[string]DataTransferPreviewRecord,
+	recordsByInventory map[string]DataTransferPreviewRecord,
+) (TransferVehicle, DataTransferPreviewRecord, bool) {
+	if member.SourceVehicleID != "" {
+		vehicle, found := vehiclesByID[member.SourceVehicleID]
+		if !found || member.VehicleInventoryNumber != "" &&
+			transferIdentity(vehicle.InventoryNumber) != transferIdentity(member.VehicleInventoryNumber) {
+			return TransferVehicle{}, DataTransferPreviewRecord{}, false
+		}
+		return vehicle, recordsByID[member.SourceVehicleID], true
+	}
+	identity := transferIdentity(member.VehicleInventoryNumber)
+	vehicle, found := vehiclesByInventory[identity]
+	if !found || identity == "" {
+		return TransferVehicle{}, DataTransferPreviewRecord{}, false
+	}
+	return vehicle, recordsByInventory[identity], true
+}
+
+func transferVehicleSetRecordKey(set TransferVehicleSet, index int) string {
+	if strings.TrimSpace(set.ID) != "" {
+		return "vehicle-set:id:" + strings.TrimSpace(set.ID)
+	}
+	if identity := transferIdentity(set.InventoryNumber); identity != "" {
+		return "vehicle-set:inventory:" + identity
+	}
+	for _, member := range set.Members {
+		if member.SourceRowNumber > 0 {
+			return "vehicle-set:row:" + strconv.Itoa(member.SourceRowNumber)
+		}
+	}
+	return "vehicle-set:index:" + strconv.Itoa(index+1)
+}
+
+func transferVehicleSetMemberIdentity(vehicle TransferVehicle) string {
+	if vehicle.ID != "" {
+		return "id:" + vehicle.ID
+	}
+	return "inventory:" + transferIdentity(vehicle.InventoryNumber)
+}
+
+func transferVehicleSetMemberField(index int) string {
+	return fmt.Sprintf("members[%d]", index)
+}
+
+func transferVehicleSetDiagnosticRow(row int) *int {
+	if row <= 0 {
+		return nil
+	}
+	return &row
+}
+
+func compactTransferVehicleSetDiagnostics(
+	diagnostics []TransferVehicleSetDiagnostic,
+) []TransferVehicleSetDiagnostic {
+	seen := map[string]bool{}
+	result := make([]TransferVehicleSetDiagnostic, 0, len(diagnostics))
+	for _, diagnostic := range diagnostics {
+		key := fmt.Sprintf("%d\x00%s\x00%s", diagnostic.RowNumber, diagnostic.Field, diagnostic.Code)
+		if !seen[key] {
+			seen[key] = true
+			result = append(result, diagnostic)
+		}
+	}
+	return result
+}
+
+func transferVehicleSetDiagnosticMessage(code string) string {
+	messages := map[string]string{
+		"missing_vehicle_set_inventory_number": "Vehicle set inventory number is required.",
+		"invalid_vehicle_set":                  "Vehicle set data violates aggregate validation.",
+		"vehicle_set_too_small":                "A vehicle set requires at least two members.",
+		"invalid_vehicle_set_position":         "Vehicle set member position must be a positive integer.",
+		"duplicate_vehicle_set_position":       "Vehicle set member positions must be unique.",
+		"non_contiguous_vehicle_set_positions": "Vehicle set member positions must be contiguous.",
+		"invalid_vehicle_set_member_count":     "Vehicle set member count must be an integer.",
+		"vehicle_set_member_count_mismatch":    "Vehicle set member count does not match the detected group.",
+		"conflicting_vehicle_set_metadata":     "Vehicle set rows contain conflicting metadata.",
+		"duplicate_vehicle_set_member":         "A vehicle occurs more than once in the vehicle set.",
+		"vehicle_set_member_in_multiple_sets":  "A vehicle belongs to more than one imported set.",
+		"missing_vehicle_set_member_reference": "Referenced vehicle is missing from the import.",
+		"invalid_vehicle_set_member":           "A vehicle set member contains blocking validation errors.",
+	}
+	if message := messages[code]; message != "" {
+		return message
+	}
+	return "Vehicle set data is invalid."
+}
+
+func finalizeDataTransferVehicleSetPreview(
+	preview *DataTransferVehicleSetPreview,
+	issues []DataTransferIssue,
+) {
+	preview.Classification = "ready"
+	for _, issue := range issues {
+		if issue.Severity == TransferIssueError {
+			preview.Classification = "error"
+			return
+		}
+		if issue.Severity == TransferIssueWarning {
+			preview.Classification = "warning"
+		}
+	}
+}
+
+func suppressDataTransferVehicleSetMemberConflicts(
+	records []DataTransferPreviewRecord,
+	issues []DataTransferIssue,
+	vehicleSets []DataTransferVehicleSetPreview,
+) ([]DataTransferPreviewRecord, []DataTransferIssue) {
+	groupedMembers := map[string]bool{}
+	for _, set := range vehicleSets {
+		if set.Classification != "warning" {
+			continue
+		}
+		for _, recordKey := range set.MemberRecordKeys {
+			groupedMembers[recordKey] = true
+		}
+	}
+	if len(groupedMembers) == 0 {
+		return records, issues
+	}
+	filtered := make([]DataTransferIssue, 0, len(issues))
+	for _, issue := range issues {
+		if issue.Area == TransferVehicles && groupedMembers[issue.RecordKey] &&
+			issue.Code == "duplicate_inventory_number" {
+			continue
+		}
+		filtered = append(filtered, issue)
+	}
+	for index := range records {
+		if records[index].Area == TransferVehicles && groupedMembers[records[index].RecordKey] {
+			finalizeDataTransferRecord(&records[index], transferIssuesForPreviewRecord(filtered, records[index]))
+		}
+	}
+	return records, filtered
+}

--- a/backend/internal/application/data_transfer_vehicle_sets.go
+++ b/backend/internal/application/data_transfer_vehicle_sets.go
@@ -58,12 +58,21 @@ func classifyDataTransferVehicleSets(
 		currentSetsByInventory[transferIdentity(set.InventoryNumber)] = set
 	}
 	seenMembers := map[string]string{}
+	seenSetInventories := map[string]bool{}
 	for index, set := range incoming.VehicleSets {
 		recordKey := transferVehicleSetRecordKey(set, index)
 		preview := DataTransferVehicleSetPreview{
 			RecordKey: recordKey, Classification: "ready", ProposedAction: "create", Data: set,
 		}
 		preview.Diagnostics = append(preview.Diagnostics, validateTransferVehicleSetStructure(set)...)
+		setInventoryIdentity := transferIdentity(set.InventoryNumber)
+		if setInventoryIdentity != "" && seenSetInventories[setInventoryIdentity] {
+			preview.Diagnostics = append(preview.Diagnostics, TransferVehicleSetDiagnostic{
+				Field: "inventoryNumber", Code: "duplicate_import_vehicle_set_inventory_number",
+			})
+		} else if setInventoryIdentity != "" {
+			seenSetInventories[setInventoryIdentity] = true
+		}
 		memberTargetIDs := make([]string, 0, len(set.Members))
 		for memberIndex, member := range set.Members {
 			if member.SourceRowNumber > 0 {
@@ -291,20 +300,21 @@ func compactTransferVehicleSetDiagnostics(
 
 func transferVehicleSetDiagnosticMessage(code string) string {
 	messages := map[string]string{
-		"missing_vehicle_set_inventory_number": "Vehicle set inventory number is required.",
-		"invalid_vehicle_set":                  "Vehicle set data violates aggregate validation.",
-		"vehicle_set_too_small":                "A vehicle set requires at least two members.",
-		"vehicle_set_too_large":                "A vehicle set cannot contain more than 100 members.",
-		"invalid_vehicle_set_position":         "Vehicle set member position must be a positive integer.",
-		"duplicate_vehicle_set_position":       "Vehicle set member positions must be unique.",
-		"non_contiguous_vehicle_set_positions": "Vehicle set member positions must be contiguous.",
-		"invalid_vehicle_set_member_count":     "Vehicle set member count must be an integer.",
-		"vehicle_set_member_count_mismatch":    "Vehicle set member count does not match the detected group.",
-		"conflicting_vehicle_set_metadata":     "Vehicle set rows contain conflicting metadata.",
-		"duplicate_vehicle_set_member":         "A vehicle occurs more than once in the vehicle set.",
-		"vehicle_set_member_in_multiple_sets":  "A vehicle belongs to more than one imported set.",
-		"missing_vehicle_set_member_reference": "Referenced vehicle is missing from the import.",
-		"invalid_vehicle_set_member":           "A vehicle set member contains blocking validation errors.",
+		"missing_vehicle_set_inventory_number":          "Vehicle set inventory number is required.",
+		"duplicate_import_vehicle_set_inventory_number": "Vehicle set inventory number occurs more than once in the import.",
+		"invalid_vehicle_set":                           "Vehicle set data violates aggregate validation.",
+		"vehicle_set_too_small":                         "A vehicle set requires at least two members.",
+		"vehicle_set_too_large":                         "A vehicle set cannot contain more than 100 members.",
+		"invalid_vehicle_set_position":                  "Vehicle set member position must be a positive integer.",
+		"duplicate_vehicle_set_position":                "Vehicle set member positions must be unique.",
+		"non_contiguous_vehicle_set_positions":          "Vehicle set member positions must be contiguous.",
+		"invalid_vehicle_set_member_count":              "Vehicle set member count must be an integer.",
+		"vehicle_set_member_count_mismatch":             "Vehicle set member count does not match the detected group.",
+		"conflicting_vehicle_set_metadata":              "Vehicle set rows contain conflicting metadata.",
+		"duplicate_vehicle_set_member":                  "A vehicle occurs more than once in the vehicle set.",
+		"vehicle_set_member_in_multiple_sets":           "A vehicle belongs to more than one imported set.",
+		"missing_vehicle_set_member_reference":          "Referenced vehicle is missing from the import.",
+		"invalid_vehicle_set_member":                    "A vehicle set member contains blocking validation errors.",
 	}
 	if message := messages[code]; message != "" {
 		return message

--- a/backend/internal/application/data_transfer_vehicle_sets_test.go
+++ b/backend/internal/application/data_transfer_vehicle_sets_test.go
@@ -106,6 +106,20 @@ func TestClassifyDataTransferVehicleSetConflicts(t *testing.T) {
 		t.Fatalf("external member conflict preview = %#v", previews)
 	}
 	assertTransferIssueCode(t, issues, "vehicle_set_member_external_conflict")
+
+	current = validTransferVehicleSetSnapshot()
+	current.VehicleSets[0].ID = "target-set"
+	current.Vehicles[0].ID = "target-a"
+	current.Vehicles[1].ID = "target-b"
+	current.VehicleSets[0].Members = current.VehicleSets[0].Members[:1]
+	current.VehicleSets[0].Members[0].SourceVehicleID = "target-a"
+	records, _ = classifyDataTransferImport("job-target-external", incoming, current, nil)
+	previews, issues = classifyDataTransferVehicleSets("job-target-external", incoming, current, records)
+	if len(previews) != 1 || previews[0].ProposedAction != "copy" ||
+		previews[0].TargetID != "target-set" || previews[0].TargetFingerprint == "" {
+		t.Fatalf("target set external conflict preview = %#v", previews)
+	}
+	assertTransferIssueCode(t, issues, "vehicle_set_member_external_conflict")
 }
 
 func TestPreviewImportPersistsVehicleSetGroupsWithoutChangingRecordCounts(t *testing.T) {

--- a/backend/internal/application/data_transfer_vehicle_sets_test.go
+++ b/backend/internal/application/data_transfer_vehicle_sets_test.go
@@ -92,6 +92,34 @@ func TestClassifyDataTransferVehicleSetReadyAndCountsMembersOnly(t *testing.T) {
 	}
 }
 
+func TestClassifyDataTransferVehicleSetsRejectsDuplicateImportedInventoryNumbers(t *testing.T) {
+	incoming := validTransferVehicleSetSnapshot()
+	incoming.Vehicles = append(incoming.Vehicles,
+		TransferVehicle{ID: "source-c", InventoryNumber: "RK-C", Manufacturer: "Roco", Name: "Wagen C",
+			Gauge: "H0", Category: "Wagen", Gattung: "Reisezugwagen"},
+		TransferVehicle{ID: "source-d", InventoryNumber: "RK-D", Manufacturer: "Roco", Name: "Wagen D",
+			Gauge: "H0", Category: "Wagen", Gattung: "Reisezugwagen"},
+	)
+	setInput := incoming.VehicleSets[0].VehicleSetInput
+	incoming.VehicleSets = append(incoming.VehicleSets, TransferVehicleSet{
+		ID: "source-set-2", InventoryNumber: incoming.VehicleSets[0].InventoryNumber, VehicleSetInput: setInput,
+		Members: []TransferVehicleSetMember{
+			{SourceVehicleID: "source-c", VehicleInventoryNumber: "RK-C", Position: 1,
+				DeclaredMemberCount: 2, SourceSetInput: setInput},
+			{SourceVehicleID: "source-d", VehicleInventoryNumber: "RK-D", Position: 2,
+				DeclaredMemberCount: 2, SourceSetInput: setInput},
+		},
+	})
+	records, _ := classifyDataTransferImport("job-duplicate-set", incoming, DataTransferSnapshot{}, nil)
+	previews, issues := classifyDataTransferVehicleSets(
+		"job-duplicate-set", incoming, DataTransferSnapshot{}, records,
+	)
+	if len(previews) != 2 || previews[0].Classification != "ready" || previews[1].Classification != "error" {
+		t.Fatalf("set previews = %#v", previews)
+	}
+	assertTransferIssueCode(t, issues, "duplicate_import_vehicle_set_inventory_number")
+}
+
 func TestClassifyDataTransferVehicleSetConflicts(t *testing.T) {
 	incoming := validTransferVehicleSetSnapshot()
 	current := validTransferVehicleSetSnapshot()

--- a/backend/internal/application/data_transfer_vehicle_sets_test.go
+++ b/backend/internal/application/data_transfer_vehicle_sets_test.go
@@ -2,6 +2,7 @@ package application
 
 import (
 	"encoding/json"
+	"fmt"
 	"slices"
 	"testing"
 )
@@ -20,6 +21,15 @@ func TestClassifyDataTransferVehicleSetStructure(t *testing.T) {
 		}},
 		{name: "too small", code: "vehicle_set_too_small", edit: func(snapshot *DataTransferSnapshot) {
 			snapshot.VehicleSets[0].Members = snapshot.VehicleSets[0].Members[:1]
+		}},
+		{name: "too large", code: "vehicle_set_too_large", edit: func(snapshot *DataTransferSnapshot) {
+			members := make([]TransferVehicleSetMember, maxVehicleSetMembers+1)
+			for index := range members {
+				members[index] = TransferVehicleSetMember{
+					SourceVehicleID: fmt.Sprintf("source-%d", index), Position: index + 1,
+				}
+			}
+			snapshot.VehicleSets[0].Members = members
 		}},
 		{name: "duplicate position", code: "duplicate_vehicle_set_position", edit: func(snapshot *DataTransferSnapshot) {
 			snapshot.VehicleSets[0].Members[1].Position = 1

--- a/backend/internal/application/data_transfer_vehicle_sets_test.go
+++ b/backend/internal/application/data_transfer_vehicle_sets_test.go
@@ -1,0 +1,188 @@
+package application
+
+import (
+	"encoding/json"
+	"slices"
+	"testing"
+)
+
+func TestClassifyDataTransferVehicleSetStructure(t *testing.T) {
+	tests := []struct {
+		name string
+		code string
+		edit func(*DataTransferSnapshot)
+	}{
+		{name: "missing inventory number", code: "missing_vehicle_set_inventory_number", edit: func(snapshot *DataTransferSnapshot) {
+			snapshot.VehicleSets[0].InventoryNumber = ""
+		}},
+		{name: "invalid required metadata", code: "invalid_vehicle_set", edit: func(snapshot *DataTransferSnapshot) {
+			snapshot.VehicleSets[0].Name = ""
+		}},
+		{name: "too small", code: "vehicle_set_too_small", edit: func(snapshot *DataTransferSnapshot) {
+			snapshot.VehicleSets[0].Members = snapshot.VehicleSets[0].Members[:1]
+		}},
+		{name: "duplicate position", code: "duplicate_vehicle_set_position", edit: func(snapshot *DataTransferSnapshot) {
+			snapshot.VehicleSets[0].Members[1].Position = 1
+		}},
+		{name: "position gap", code: "non_contiguous_vehicle_set_positions", edit: func(snapshot *DataTransferSnapshot) {
+			snapshot.VehicleSets[0].Members[1].Position = 3
+		}},
+		{name: "member count mismatch", code: "vehicle_set_member_count_mismatch", edit: func(snapshot *DataTransferSnapshot) {
+			snapshot.VehicleSets[0].Members[0].DeclaredMemberCount = 3
+			snapshot.VehicleSets[0].Members[0].SourceRowNumber = 2
+		}},
+		{name: "conflicting CSV metadata", code: "conflicting_vehicle_set_metadata", edit: func(snapshot *DataTransferSnapshot) {
+			snapshot.VehicleSets[0].Members[1].SourceSetInput = snapshot.VehicleSets[0].VehicleSetInput
+			snapshot.VehicleSets[0].Members[1].SourceSetInput.Name = "Anderer Name"
+			snapshot.VehicleSets[0].Members[1].SourceRowNumber = 3
+		}},
+		{name: "duplicate member", code: "duplicate_vehicle_set_member", edit: func(snapshot *DataTransferSnapshot) {
+			snapshot.VehicleSets[0].Members[1].SourceVehicleID = "source-a"
+			snapshot.VehicleSets[0].Members[1].VehicleInventoryNumber = "RK-A"
+		}},
+		{name: "missing member reference", code: "missing_vehicle_set_member_reference", edit: func(snapshot *DataTransferSnapshot) {
+			snapshot.VehicleSets[0].Members[1].SourceVehicleID = "missing"
+			snapshot.VehicleSets[0].Members[1].VehicleInventoryNumber = "RK-MISSING"
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			incoming := validTransferVehicleSetSnapshot()
+			test.edit(&incoming)
+			records, _ := classifyDataTransferImport("job-set", incoming, DataTransferSnapshot{}, nil)
+			previews, issues := classifyDataTransferVehicleSets(
+				"job-set", incoming, DataTransferSnapshot{}, records,
+			)
+			if len(previews) != 1 || previews[0].Classification != "error" {
+				t.Fatalf("set previews = %#v", previews)
+			}
+			codes := make([]string, 0, len(issues))
+			for _, issue := range issues {
+				codes = append(codes, issue.Code)
+			}
+			if !slices.Contains(codes, test.code) {
+				t.Fatalf("issue codes = %#v, want %q", codes, test.code)
+			}
+		})
+	}
+}
+
+func TestClassifyDataTransferVehicleSetReadyAndCountsMembersOnly(t *testing.T) {
+	incoming := validTransferVehicleSetSnapshot()
+	records, vehicleIssues := classifyDataTransferImport("job-set", incoming, DataTransferSnapshot{}, nil)
+	previews, setIssues := classifyDataTransferVehicleSets("job-set", incoming, DataTransferSnapshot{}, records)
+	if len(vehicleIssues) != 0 || len(setIssues) != 0 || len(previews) != 1 ||
+		previews[0].Classification != "ready" || len(previews[0].MemberRecordKeys) != 2 {
+		t.Fatalf("valid set classification = records %#v, previews %#v, issues %#v/%#v",
+			records, previews, vehicleIssues, setIssues)
+	}
+	ready, warnings, failures := countDataTransferPreviewRecords(records)
+	if ready != 2 || warnings != 0 || failures != 0 {
+		t.Fatalf("vehicle record counts = %d/%d/%d", ready, warnings, failures)
+	}
+}
+
+func TestClassifyDataTransferVehicleSetConflicts(t *testing.T) {
+	incoming := validTransferVehicleSetSnapshot()
+	current := validTransferVehicleSetSnapshot()
+	current.VehicleSets[0].ID = "target-set"
+	current.VehicleSets[0].UpdatedAt = "2026-08-27T10:00:00Z"
+	current.Vehicles[0].ID = "target-a"
+	current.Vehicles[1].ID = "target-b"
+	current.VehicleSets[0].Members[0].SourceVehicleID = "target-a"
+	current.VehicleSets[0].Members[1].SourceVehicleID = "target-b"
+	records, _ := classifyDataTransferImport("job-set", incoming, current, nil)
+	previews, issues := classifyDataTransferVehicleSets("job-set", incoming, current, records)
+	if len(previews) != 1 || previews[0].TargetID != "target-set" ||
+		previews[0].TargetFingerprint == "" || previews[0].ProposedAction != "replace" {
+		t.Fatalf("duplicate set preview = %#v", previews)
+	}
+	assertTransferIssueCode(t, issues, "duplicate_vehicle_set_inventory_number")
+
+	current.VehicleSets = nil
+	records, _ = classifyDataTransferImport("job-external", incoming, current, nil)
+	previews, issues = classifyDataTransferVehicleSets("job-external", incoming, current, records)
+	if len(previews) != 1 || previews[0].ProposedAction != "copy" {
+		t.Fatalf("external member conflict preview = %#v", previews)
+	}
+	assertTransferIssueCode(t, issues, "vehicle_set_member_external_conflict")
+}
+
+func TestPreviewImportPersistsVehicleSetGroupsWithoutChangingRecordCounts(t *testing.T) {
+	repository, service := newDataTransferImportFixture(t)
+	job := fixtureCreateImportJob(t, service, TransferVehicles, TransferJSON)
+	incoming := validTransferVehicleSetSnapshot()
+	payload, err := json.Marshal(DataTransferPackage{
+		Format: DataTransferPackageFormat, Version: DataTransferPackageVersion,
+		Areas: DataTransferPackageAreas{Vehicles: incoming.Vehicles, VehicleSets: incoming.VehicleSets},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	preview, err := service.UploadAndPreview(t.Context(), job.ID, "vehicle-set.json", payload, "editor-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if preview.TotalRecords != 2 || preview.ReadyRecords != 2 || preview.WarningRecords != 0 ||
+		preview.ErrorRecords != 0 || len(preview.VehicleSets) != 1 ||
+		preview.VehicleSets[0].Classification != "ready" {
+		t.Fatalf("vehicle set preview = %#v", preview)
+	}
+	persisted, err := repository.GetJob(t.Context(), job.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded, err := json.Marshal(persisted.Preview)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if persisted.Preview["vehicleSets"] == nil || !json.Valid(encoded) {
+		t.Fatalf("persisted vehicle set preview = %s", encoded)
+	}
+}
+
+func TestVehicleSetConflictSuppressesMemberLevelDuplicateIssues(t *testing.T) {
+	incoming := validTransferVehicleSetSnapshot()
+	current := validTransferVehicleSetSnapshot()
+	current.VehicleSets[0].ID = "target-set"
+	current.Vehicles[0].ID = "target-a"
+	current.Vehicles[1].ID = "target-b"
+	current.VehicleSets[0].Members[0].SourceVehicleID = "target-a"
+	current.VehicleSets[0].Members[1].SourceVehicleID = "target-b"
+	records, issues := classifyDataTransferImport("job-set", incoming, current, nil)
+	sets, setIssues := classifyDataTransferVehicleSets("job-set", incoming, current, records)
+	issues = append(issues, setIssues...)
+	records, issues = suppressDataTransferVehicleSetMemberConflicts(records, issues, sets)
+	for _, issue := range issues {
+		if issue.Code == "duplicate_inventory_number" {
+			t.Fatalf("member conflict was not suppressed: %#v", issues)
+		}
+	}
+	assertTransferIssueCode(t, issues, "duplicate_vehicle_set_inventory_number")
+	if records[0].Classification != "ready" || records[1].Classification != "ready" {
+		t.Fatalf("member classifications = %#v", records)
+	}
+}
+
+func validTransferVehicleSetSnapshot() DataTransferSnapshot {
+	setInput := VehicleSetInput{
+		Name: "Rheingold", Manufacturer: "Roco", Gauge: "H0", Category: "Set", Gattung: "Reisezug",
+	}
+	return DataTransferSnapshot{
+		Vehicles: []TransferVehicle{
+			{ID: "source-a", InventoryNumber: "RK-A", Manufacturer: "Roco", Name: "Wagen A", Gauge: "H0",
+				Category: "Wagen", Gattung: "Reisezugwagen"},
+			{ID: "source-b", InventoryNumber: "RK-B", Manufacturer: "Roco", Name: "Wagen B", Gauge: "H0",
+				Category: "Wagen", Gattung: "Reisezugwagen"},
+		},
+		VehicleSets: []TransferVehicleSet{{
+			ID: "source-set", InventoryNumber: "Set-001", VehicleSetInput: setInput,
+			Members: []TransferVehicleSetMember{
+				{SourceVehicleID: "source-a", VehicleInventoryNumber: "RK-A", Position: 1,
+					DeclaredMemberCount: 2, SourceSetInput: setInput},
+				{SourceVehicleID: "source-b", VehicleInventoryNumber: "RK-B", Position: 2,
+					DeclaredMemberCount: 2, SourceSetInput: setInput},
+			},
+		}},
+	}
+}

--- a/backend/internal/infrastructure/data_transfer_apply.go
+++ b/backend/internal/infrastructure/data_transfer_apply.go
@@ -14,11 +14,12 @@ import (
 )
 
 type dataTransferPersistedPreview struct {
-	SourceSHA256       string                                     `json:"sourceSha256"`
-	FingerprintVersion int                                        `json:"fingerprintVersion,omitempty"`
-	Records            []application.DataTransferPreviewRecord    `json:"records"`
-	CSVMapping         []application.DataTransferCSVColumnMapping `json:"csvMapping,omitempty"`
-	VehicleFields      []application.VehicleTransferField         `json:"vehicleFields,omitempty"`
+	SourceSHA256       string                                      `json:"sourceSha256"`
+	FingerprintVersion int                                         `json:"fingerprintVersion,omitempty"`
+	Records            []application.DataTransferPreviewRecord     `json:"records"`
+	VehicleSets        []application.DataTransferVehicleSetPreview `json:"vehicleSets,omitempty"`
+	CSVMapping         []application.DataTransferCSVColumnMapping  `json:"csvMapping,omitempty"`
+	VehicleFields      []application.VehicleTransferField          `json:"vehicleFields,omitempty"`
 }
 
 type dataTransferApplyDB interface {
@@ -28,8 +29,14 @@ type dataTransferApplyDB interface {
 }
 
 type dataTransferApplyResult struct {
-	Applied int
-	Skipped int
+	Applied  int
+	Skipped  int
+	Vehicles map[string]transferVehicleApplyResult
+}
+
+type transferVehicleApplyResult struct {
+	ID              string
+	InventoryNumber string
 }
 
 func (repository *DataTransferRepository) ApplyImport(
@@ -58,8 +65,13 @@ func (repository *DataTransferRepository) ApplyImportWithPolicy(
 	if err != nil {
 		return err
 	}
-	result, err := applyTransferRecords(ctx, tx, job, preview.Records, preview.CSVMapping, issues, policy)
+	result, err := applyTransferRecords(
+		ctx, tx, job, preview.Records, preview.VehicleSets, preview.CSVMapping, issues, policy,
+	)
 	if err != nil {
+		return err
+	}
+	if err := applyTransferVehicleSets(ctx, tx, preview.VehicleSets, issues, result.Vehicles, actor); err != nil {
 		return err
 	}
 	now := timestamp()
@@ -135,6 +147,9 @@ FROM data_transfer_jobs WHERE id=?`, job.ID).Scan(
 			return dataTransferPersistedPreview{}, nil, dataTransferApplyConflict("import has unresolved conflicts")
 		}
 	}
+	if err := revalidateTransferVehicleSetPreview(ctx, tx, preview.VehicleSets, preview.Records, issues); err != nil {
+		return dataTransferPersistedPreview{}, nil, err
+	}
 	targetFingerprints, err := currentTransferTargetFingerprints(
 		ctx, tx, preview.Records, preview.FingerprintVersion,
 	)
@@ -182,21 +197,23 @@ WHERE job_id=? ORDER BY created_at, id`, jobID)
 
 func validTransferApplyResolution(code, resolution string) bool {
 	allowed := map[string]map[string]bool{
-		"missing_inventory_number":             {"skip": true},
-		"missing_manufacturer":                 {"skip": true},
-		"missing_name":                         {"skip": true},
-		"missing_gauge":                        {"skip": true},
-		"missing_category":                     {"skip": true},
-		"missing_gattung":                      {"skip": true},
-		"invalid_vehicle":                      {"skip": true},
-		"invalid_accessory":                    {"skip": true},
-		"duplicate_inventory_number":           {"replace": true, "copy": true, "skip": true},
-		"matching_manufacturer_article_number": {"use_existing": true, "create": true, "skip": true},
-		"duplicate_exhibition_list":            {"replace": true, "merge": true, "copy": true, "skip": true},
-		"locked_exhibition_list":               {"copy": true, "skip": true},
-		"exhibition_vehicle_reference":         {"link": true, "skip": true},
-		"missing_vehicle_reference":            {"skip": true},
-		"duplicate_input_inventory_number":     {"skip": true},
+		"missing_inventory_number":               {"skip": true},
+		"missing_manufacturer":                   {"skip": true},
+		"missing_name":                           {"skip": true},
+		"missing_gauge":                          {"skip": true},
+		"missing_category":                       {"skip": true},
+		"missing_gattung":                        {"skip": true},
+		"invalid_vehicle":                        {"skip": true},
+		"invalid_accessory":                      {"skip": true},
+		"duplicate_inventory_number":             {"replace": true, "copy": true, "skip": true},
+		"matching_manufacturer_article_number":   {"use_existing": true, "create": true, "skip": true},
+		"duplicate_exhibition_list":              {"replace": true, "merge": true, "copy": true, "skip": true},
+		"locked_exhibition_list":                 {"copy": true, "skip": true},
+		"exhibition_vehicle_reference":           {"link": true, "skip": true},
+		"missing_vehicle_reference":              {"skip": true},
+		"duplicate_input_inventory_number":       {"skip": true},
+		"duplicate_vehicle_set_inventory_number": {"replace": true, "copy": true, "skip": true},
+		"vehicle_set_member_external_conflict":   {"copy": true, "skip": true},
 	}
 	return allowed[code][resolution]
 }
@@ -255,16 +272,46 @@ func applyTransferRecords(
 	db *sql.Tx,
 	job application.DataTransferJob,
 	records []application.DataTransferPreviewRecord,
+	vehicleSets []application.DataTransferVehicleSetPreview,
 	csvMapping []application.DataTransferCSVColumnMapping,
 	issues []application.DataTransferIssue,
 	policy application.DataTransferImportPolicy,
 ) (dataTransferApplyResult, error) {
-	result := dataTransferApplyResult{}
+	_, memberPolicies, err := transferVehicleSetApplyPolicies(vehicleSets, issues)
+	if err != nil {
+		return dataTransferApplyResult{}, err
+	}
+	result := dataTransferApplyResult{Vehicles: map[string]transferVehicleApplyResult{}}
 	var csvVehicleTargets map[string]application.TransferVehicle
 	csvVehicleTargetsLoaded := false
 	for _, record := range records {
 		recordIssues := transferRecordIssues(issues, record)
 		action, skip := transferRecordAction(record, recordIssues)
+		if setPolicy, member := memberPolicies[record.RecordKey]; record.Area == application.TransferVehicles && member {
+			switch setPolicy.Action {
+			case "skip":
+				skip = true
+			case "copy":
+				if record.TargetID != "" {
+					action = "copy"
+				} else {
+					action = "create"
+				}
+			case "replace":
+				if record.TargetID != "" {
+					action = "replace"
+				} else {
+					action = "create"
+				}
+			case "create":
+				if record.TargetID != "" {
+					return dataTransferApplyResult{}, dataTransferApplyConflict(
+						"vehicle set member conflict has no group resolution",
+					)
+				}
+				action = "create"
+			}
+		}
 		if skip {
 			result.Skipped++
 			continue
@@ -294,9 +341,16 @@ func applyTransferRecords(
 					existingCSVVehicle = &existing
 				}
 			}
-			err = applyTransferVehicle(
+			vehicleResult, vehicleErr := applyTransferVehicle(
 				ctx, db, record, action, job.PackageVersion, csvMapping, existingCSVVehicle,
 			)
+			err = vehicleErr
+			if err == nil {
+				if _, duplicate := result.Vehicles[record.RecordKey]; duplicate {
+					return dataTransferApplyResult{}, dataTransferApplyConflict("duplicate vehicle record key")
+				}
+				result.Vehicles[record.RecordKey] = vehicleResult
+			}
 		case application.TransferAccessories:
 			err = applyTransferAccessory(ctx, db, record, action)
 		case application.TransferExhibitionLists:
@@ -366,25 +420,26 @@ func applyTransferVehicle(
 	packageVersion int,
 	csvMapping []application.DataTransferCSVColumnMapping,
 	existingCSVVehicle *application.TransferVehicle,
-) error {
+) (transferVehicleApplyResult, error) {
 	vehicle := application.TransferVehicle{}
 	if err := json.Unmarshal(record.Data, &vehicle); err != nil {
-		return dataTransferApplyConflict("vehicle preview data is invalid")
+		return transferVehicleApplyResult{}, dataTransferApplyConflict("vehicle preview data is invalid")
 	}
 	if err := application.ValidateTransferVehicle(vehicle); err != nil {
-		return dataTransferApplyConflict("vehicle preview data violates aggregate validation")
+		return transferVehicleApplyResult{}, dataTransferApplyConflict("vehicle preview data violates aggregate validation")
 	}
 	now := timestamp()
 	if action == "copy" {
 		inventoryNumber, err := uniqueTransferInventoryNumber(ctx, db, "vehicles", vehicle.InventoryNumber)
 		if err != nil {
-			return err
+			return transferVehicleApplyResult{}, err
 		}
 		vehicle.InventoryNumber = inventoryNumber
 		action = "create"
 	}
 	switch action {
 	case "create":
+		vehicleID := randomID()
 		arguments := transferVehicleArguments(vehicle, now)
 		_, err := db.ExecContext(ctx, `
 INSERT INTO vehicles(
@@ -400,11 +455,14 @@ INSERT INTO vehicles(
   smoke_generator_description, additional_info, qr_code_enabled, created_at, updated_at
 ) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
          ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-			append([]any{randomID()}, arguments...)...)
-		return err
+			append([]any{vehicleID}, arguments...)...)
+		if err != nil {
+			return transferVehicleApplyResult{}, err
+		}
+		return transferVehicleApplyResult{ID: vehicleID, InventoryNumber: vehicle.InventoryNumber}, nil
 	case "replace":
 		if record.TargetID == "" {
-			return dataTransferApplyConflict("vehicle replacement target is missing")
+			return transferVehicleApplyResult{}, dataTransferApplyConflict("vehicle replacement target is missing")
 		}
 		if packageVersion == application.DataTransferPackageLegacyVersion {
 			arguments := transferVehicleArguments(vehicle, now)
@@ -417,19 +475,22 @@ UPDATE vehicles SET inventory_number=?, manufacturer=?, article_number=?, articl
   condition_details=?, packaging=?, updated_at=?
 WHERE id=?`, append(append(arguments[0:35], now), record.TargetID)...)
 			if err != nil {
-				return err
+				return transferVehicleApplyResult{}, err
 			}
-			return requireApplyUpdate(result, "replace legacy vehicle")
+			if err := requireApplyUpdate(result, "replace legacy vehicle"); err != nil {
+				return transferVehicleApplyResult{}, err
+			}
+			return transferVehicleApplyResult{ID: record.TargetID, InventoryNumber: vehicle.InventoryNumber}, nil
 		}
 		if len(csvMapping) > 0 {
 			if existingCSVVehicle == nil {
-				return dataTransferApplyConflict("vehicle replacement target is missing")
+				return transferVehicleApplyResult{}, dataTransferApplyConflict("vehicle replacement target is missing")
 			}
 			merged, err := application.PreserveUnmappedTransferVehicleFields(
 				vehicle, *existingCSVVehicle, csvMapping,
 			)
 			if err != nil {
-				return err
+				return transferVehicleApplyResult{}, err
 			}
 			vehicle = merged
 		}
@@ -447,11 +508,14 @@ UPDATE vehicles SET inventory_number=?, manufacturer=?, article_number=?, articl
   smoke_generator_enabled=?, smoke_generator_description=?, additional_info=?, qr_code_enabled=?, updated_at=?
 WHERE id=?`, append(append(arguments[0:62], now), record.TargetID)...)
 		if err != nil {
-			return err
+			return transferVehicleApplyResult{}, err
 		}
-		return requireApplyUpdate(result, "replace vehicle")
+		if err := requireApplyUpdate(result, "replace vehicle"); err != nil {
+			return transferVehicleApplyResult{}, err
+		}
+		return transferVehicleApplyResult{ID: record.TargetID, InventoryNumber: vehicle.InventoryNumber}, nil
 	default:
-		return dataTransferApplyConflict("unsupported vehicle resolution")
+		return transferVehicleApplyResult{}, dataTransferApplyConflict("unsupported vehicle resolution")
 	}
 }
 
@@ -1007,6 +1071,7 @@ func uniqueTransferInventoryNumber(
 ) (string, error) {
 	query := map[string]string{
 		"vehicles":           `SELECT EXISTS(SELECT 1 FROM vehicles WHERE inventory_number=? COLLATE NOCASE)`,
+		"vehicle_sets":       `SELECT EXISTS(SELECT 1 FROM vehicle_sets WHERE inventory_number=? COLLATE NOCASE)`,
 		"accessory_products": `SELECT EXISTS(SELECT 1 FROM accessory_products WHERE inventory_number=? COLLATE NOCASE)`,
 		"accessory_assets":   `SELECT EXISTS(SELECT 1 FROM accessory_assets WHERE inventory_number=? COLLATE NOCASE)`,
 	}[table]

--- a/backend/internal/infrastructure/data_transfer_apply.go
+++ b/backend/internal/infrastructure/data_transfer_apply.go
@@ -71,7 +71,9 @@ func (repository *DataTransferRepository) ApplyImportWithPolicy(
 	if err != nil {
 		return err
 	}
-	if err := applyTransferVehicleSets(ctx, tx, preview.VehicleSets, issues, result.Vehicles, actor); err != nil {
+	if err := applyTransferVehicleSets(
+		ctx, tx, preview.VehicleSets, preview.CSVMapping, issues, result.Vehicles, actor,
+	); err != nil {
 		return err
 	}
 	now := timestamp()

--- a/backend/internal/infrastructure/data_transfer_apply_vehicle_sets_test.go
+++ b/backend/internal/infrastructure/data_transfer_apply_vehicle_sets_test.go
@@ -99,6 +99,70 @@ func TestDataTransferApplyReplacesVehicleSetAndDetachesMissingMembers(t *testing
 	}
 }
 
+func TestDataTransferApplyCSVReplacePreservesUnmappedVehicleSetFields(t *testing.T) {
+	db := testDB(t)
+	repository := infrastructure.NewDataTransferRepository(db)
+	insertApplyVehicleSet(t, db, "target-set", "RK-SET-CSV", []applyVehicleSetMemberFixture{
+		{ID: "target-a", InventoryNumber: "RK-CSV-A", Position: 1},
+		{ID: "target-old", InventoryNumber: "RK-CSV-OLD", Position: 2},
+	})
+	if _, err := db.Exec(`
+UPDATE vehicle_sets
+SET description='Lokale Beschreibung', storage_location='Vitrine 7'
+WHERE id='target-set'`); err != nil {
+		t.Fatal(err)
+	}
+	targetSet, targetVehicles := applyVehicleSetSnapshot(t, repository, "target-set")
+	records, setPreview := applyVehicleSetPreview(t, "RK-SET-CSV", "RK-CSV-A", "RK-CSV-B")
+	records[0].ProposedAction = "replace"
+	records[0].TargetID = "target-a"
+	records[0].TargetFingerprint = application.DataTransferTargetFingerprint(targetVehicles["RK-CSV-A"])
+	setPreview.Classification = "warning"
+	setPreview.ProposedAction = "replace"
+	setPreview.TargetID = targetSet.ID
+	setPreview.TargetFingerprint = application.DataTransferTargetFingerprint(targetSet)
+	setPreview.Data.Name = "CSV-Name"
+	job := createApplyJobWithVehicleSets(
+		t, repository, "sha-set-csv-preserve", records, []application.DataTransferVehicleSetPreview{setPreview},
+	)
+	job.Preview["csvMapping"] = []application.DataTransferCSVColumnMapping{
+		{TargetField: "inventoryNumber"},
+		{TargetField: "manufacturer"},
+		{TargetField: "name"},
+		{TargetField: "gauge"},
+		{TargetField: "category"},
+		{TargetField: "gattung"},
+		{TargetField: "vehicleSetInventoryNumber"},
+		{TargetField: "vehicleSetName"},
+		{TargetField: "vehicleSetManufacturer"},
+		{TargetField: "vehicleSetGauge"},
+		{TargetField: "vehicleSetCategory"},
+		{TargetField: "vehicleSetGattung"},
+	}
+	var err error
+	job, err = repository.UpdateJob(t.Context(), job)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolveApplyVehicleSetIssue(
+		t, repository, job.ID, setPreview, "duplicate_vehicle_set_inventory_number", "replace",
+	)
+
+	if err := repository.ApplyImport(t.Context(), job, "editor-1"); err != nil {
+		t.Fatal(err)
+	}
+	var name, description, storageLocation string
+	if err := db.QueryRow(`
+SELECT name, description, storage_location FROM vehicle_sets WHERE id='target-set'`).Scan(
+		&name, &description, &storageLocation,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if name != "CSV-Name" || description != "Lokale Beschreibung" || storageLocation != "Vitrine 7" {
+		t.Fatalf("CSV replace set fields = %q/%q/%q", name, description, storageLocation)
+	}
+}
+
 func TestDataTransferApplyCopiesVehicleSetWithoutReusingMembers(t *testing.T) {
 	db := testDB(t)
 	repository := infrastructure.NewDataTransferRepository(db)

--- a/backend/internal/infrastructure/data_transfer_apply_vehicle_sets_test.go
+++ b/backend/internal/infrastructure/data_transfer_apply_vehicle_sets_test.go
@@ -1,0 +1,393 @@
+package infrastructure_test
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"railkeeper/backend/internal/application"
+	"railkeeper/backend/internal/infrastructure"
+)
+
+func TestDataTransferApplyCreatesVehicleSetAtomically(t *testing.T) {
+	db := testDB(t)
+	repository := infrastructure.NewDataTransferRepository(db)
+	records, setPreview := applyVehicleSetPreview(t, "RK-SET-IMPORT", "RK-SET-A", "RK-SET-B")
+	job := createApplyJobWithVehicleSets(t, repository, "sha-set-create", records, []application.DataTransferVehicleSetPreview{setPreview})
+
+	if err := repository.ApplyImport(t.Context(), job, "editor-1"); err != nil {
+		t.Fatal(err)
+	}
+	var setCount, vehicleCount, memberCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM vehicle_sets WHERE inventory_number='RK-SET-IMPORT'`).Scan(&setCount); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM vehicles WHERE inventory_number IN ('RK-SET-A', 'RK-SET-B')`).Scan(&vehicleCount); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`
+SELECT COUNT(*) FROM vehicle_set_members member
+JOIN vehicle_sets vehicle_set ON vehicle_set.id=member.vehicle_set_id
+WHERE vehicle_set.inventory_number='RK-SET-IMPORT' AND member.position IN (1, 2)`).Scan(&memberCount); err != nil {
+		t.Fatal(err)
+	}
+	if setCount != 1 || vehicleCount != 2 || memberCount != 2 {
+		t.Fatalf("created set/vehicles/members = %d/%d/%d", setCount, vehicleCount, memberCount)
+	}
+}
+
+func TestDataTransferApplyRollsBackIncompleteVehicleSet(t *testing.T) {
+	db := testDB(t)
+	repository := infrastructure.NewDataTransferRepository(db)
+	records, setPreview := applyVehicleSetPreview(t, "RK-SET-ROLLBACK", "RK-ROLLBACK-A", "RK-ROLLBACK-B")
+	setPreview.MemberRecordKeys[1] = "missing-record"
+	job := createApplyJobWithVehicleSets(t, repository, "sha-set-rollback", records, []application.DataTransferVehicleSetPreview{setPreview})
+
+	err := repository.ApplyImport(t.Context(), job, "editor-1")
+	if !errors.Is(err, application.ErrDataTransferConflict) {
+		t.Fatalf("ApplyImport() error = %v, want conflict", err)
+	}
+	for _, table := range []string{"vehicles", "vehicle_sets", "vehicle_set_members"} {
+		var count int
+		if err := db.QueryRow("SELECT COUNT(*) FROM " + table).Scan(&count); err != nil {
+			t.Fatal(err)
+		}
+		if count != 0 {
+			t.Fatalf("%s count after rollback = %d", table, count)
+		}
+	}
+	assertApplyJobStillReady(t, repository, job.ID)
+}
+
+func TestDataTransferApplyReplacesVehicleSetAndDetachesMissingMembers(t *testing.T) {
+	db := testDB(t)
+	repository := infrastructure.NewDataTransferRepository(db)
+	insertApplyVehicleSet(t, db, "target-set", "RK-SET-REPLACE", []applyVehicleSetMemberFixture{
+		{ID: "target-a", InventoryNumber: "RK-REPLACE-A", Position: 1},
+		{ID: "target-old", InventoryNumber: "RK-REPLACE-OLD", Position: 2},
+	})
+	targetSet, targetVehicles := applyVehicleSetSnapshot(t, repository, "target-set")
+	records, setPreview := applyVehicleSetPreview(t, "RK-SET-REPLACE", "RK-REPLACE-A", "RK-REPLACE-B")
+	records[0].ProposedAction = "replace"
+	records[0].TargetID = "target-a"
+	records[0].TargetFingerprint = application.DataTransferTargetFingerprint(targetVehicles["RK-REPLACE-A"])
+	setPreview.Classification = "warning"
+	setPreview.ProposedAction = "replace"
+	setPreview.TargetID = targetSet.ID
+	setPreview.TargetFingerprint = application.DataTransferTargetFingerprint(targetSet)
+	setPreview.Data.Name = "Rheingold aktualisiert"
+	job := createApplyJobWithVehicleSets(t, repository, "sha-set-replace", records, []application.DataTransferVehicleSetPreview{setPreview})
+	resolveApplyVehicleSetIssue(t, repository, job.ID, setPreview, "duplicate_vehicle_set_inventory_number", "replace")
+
+	if err := repository.ApplyImport(t.Context(), job, "editor-1"); err != nil {
+		t.Fatal(err)
+	}
+	var name string
+	if err := db.QueryRow(`SELECT name FROM vehicle_sets WHERE id='target-set'`).Scan(&name); err != nil {
+		t.Fatal(err)
+	}
+	var importedMembers, detachedVehicle int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM vehicle_set_members WHERE vehicle_set_id='target-set'`).Scan(&importedMembers); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM vehicles WHERE id='target-old'`).Scan(&detachedVehicle); err != nil {
+		t.Fatal(err)
+	}
+	if name != "Rheingold aktualisiert" || importedMembers != 2 || detachedVehicle != 1 {
+		t.Fatalf("replace result name/members/detached = %q/%d/%d", name, importedMembers, detachedVehicle)
+	}
+}
+
+func TestDataTransferApplyCopiesVehicleSetWithoutReusingMembers(t *testing.T) {
+	db := testDB(t)
+	repository := infrastructure.NewDataTransferRepository(db)
+	insertApplyVehicleSet(t, db, "target-set", "RK-SET-COPY", []applyVehicleSetMemberFixture{
+		{ID: "target-a", InventoryNumber: "RK-COPY-A", Position: 1},
+		{ID: "target-b", InventoryNumber: "RK-COPY-B", Position: 2},
+	})
+	targetSet, targetVehicles := applyVehicleSetSnapshot(t, repository, "target-set")
+	records, setPreview := applyVehicleSetPreview(t, "RK-SET-COPY", "RK-COPY-A", "RK-COPY-B")
+	for index, inventoryNumber := range []string{"RK-COPY-A", "RK-COPY-B"} {
+		records[index].ProposedAction = "replace"
+		records[index].TargetID = targetVehicles[inventoryNumber].ID
+		records[index].TargetFingerprint = application.DataTransferTargetFingerprint(targetVehicles[inventoryNumber])
+	}
+	setPreview.Classification = "warning"
+	setPreview.ProposedAction = "replace"
+	setPreview.TargetID = targetSet.ID
+	setPreview.TargetFingerprint = application.DataTransferTargetFingerprint(targetSet)
+	job := createApplyJobWithVehicleSets(t, repository, "sha-set-copy", records, []application.DataTransferVehicleSetPreview{setPreview})
+	resolveApplyVehicleSetIssue(t, repository, job.ID, setPreview, "duplicate_vehicle_set_inventory_number", "copy")
+
+	if err := repository.ApplyImport(t.Context(), job, "editor-1"); err != nil {
+		t.Fatal(err)
+	}
+	var sets, vehicles, originalMembers, copiedMembers int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM vehicle_sets`).Scan(&sets); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM vehicles`).Scan(&vehicles); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM vehicle_set_members WHERE vehicle_set_id='target-set'`).Scan(&originalMembers); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`
+SELECT COUNT(*) FROM vehicle_set_members member
+JOIN vehicle_sets vehicle_set ON vehicle_set.id=member.vehicle_set_id
+WHERE vehicle_set.inventory_number='RK-SET-COPY-COPY'`).Scan(&copiedMembers); err != nil {
+		t.Fatal(err)
+	}
+	if sets != 2 || vehicles != 4 || originalMembers != 2 || copiedMembers != 2 {
+		t.Fatalf("copy result sets/vehicles/original/copied = %d/%d/%d/%d", sets, vehicles, originalMembers, copiedMembers)
+	}
+}
+
+func TestDataTransferApplySkipsVehicleSetAsGroup(t *testing.T) {
+	db := testDB(t)
+	repository := infrastructure.NewDataTransferRepository(db)
+	insertApplyVehicleSet(t, db, "target-set", "RK-SET-SKIP", []applyVehicleSetMemberFixture{
+		{ID: "target-a", InventoryNumber: "RK-SKIP-A", Position: 1},
+		{ID: "target-b", InventoryNumber: "RK-SKIP-B", Position: 2},
+	})
+	targetSet, targetVehicles := applyVehicleSetSnapshot(t, repository, "target-set")
+	records, setPreview := applyVehicleSetPreview(t, "RK-SET-SKIP", "RK-SKIP-A", "RK-SKIP-B")
+	for index, inventoryNumber := range []string{"RK-SKIP-A", "RK-SKIP-B"} {
+		records[index].ProposedAction = "replace"
+		records[index].TargetID = targetVehicles[inventoryNumber].ID
+		records[index].TargetFingerprint = application.DataTransferTargetFingerprint(targetVehicles[inventoryNumber])
+	}
+	setPreview.Classification = "warning"
+	setPreview.ProposedAction = "replace"
+	setPreview.TargetID = targetSet.ID
+	setPreview.TargetFingerprint = application.DataTransferTargetFingerprint(targetSet)
+	setPreview.Data.Name = "Darf nicht gespeichert werden"
+	job := createApplyJobWithVehicleSets(t, repository, "sha-set-skip", records, []application.DataTransferVehicleSetPreview{setPreview})
+	resolveApplyVehicleSetIssue(t, repository, job.ID, setPreview, "duplicate_vehicle_set_inventory_number", "skip")
+
+	if err := repository.ApplyImport(t.Context(), job, "editor-1"); err != nil {
+		t.Fatal(err)
+	}
+	var name string
+	if err := db.QueryRow(`SELECT name FROM vehicle_sets WHERE id='target-set'`).Scan(&name); err != nil {
+		t.Fatal(err)
+	}
+	var sets, vehicles int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM vehicle_sets`).Scan(&sets); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM vehicles`).Scan(&vehicles); err != nil {
+		t.Fatal(err)
+	}
+	if name != "Bestehendes Set" || sets != 1 || vehicles != 2 {
+		t.Fatalf("skip result name/sets/vehicles = %q/%d/%d", name, sets, vehicles)
+	}
+}
+
+func TestDataTransferApplyRejectsUnsafeExternalVehicleSetConflict(t *testing.T) {
+	db := testDB(t)
+	repository := infrastructure.NewDataTransferRepository(db)
+	insertApplyVehicleSet(t, db, "target-set", "RK-SET-EXTERNAL", []applyVehicleSetMemberFixture{
+		{ID: "target-a", InventoryNumber: "RK-EXTERNAL-A", Position: 1},
+		{ID: "target-old", InventoryNumber: "RK-EXTERNAL-OLD", Position: 2},
+	})
+	insertApplyVehicle(t, db, "outside-b", "RK-EXTERNAL-B")
+	targetSet, targetVehicles := applyVehicleSetSnapshot(t, repository, "target-set")
+	outside := applyVehicleSnapshot(t, repository, "RK-EXTERNAL-B")
+	records, setPreview := applyVehicleSetPreview(t, "RK-SET-EXTERNAL", "RK-EXTERNAL-A", "RK-EXTERNAL-B")
+	records[0].ProposedAction = "replace"
+	records[0].TargetID = targetVehicles["RK-EXTERNAL-A"].ID
+	records[0].TargetFingerprint = application.DataTransferTargetFingerprint(targetVehicles["RK-EXTERNAL-A"])
+	records[1].ProposedAction = "replace"
+	records[1].TargetID = outside.ID
+	records[1].TargetFingerprint = application.DataTransferTargetFingerprint(outside)
+	setPreview.Classification = "warning"
+	setPreview.ProposedAction = "copy"
+	setPreview.TargetID = targetSet.ID
+	setPreview.TargetFingerprint = application.DataTransferTargetFingerprint(targetSet)
+	job := createApplyJobWithVehicleSets(t, repository, "sha-set-external", records, []application.DataTransferVehicleSetPreview{setPreview})
+	resolveApplyVehicleSetIssue(t, repository, job.ID, setPreview, "vehicle_set_member_external_conflict", "replace")
+
+	err := repository.ApplyImport(t.Context(), job, "editor-1")
+	if !errors.Is(err, application.ErrDataTransferConflict) {
+		t.Fatalf("ApplyImport() error = %v, want conflict", err)
+	}
+	var sets, vehicles int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM vehicle_sets`).Scan(&sets); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM vehicles`).Scan(&vehicles); err != nil {
+		t.Fatal(err)
+	}
+	if sets != 1 || vehicles != 3 {
+		t.Fatalf("external conflict changed sets/vehicles = %d/%d", sets, vehicles)
+	}
+	assertApplyJobStillReady(t, repository, job.ID)
+}
+
+func applyVehicleSetPreview(
+	t *testing.T,
+	setInventoryNumber string,
+	firstInventoryNumber string,
+	secondInventoryNumber string,
+) ([]application.DataTransferPreviewRecord, application.DataTransferVehicleSetPreview) {
+	t.Helper()
+	records := []application.DataTransferPreviewRecord{
+		applyVehicleRecordWithID(t, "source-a", firstInventoryNumber),
+		applyVehicleRecordWithID(t, "source-b", secondInventoryNumber),
+	}
+	set := application.TransferVehicleSet{
+		ID: "source-set", InventoryNumber: setInventoryNumber,
+		VehicleSetInput: application.VehicleSetInput{
+			Name: "Rheingold", Manufacturer: "Roco", Gauge: "H0", Category: "Set", Gattung: "Reisezug",
+		},
+		Members: []application.TransferVehicleSetMember{
+			{SourceVehicleID: "source-a", VehicleInventoryNumber: firstInventoryNumber, Position: 1, Label: "A"},
+			{SourceVehicleID: "source-b", VehicleInventoryNumber: secondInventoryNumber, Position: 2, Label: "B"},
+		},
+	}
+	return records, application.DataTransferVehicleSetPreview{
+		RecordKey: "vehicle-set:id:source-set", Classification: "ready", ProposedAction: "create",
+		MemberRecordKeys: []string{firstInventoryNumber, secondInventoryNumber}, Data: set,
+	}
+}
+
+func applyVehicleRecordWithID(
+	t *testing.T,
+	sourceID string,
+	inventoryNumber string,
+) application.DataTransferPreviewRecord {
+	t.Helper()
+	data, err := json.Marshal(application.TransferVehicle{
+		ID: sourceID, InventoryNumber: inventoryNumber, Manufacturer: "Roco", Name: inventoryNumber,
+		Gauge: "H0", Category: "Wagen", Gattung: "Reisezugwagen",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return application.DataTransferPreviewRecord{
+		Area: application.TransferVehicles, RecordKey: inventoryNumber, Classification: "ready",
+		ProposedAction: "create", Data: data,
+	}
+}
+
+func createApplyJobWithVehicleSets(
+	t *testing.T,
+	repository *infrastructure.DataTransferRepository,
+	sourceSHA string,
+	records []application.DataTransferPreviewRecord,
+	sets []application.DataTransferVehicleSetPreview,
+) application.DataTransferJob {
+	t.Helper()
+	job := createApplyJob(t, repository, sourceSHA, records)
+	job.Preview["vehicleSets"] = sets
+	updated, err := repository.UpdateJob(t.Context(), job)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return updated
+}
+
+type applyVehicleSetMemberFixture struct {
+	ID              string
+	InventoryNumber string
+	Position        int
+}
+
+func insertApplyVehicleSet(
+	t *testing.T,
+	db *sql.DB,
+	setID string,
+	inventoryNumber string,
+	members []applyVehicleSetMemberFixture,
+) {
+	t.Helper()
+	for _, member := range members {
+		insertApplyVehicle(t, db, member.ID, member.InventoryNumber)
+	}
+	if _, err := db.Exec(`
+INSERT INTO vehicle_sets(
+  id, inventory_number, name, manufacturer, gauge, category, gattung, created_at, updated_at
+) VALUES(?, ?, 'Bestehendes Set', 'Roco', 'H0', 'Set', 'Reisezug',
+  '2026-08-27T10:00:00Z', '2026-08-27T10:00:00Z')`, setID, inventoryNumber); err != nil {
+		t.Fatal(err)
+	}
+	for _, member := range members {
+		if _, err := db.Exec(`
+INSERT INTO vehicle_set_members(vehicle_set_id, vehicle_id, position, label)
+VALUES(?, ?, ?, '')`, setID, member.ID, member.Position); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func insertApplyVehicle(t *testing.T, db *sql.DB, id string, inventoryNumber string) {
+	t.Helper()
+	if _, err := db.Exec(`
+INSERT INTO vehicles(
+  id, inventory_number, manufacturer, name, gauge, category, gattung, created_at, updated_at
+) VALUES(?, ?, 'Roco', ?, 'H0', 'Wagen', 'Reisezugwagen',
+  '2026-08-27T10:00:00Z', '2026-08-27T10:00:00Z')`, id, inventoryNumber, inventoryNumber); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func applyVehicleSetSnapshot(
+	t *testing.T,
+	repository *infrastructure.DataTransferRepository,
+	setID string,
+) (application.TransferVehicleSet, map[string]application.TransferVehicle) {
+	t.Helper()
+	snapshot, err := repository.Snapshot(t.Context(), []application.TransferArea{application.TransferVehicles})
+	if err != nil {
+		t.Fatal(err)
+	}
+	vehicles := make(map[string]application.TransferVehicle, len(snapshot.Vehicles))
+	for _, vehicle := range snapshot.Vehicles {
+		vehicles[vehicle.InventoryNumber] = vehicle
+	}
+	for _, set := range snapshot.VehicleSets {
+		if set.ID == setID {
+			return set, vehicles
+		}
+	}
+	t.Fatalf("vehicle set %q not found", setID)
+	return application.TransferVehicleSet{}, nil
+}
+
+func applyVehicleSnapshot(
+	t *testing.T,
+	repository *infrastructure.DataTransferRepository,
+	inventoryNumber string,
+) application.TransferVehicle {
+	t.Helper()
+	snapshot, err := repository.Snapshot(t.Context(), []application.TransferArea{application.TransferVehicles})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, vehicle := range snapshot.Vehicles {
+		if vehicle.InventoryNumber == inventoryNumber {
+			return vehicle
+		}
+	}
+	t.Fatalf("vehicle %q not found", inventoryNumber)
+	return application.TransferVehicle{}
+}
+
+func resolveApplyVehicleSetIssue(
+	t *testing.T,
+	repository *infrastructure.DataTransferRepository,
+	jobID string,
+	preview application.DataTransferVehicleSetPreview,
+	code string,
+	resolution string,
+) {
+	t.Helper()
+	if err := repository.ReplaceIssues(t.Context(), jobID, []application.DataTransferIssue{{
+		JobID: jobID, Area: application.TransferVehicles, RecordKey: preview.RecordKey,
+		Severity: application.TransferIssueWarning, Code: code, SelectedResolution: resolution,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/backend/internal/infrastructure/data_transfer_snapshot.go
+++ b/backend/internal/infrastructure/data_transfer_snapshot.go
@@ -25,6 +25,9 @@ func (repository *DataTransferRepository) Snapshot(
 		switch area {
 		case application.TransferVehicles:
 			snapshot.Vehicles, err = transferVehicleSnapshot(ctx, tx)
+			if err == nil {
+				snapshot.VehicleSets, err = transferVehicleSetSnapshot(ctx, tx)
+			}
 		case application.TransferAccessories:
 			snapshot.Accessories, err = transferAccessorySnapshot(ctx, tx)
 		case application.TransferExhibitionLists:

--- a/backend/internal/infrastructure/data_transfer_snapshot_test.go
+++ b/backend/internal/infrastructure/data_transfer_snapshot_test.go
@@ -167,6 +167,55 @@ INSERT INTO vehicles(
 	}
 }
 
+func TestDataTransferSnapshotIncludesVehicleSets(t *testing.T) {
+	db := testDB(t)
+	for _, statement := range []string{
+		`INSERT INTO vehicles(id, inventory_number, manufacturer, name, gauge, category, gattung, created_at, updated_at)
+         VALUES('vehicle-a', 'RK-A', 'Roco', 'Wagen A', 'H0', 'Wagen', 'Reisezugwagen',
+           '2026-08-27T10:00:00Z', '2026-08-27T10:00:00Z')`,
+		`INSERT INTO vehicles(id, inventory_number, manufacturer, name, gauge, category, gattung, created_at, updated_at)
+         VALUES('vehicle-b', 'RK-B', 'Roco', 'Wagen B', 'H0', 'Wagen', 'Reisezugwagen',
+           '2026-08-27T10:00:00Z', '2026-08-27T10:00:00Z')`,
+		`INSERT INTO vehicle_sets(
+           id, inventory_number, name, manufacturer, article_number, article_source_url, gauge, epoch,
+           railway_company, category, gattung, description, ean, production_period, list_price,
+           acquisition_type, acquired_from, purchase_price, purchase_date, storage_location,
+           storage_details, condition, condition_details, packaging, created_at, updated_at
+         ) VALUES(
+           'set-1', 'Set-001', 'Rheingold', 'Roco', '43000', 'https://example.invalid/43000', 'H0', 'III',
+           'DB', 'Set', 'Reisezug', 'Komplettzug', '4000000000001', '2020', '499.00',
+           'purchase', 'Fachhandel', '450.00', '2026-08-01', 'Vitrine', 'Fach 2',
+           'very_good', 'Vollständig', 'original', '2026-08-27T10:00:00Z', '2026-08-27T10:00:00Z'
+         )`,
+		`INSERT INTO vehicle_set_members(vehicle_set_id, vehicle_id, position, label)
+         VALUES('set-1', 'vehicle-b', 2, 'Speisewagen')`,
+		`INSERT INTO vehicle_set_members(vehicle_set_id, vehicle_id, position, label)
+         VALUES('set-1', 'vehicle-a', 1, 'Steuerwagen')`,
+	} {
+		if _, err := db.Exec(statement); err != nil {
+			t.Fatal(err)
+		}
+	}
+	repository := infrastructure.NewDataTransferRepository(db)
+	snapshot, err := repository.Snapshot(t.Context(), []application.TransferArea{application.TransferVehicles})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snapshot.VehicleSets) != 1 || len(snapshot.VehicleSets[0].Members) != 2 {
+		t.Fatalf("vehicle sets = %#v", snapshot.VehicleSets)
+	}
+	set := snapshot.VehicleSets[0]
+	if set.InventoryNumber != "Set-001" || set.Name != "Rheingold" || set.ArticleNumber != "43000" ||
+		set.StorageLocation != "Vitrine" {
+		t.Fatalf("vehicle set metadata = %#v", set)
+	}
+	if set.Members[0].Position != 1 || set.Members[0].SourceVehicleID != "vehicle-a" ||
+		set.Members[0].VehicleInventoryNumber != "RK-A" || set.Members[0].Label != "Steuerwagen" ||
+		set.Members[1].Position != 2 {
+		t.Fatalf("ordered members = %#v", set.Members)
+	}
+}
+
 func TestDataTransferSnapshotAccessoryIncludesCurrentStateOnly(t *testing.T) {
 	db := testDB(t)
 	for _, statement := range []string{

--- a/backend/internal/infrastructure/data_transfer_vehicle_sets.go
+++ b/backend/internal/infrastructure/data_transfer_vehicle_sets.go
@@ -3,10 +3,19 @@ package infrastructure
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
+	"slices"
+	"strings"
 
 	"railkeeper/backend/internal/application"
 )
+
+type transferVehicleSetApplyPolicy struct {
+	Action           string
+	TargetSetID      string
+	MemberRecordKeys map[string]bool
+}
 
 func transferVehicleSetSnapshot(ctx context.Context, tx *sql.Tx) ([]application.TransferVehicleSet, error) {
 	rows, err := tx.QueryContext(ctx, `
@@ -72,4 +81,311 @@ ORDER BY member.vehicle_set_id, member.position, member.vehicle_id`)
 		return nil, fmt.Errorf("iterate transfer vehicle set members: %w", err)
 	}
 	return sets, nil
+}
+
+func revalidateTransferVehicleSetPreview(
+	ctx context.Context,
+	tx *sql.Tx,
+	previews []application.DataTransferVehicleSetPreview,
+	records []application.DataTransferPreviewRecord,
+	issues []application.DataTransferIssue,
+) error {
+	if len(previews) == 0 {
+		return nil
+	}
+	_, memberPolicies, err := transferVehicleSetApplyPolicies(previews, issues)
+	if err != nil {
+		return err
+	}
+	vehicleRecords := map[string]application.DataTransferPreviewRecord{}
+	for _, record := range records {
+		if record.Area != application.TransferVehicles {
+			continue
+		}
+		if _, duplicate := vehicleRecords[record.RecordKey]; duplicate {
+			return dataTransferApplyConflict("vehicle set preview contains duplicate member record keys")
+		}
+		vehicleRecords[record.RecordKey] = record
+	}
+	sets, err := transferVehicleSetSnapshot(ctx, tx)
+	if err != nil {
+		return err
+	}
+	setsByID := make(map[string]application.TransferVehicleSet, len(sets))
+	setsByInventory := make(map[string]application.TransferVehicleSet, len(sets))
+	for _, set := range sets {
+		setsByID[set.ID] = set
+		setsByInventory[strings.ToLower(strings.TrimSpace(set.InventoryNumber))] = set
+	}
+	seenMembers := map[string]bool{}
+	for _, preview := range previews {
+		if preview.Classification == "error" || len(preview.Diagnostics) != 0 ||
+			application.ValidateTransferVehicleSet(preview.Data) != nil {
+			return dataTransferApplyConflict("persisted vehicle set preview is invalid")
+		}
+		if len(preview.MemberRecordKeys) != len(preview.Data.Members) {
+			return dataTransferApplyConflict("vehicle set member preview is incomplete")
+		}
+		policy := memberPolicies[preview.MemberRecordKeys[0]]
+		for index, recordKey := range preview.MemberRecordKeys {
+			record, found := vehicleRecords[recordKey]
+			if !found || seenMembers[recordKey] || !policy.MemberRecordKeys[recordKey] {
+				return dataTransferApplyConflict("vehicle set member preview is inconsistent")
+			}
+			seenMembers[recordKey] = true
+			vehicle := application.TransferVehicle{}
+			if err := json.Unmarshal(record.Data, &vehicle); err != nil ||
+				!transferVehicleSetMemberMatches(preview.Data.Members[index], vehicle) {
+				return dataTransferApplyConflict("vehicle set member reference changed")
+			}
+		}
+		currentByInventory, inventoryExists := setsByInventory[strings.ToLower(strings.TrimSpace(preview.Data.InventoryNumber))]
+		if preview.TargetID != "" {
+			target, found := setsByID[preview.TargetID]
+			if !found || preview.TargetFingerprint == "" ||
+				application.DataTransferTargetFingerprint(target) != preview.TargetFingerprint {
+				return dataTransferApplyConflict("vehicle set preview target changed")
+			}
+			if !inventoryExists || currentByInventory.ID != target.ID {
+				return dataTransferApplyConflict("vehicle set inventory target changed")
+			}
+		} else if inventoryExists && policy.Action != "copy" && policy.Action != "skip" {
+			return dataTransferApplyConflict("vehicle set inventory number now exists")
+		}
+		if err := validateTransferVehicleSetTargetMembers(policy, preview, vehicleRecords, setsByID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func transferVehicleSetApplyPolicies(
+	previews []application.DataTransferVehicleSetPreview,
+	issues []application.DataTransferIssue,
+) (map[string]transferVehicleSetApplyPolicy, map[string]transferVehicleSetApplyPolicy, error) {
+	setPolicies := make(map[string]transferVehicleSetApplyPolicy, len(previews))
+	memberPolicies := map[string]transferVehicleSetApplyPolicy{}
+	for _, preview := range previews {
+		if preview.RecordKey == "" {
+			return nil, nil, dataTransferApplyConflict("vehicle set record key is missing")
+		}
+		if _, duplicate := setPolicies[preview.RecordKey]; duplicate {
+			return nil, nil, dataTransferApplyConflict("duplicate vehicle set record key")
+		}
+		action := preview.ProposedAction
+		resolved := false
+		for _, issue := range issues {
+			if issue.Area != application.TransferVehicles || issue.RecordKey != preview.RecordKey {
+				continue
+			}
+			switch issue.Code {
+			case "duplicate_vehicle_set_inventory_number", "vehicle_set_member_external_conflict":
+				action = issue.SelectedResolution
+				resolved = true
+			}
+		}
+		if preview.Classification == "warning" && !resolved {
+			return nil, nil, dataTransferApplyConflict("vehicle set conflict has no resolution")
+		}
+		if !slices.Contains([]string{"create", "replace", "copy", "skip"}, action) {
+			return nil, nil, dataTransferApplyConflict("unsupported vehicle set resolution")
+		}
+		if action == "replace" && preview.TargetID == "" {
+			return nil, nil, dataTransferApplyConflict("vehicle set replacement target is missing")
+		}
+		policy := transferVehicleSetApplyPolicy{
+			Action: action, TargetSetID: preview.TargetID, MemberRecordKeys: map[string]bool{},
+		}
+		for _, recordKey := range preview.MemberRecordKeys {
+			if recordKey == "" || memberPolicies[recordKey].Action != "" {
+				return nil, nil, dataTransferApplyConflict("vehicle belongs to more than one imported set")
+			}
+			policy.MemberRecordKeys[recordKey] = true
+		}
+		if len(policy.MemberRecordKeys) == 0 {
+			return nil, nil, dataTransferApplyConflict("vehicle set has no member records")
+		}
+		setPolicies[preview.RecordKey] = policy
+		for recordKey := range policy.MemberRecordKeys {
+			memberPolicies[recordKey] = policy
+		}
+	}
+	return setPolicies, memberPolicies, nil
+}
+
+func validateTransferVehicleSetTargetMembers(
+	policy transferVehicleSetApplyPolicy,
+	preview application.DataTransferVehicleSetPreview,
+	records map[string]application.DataTransferPreviewRecord,
+	setsByID map[string]application.TransferVehicleSet,
+) error {
+	if policy.Action == "skip" || policy.Action == "copy" {
+		return nil
+	}
+	if policy.Action == "create" {
+		for recordKey := range policy.MemberRecordKeys {
+			if records[recordKey].TargetID != "" {
+				return dataTransferApplyConflict("new vehicle set would reuse an existing vehicle")
+			}
+		}
+		return nil
+	}
+	target, found := setsByID[preview.TargetID]
+	if !found {
+		return dataTransferApplyConflict("vehicle set replacement target is missing")
+	}
+	targetMemberIDs := map[string]bool{}
+	for _, member := range target.Members {
+		targetMemberIDs[member.SourceVehicleID] = true
+	}
+	for recordKey := range policy.MemberRecordKeys {
+		targetID := records[recordKey].TargetID
+		if targetID != "" && !targetMemberIDs[targetID] {
+			return dataTransferApplyConflict("vehicle set member target is outside the replacement set")
+		}
+	}
+	return nil
+}
+
+func applyTransferVehicleSets(
+	ctx context.Context,
+	tx *sql.Tx,
+	previews []application.DataTransferVehicleSetPreview,
+	issues []application.DataTransferIssue,
+	vehicles map[string]transferVehicleApplyResult,
+	actor string,
+) error {
+	policies, _, err := transferVehicleSetApplyPolicies(previews, issues)
+	if err != nil {
+		return err
+	}
+	for _, preview := range previews {
+		policy := policies[preview.RecordKey]
+		if policy.Action == "skip" {
+			continue
+		}
+		if application.ValidateTransferVehicleSet(preview.Data) != nil ||
+			len(preview.MemberRecordKeys) != len(preview.Data.Members) {
+			return dataTransferApplyConflict("vehicle set preview changed before apply")
+		}
+		memberResults := make([]transferVehicleApplyResult, len(preview.MemberRecordKeys))
+		seenVehicleIDs := map[string]bool{}
+		for index, recordKey := range preview.MemberRecordKeys {
+			result, found := vehicles[recordKey]
+			if !found || result.ID == "" || seenVehicleIDs[result.ID] {
+				return dataTransferApplyConflict("vehicle set member apply result is incomplete")
+			}
+			seenVehicleIDs[result.ID] = true
+			memberResults[index] = result
+		}
+		setID := preview.TargetID
+		inventoryNumber := preview.Data.InventoryNumber
+		now := timestamp()
+		switch policy.Action {
+		case "create":
+			setID = randomID()
+			if err := insertTransferVehicleSet(ctx, tx, setID, inventoryNumber, preview.Data.VehicleSetInput, now); err != nil {
+				return err
+			}
+		case "copy":
+			setID = randomID()
+			inventoryNumber, err = uniqueTransferInventoryNumber(ctx, tx, "vehicle_sets", inventoryNumber)
+			if err != nil {
+				return err
+			}
+			if err := insertTransferVehicleSet(ctx, tx, setID, inventoryNumber, preview.Data.VehicleSetInput, now); err != nil {
+				return err
+			}
+		case "replace":
+			if err := updateTransferVehicleSet(
+				ctx, tx, setID, inventoryNumber, preview.Data.VehicleSetInput, now,
+			); err != nil {
+				return err
+			}
+			if _, err := tx.ExecContext(ctx, `DELETE FROM vehicle_set_members WHERE vehicle_set_id=?`, setID); err != nil {
+				return fmt.Errorf("clear transfer vehicle set members: %w", err)
+			}
+		}
+		for index, member := range preview.Data.Members {
+			if _, err := tx.ExecContext(ctx, `
+INSERT INTO vehicle_set_members(vehicle_set_id, vehicle_id, position, label)
+VALUES(?, ?, ?, ?)`, setID, memberResults[index].ID, member.Position, member.Label); err != nil {
+				return fmt.Errorf("insert transfer vehicle set member: %w", err)
+			}
+		}
+		if _, err := tx.ExecContext(ctx, `
+INSERT INTO audit_logs(id, actor_user_id, action, target_type, target_id, created_at, details_json)
+VALUES(?, NULLIF(?, ''), 'VehicleSetImported', 'vehicle_set', ?, ?, ?)`,
+			randomID(), actor, setID, now, fmt.Sprintf(`{"action":%q}`, policy.Action)); err != nil {
+			return fmt.Errorf("write transfer vehicle set audit log: %w", err)
+		}
+	}
+	return nil
+}
+
+func insertTransferVehicleSet(
+	ctx context.Context,
+	tx *sql.Tx,
+	id string,
+	inventoryNumber string,
+	input application.VehicleSetInput,
+	now string,
+) error {
+	arguments := transferVehicleSetArguments(inventoryNumber, input)
+	_, err := tx.ExecContext(ctx, `
+INSERT INTO vehicle_sets(
+  id, inventory_number, name, manufacturer, article_number, article_source_url, gauge, epoch,
+  railway_company, category, gattung, description, ean, production_period, list_price, acquisition_type,
+  acquired_from, purchase_price, purchase_date, storage_location, storage_details, condition,
+  condition_details, packaging, created_at, updated_at
+) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		append([]any{id}, append(arguments, now, now)...)...)
+	if err != nil {
+		return fmt.Errorf("insert transfer vehicle set: %w", err)
+	}
+	return nil
+}
+
+func updateTransferVehicleSet(
+	ctx context.Context,
+	tx *sql.Tx,
+	id string,
+	inventoryNumber string,
+	input application.VehicleSetInput,
+	now string,
+) error {
+	arguments := transferVehicleSetArguments(inventoryNumber, input)
+	result, err := tx.ExecContext(ctx, `
+UPDATE vehicle_sets SET
+  inventory_number=?, name=?, manufacturer=?, article_number=?, article_source_url=?, gauge=?, epoch=?,
+  railway_company=?, category=?, gattung=?, description=?, ean=?, production_period=?, list_price=?,
+  acquisition_type=?, acquired_from=?, purchase_price=?, purchase_date=?, storage_location=?, storage_details=?,
+  condition=?, condition_details=?, packaging=?, updated_at=?
+WHERE id=?`, append(append(arguments, now), id)...)
+	if err != nil {
+		return fmt.Errorf("update transfer vehicle set: %w", err)
+	}
+	return requireApplyUpdate(result, "replace vehicle set")
+}
+
+func transferVehicleSetArguments(inventoryNumber string, input application.VehicleSetInput) []any {
+	return []any{
+		inventoryNumber, input.Name, input.Manufacturer, input.ArticleNumber, input.ArticleSourceURL, input.Gauge,
+		input.Epoch, input.RailwayCompany, input.Category, input.Gattung, input.Description, input.EAN,
+		input.ProductionPeriod, input.ListPrice, input.AcquisitionType, input.AcquiredFrom, input.PurchasePrice,
+		input.PurchaseDate, input.StorageLocation, input.StorageDetails, input.Condition, input.ConditionDetails,
+		input.Packaging,
+	}
+}
+
+func transferVehicleSetMemberMatches(
+	member application.TransferVehicleSetMember,
+	vehicle application.TransferVehicle,
+) bool {
+	if member.SourceVehicleID != "" && member.SourceVehicleID != vehicle.ID {
+		return false
+	}
+	return member.VehicleInventoryNumber == "" || strings.EqualFold(
+		strings.TrimSpace(member.VehicleInventoryNumber), strings.TrimSpace(vehicle.InventoryNumber),
+	)
 }

--- a/backend/internal/infrastructure/data_transfer_vehicle_sets.go
+++ b/backend/internal/infrastructure/data_transfer_vehicle_sets.go
@@ -251,6 +251,7 @@ func applyTransferVehicleSets(
 	ctx context.Context,
 	tx *sql.Tx,
 	previews []application.DataTransferVehicleSetPreview,
+	csvMapping []application.DataTransferCSVColumnMapping,
 	issues []application.DataTransferIssue,
 	vehicles map[string]transferVehicleApplyResult,
 	actor string,
@@ -258,6 +259,16 @@ func applyTransferVehicleSets(
 	policies, _, err := transferVehicleSetApplyPolicies(previews, issues)
 	if err != nil {
 		return err
+	}
+	existingSetsByID := map[string]application.TransferVehicleSet{}
+	if len(previews) > 0 && len(csvMapping) > 0 {
+		existingSets, err := transferVehicleSetSnapshot(ctx, tx)
+		if err != nil {
+			return err
+		}
+		for _, set := range existingSets {
+			existingSetsByID[set.ID] = set
+		}
 	}
 	for _, preview := range previews {
 		policy := policies[preview.RecordKey]
@@ -278,13 +289,14 @@ func applyTransferVehicleSets(
 			seenVehicleIDs[result.ID] = true
 			memberResults[index] = result
 		}
+		setData := preview.Data
 		setID := preview.TargetID
-		inventoryNumber := preview.Data.InventoryNumber
+		inventoryNumber := setData.InventoryNumber
 		now := timestamp()
 		switch policy.Action {
 		case "create":
 			setID = randomID()
-			if err := insertTransferVehicleSet(ctx, tx, setID, inventoryNumber, preview.Data.VehicleSetInput, now); err != nil {
+			if err := insertTransferVehicleSet(ctx, tx, setID, inventoryNumber, setData.VehicleSetInput, now); err != nil {
 				return err
 			}
 		case "copy":
@@ -293,12 +305,20 @@ func applyTransferVehicleSets(
 			if err != nil {
 				return err
 			}
-			if err := insertTransferVehicleSet(ctx, tx, setID, inventoryNumber, preview.Data.VehicleSetInput, now); err != nil {
+			if err := insertTransferVehicleSet(ctx, tx, setID, inventoryNumber, setData.VehicleSetInput, now); err != nil {
 				return err
 			}
 		case "replace":
+			if len(csvMapping) > 0 {
+				existing, found := existingSetsByID[setID]
+				if !found {
+					return dataTransferApplyConflict("vehicle set replacement target is missing")
+				}
+				setData = application.PreserveUnmappedTransferVehicleSetFields(setData, existing, csvMapping)
+				inventoryNumber = setData.InventoryNumber
+			}
 			if err := updateTransferVehicleSet(
-				ctx, tx, setID, inventoryNumber, preview.Data.VehicleSetInput, now,
+				ctx, tx, setID, inventoryNumber, setData.VehicleSetInput, now,
 			); err != nil {
 				return err
 			}

--- a/backend/internal/infrastructure/data_transfer_vehicle_sets.go
+++ b/backend/internal/infrastructure/data_transfer_vehicle_sets.go
@@ -1,0 +1,75 @@
+package infrastructure
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"railkeeper/backend/internal/application"
+)
+
+func transferVehicleSetSnapshot(ctx context.Context, tx *sql.Tx) ([]application.TransferVehicleSet, error) {
+	rows, err := tx.QueryContext(ctx, `
+SELECT id, inventory_number, name, manufacturer, article_number, article_source_url, gauge, epoch,
+       railway_company, category, gattung, description, ean, production_period, list_price,
+       acquisition_type, acquired_from, purchase_price, purchase_date, storage_location,
+       storage_details, condition, condition_details, packaging, created_at, updated_at
+FROM vehicle_sets
+ORDER BY inventory_number COLLATE NOCASE, id`)
+	if err != nil {
+		return nil, fmt.Errorf("query transfer vehicle sets: %w", err)
+	}
+	sets := []application.TransferVehicleSet{}
+	setIndexes := map[string]int{}
+	for rows.Next() {
+		set := application.TransferVehicleSet{}
+		if err := rows.Scan(
+			&set.ID, &set.InventoryNumber, &set.Name, &set.Manufacturer, &set.ArticleNumber,
+			&set.ArticleSourceURL, &set.Gauge, &set.Epoch, &set.RailwayCompany, &set.Category,
+			&set.Gattung, &set.Description, &set.EAN, &set.ProductionPeriod, &set.ListPrice,
+			&set.AcquisitionType, &set.AcquiredFrom, &set.PurchasePrice, &set.PurchaseDate,
+			&set.StorageLocation, &set.StorageDetails, &set.Condition, &set.ConditionDetails,
+			&set.Packaging, &set.CreatedAt, &set.UpdatedAt,
+		); err != nil {
+			_ = rows.Close()
+			return nil, fmt.Errorf("scan transfer vehicle set: %w", err)
+		}
+		setIndexes[set.ID] = len(sets)
+		sets = append(sets, set)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return nil, fmt.Errorf("iterate transfer vehicle sets: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, fmt.Errorf("close transfer vehicle sets: %w", err)
+	}
+
+	memberRows, err := tx.QueryContext(ctx, `
+SELECT member.vehicle_set_id, member.vehicle_id, vehicle.inventory_number, member.position, member.label
+FROM vehicle_set_members member
+JOIN vehicles vehicle ON vehicle.id=member.vehicle_id
+ORDER BY member.vehicle_set_id, member.position, member.vehicle_id`)
+	if err != nil {
+		return nil, fmt.Errorf("query transfer vehicle set members: %w", err)
+	}
+	defer func() { _ = memberRows.Close() }()
+	for memberRows.Next() {
+		var setID string
+		member := application.TransferVehicleSetMember{}
+		if err := memberRows.Scan(
+			&setID, &member.SourceVehicleID, &member.VehicleInventoryNumber, &member.Position, &member.Label,
+		); err != nil {
+			return nil, fmt.Errorf("scan transfer vehicle set member: %w", err)
+		}
+		index, found := setIndexes[setID]
+		if !found {
+			return nil, fmt.Errorf("transfer vehicle set member references unknown set %q", setID)
+		}
+		sets[index].Members = append(sets[index].Members, member)
+	}
+	if err := memberRows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate transfer vehicle set members: %w", err)
+	}
+	return sets, nil
+}

--- a/docs/designs/2026-08-27-import-export-sets-and-review-fixes-design.md
+++ b/docs/designs/2026-08-27-import-export-sets-and-review-fixes-design.md
@@ -1,0 +1,193 @@
+# Import/Export: Set-Roundtrip und Prüfkorrekturen
+
+Datum: 2026-08-27  
+Status: freigegeben
+
+## Ziel
+
+Der Import/Export-Arbeitsbereich soll konsistent bedienbar sein und Fahrzeugsets verlustfrei
+zwischen RailKeeper-Installationen übertragen. Die Umsetzung behebt zugleich die in Issue #159
+gemeldete Rückkehr von der Prüfung zur CSV-Zuordnung, den Versatz der Spalte `Datensatz`, die
+uneinheitliche Anordnung der Profilaktionen und die fehlende direkte Bearbeitung per Zeilenklick.
+
+Issue #140 wird um einen vollständigen Set-Roundtrip für JSON und CSV abgeschlossen. Ein Set umfasst
+dabei seine Stammdaten, seine Mitglieder, die Mitgliedsreihenfolge und die optionalen
+Mitgliedsbezeichnungen.
+
+## Nicht im Umfang
+
+- Bilder, Anhänge, Wartungen, CV-Dateien und andere Binär- oder Detaildaten bleiben außerhalb des
+  Transferprofils. Dafür bleibt die Anwendungssicherung zuständig.
+- Profile erhalten keinen neuen auswählbaren Bereich `Fahrzeugsets`. Sets gehören strukturell zum
+  vorhandenen Bereich `Fahrzeuge`.
+- Alte Transferpakete werden nicht nachträglich um Set-Informationen ergänzt.
+
+## Bedienoberfläche
+
+### Profilbearbeitung
+
+Jede bearbeitbare Profilzeile öffnet den Profildialog per Mausklick, `Enter` oder Leertaste. Das
+Startsymbol und das Drei-Punkte-Menü bleiben eigenständige Schaltflächen. Ihre Maus- und
+Tastaturereignisse dürfen den Zeilenklick nicht zusätzlich auslösen.
+
+Im Profildialog steht die destruktive Aktion links. `Abbrechen` und die primäre Speicheraktion stehen
+rechts in derselben Zeile und dürfen auf Desktopbreiten nicht umbrechen. Auf kleinen Mobilbreiten
+werden die Aktionen kontrolliert auf volle Breite gestapelt. Fokusreihenfolge, Beschriftung und
+sichtbarer Tastaturfokus bleiben erhalten.
+
+### Importprüfung
+
+Die zweite Spalte der Prüftabelle bleibt eine reguläre Tabellenzelle. Datensatzschlüssel und
+Zeilennummer liegen in einem inneren Layoutcontainer. Dadurch verwenden Kopf und Inhalt weiterhin
+dasselbe Tabellenraster.
+
+Nach einer Konfliktentscheidung bleibt die Ansicht auf `Prüfung` oder wechselt nach der letzten
+Entscheidung zu `Bestätigung`. Eine Aktualisierung desselben Auftrags darf die bereits bestätigte
+CSV-Zuordnung nicht zurücksetzen. Nur eine andere Quelldatei, eine geänderte Zuordnung, ein anderer
+Auftrag oder ein echter Reupload-Konflikt setzt diese Bestätigung zurück.
+
+Die Auswahltexte verwenden fachliche Aktionen statt technischer Auflösungsbegriffe:
+
+- `Aktion wählen`
+- `Bestehenden Datensatz überschreiben`
+- `Als neuen Datensatz mit neuer Inventarnummer importieren`
+- `Diesen Datensatz nicht importieren`
+- bei passenden Hersteller-/Artikelnummern: `Vorhandenes Fahrzeug verwenden`
+- bei passenden Hersteller-/Artikelnummern: `Zusätzlich als neues Fahrzeug importieren`
+
+Die englischen Texte werden sinngleich gepflegt.
+
+### Set-Prüfung
+
+Die Vorschau erhält einen Abschnitt `Erkannte Fahrzeugsets`. Jede Gruppe zeigt mindestens
+Set-Inventarnummer, Name, Mitgliederzahl, Status und eine gegebenenfalls erforderliche Gesamtaktion.
+Die vorhandene Kennzahl `Datensätze` zählt weiterhin Fahrzeuge und wird durch Set-Metadaten nicht
+künstlich erhöht.
+
+## Transferformat
+
+### JSON
+
+Die Paketversion steigt von 2 auf 3. Innerhalb von `areas` wird neben `vehicles` die optionale
+Sammlung `vehicleSets` ausgegeben, sobald der Bereich `Fahrzeuge` ausgewählt wurde und Sets vorhanden
+sind.
+
+Ein Set-Datensatz enthält:
+
+- Quell-ID und Set-Inventarnummer,
+- alle Felder aus `VehicleSetInput`,
+- eine geordnete Mitgliederliste mit Quell-Fahrzeug-ID, Fahrzeug-Inventarnummer, Position und Label.
+
+Mitgliedsreferenzen verwenden die Quell-ID zur eindeutigen Paketverknüpfung und die
+Inventarnummer zur lesbaren Kontrolle. Zielsystem-IDs werden nie aus dem Paket übernommen.
+
+Pakete der Versionen 1 und 2 bleiben lesbar. Da sie keine Set-Struktur besitzen, werden ihre
+Fahrzeuge wie bisher einzeln importiert.
+
+### CSV
+
+CSV bleibt eine Datei mit einer Zeile pro Fahrzeug. Set-Mitglieder erhalten zusätzliche,
+eindeutig präfixierte Spalten:
+
+- `vehicleSetInventoryNumber`, `vehicleSetName`, `vehicleSetManufacturer`,
+  `vehicleSetArticleNumber`, `vehicleSetArticleSourceUrl`, `vehicleSetGauge`, `vehicleSetEpoch`,
+  `vehicleSetRailwayCompany`, `vehicleSetCategory`, `vehicleSetGattung`, `vehicleSetDescription`,
+  `vehicleSetEAN`, `vehicleSetProductionPeriod`, `vehicleSetListPrice`,
+  `vehicleSetAcquisitionType`, `vehicleSetAcquiredFrom`, `vehicleSetPurchasePrice`,
+  `vehicleSetPurchaseDate`, `vehicleSetStorageLocation`, `vehicleSetStorageDetails`,
+  `vehicleSetCondition`, `vehicleSetConditionDetails`, `vehicleSetPackaging`,
+- `vehicleSetPosition`, `vehicleSetMemberCount` und `vehicleSetMemberLabel`.
+
+Set-freie Fahrzeuge lassen diese Spalten leer. Beim Import gruppiert die Set-Inventarnummer die
+Mitglieder. Die Reihenfolge der CSV-Zeilen ist dafür unerheblich. Die Spalten nehmen an der
+bestehenden Alias-, Profil- und manuellen Zuordnung teil und erhalten deutsche sowie englische
+Aliase.
+
+## Validierung
+
+Ein erkannter Set-Verbund ist nur gültig, wenn:
+
+- die Set-Inventarnummer gesetzt ist,
+- Name, Hersteller, Spurweite, Kategorie und Gattung gesetzt sind,
+- mindestens zwei unterschiedliche Mitglieder vorliegen,
+- Positionen positiv, eindeutig und lückenlos von 1 bis zur Mitgliederzahl laufen,
+- alle Zeilen dieselbe Mitgliederzahl und dieselben Set-Stammdaten enthalten,
+- jedes Mitglied genau einem Set angehört,
+- jede JSON-Mitgliedsreferenz auf ein enthaltenes Fahrzeug zeigt.
+
+Teilweise vorhandene Set-Spalten werden nicht stillschweigend ignoriert. Sie erzeugen eine
+Prüfmeldung. Ein fehlerhaftes oder übersprungenes Mitglied verhindert, dass ein unvollständiges Set
+geschrieben wird.
+
+## Konflikte und Schreibregeln
+
+Set-Konflikte werden auf Gruppenebene entschieden:
+
+- `Bestehendes Set aktualisieren`: Set-Stammdaten werden aktualisiert. Mitglieder werden nur mit
+  Fahrzeugen innerhalb dieses Sets abgeglichen. Fehlende Mitglieder werden angelegt. Nicht mehr im
+  Import enthaltene bisherige Mitglieder bleiben als Fahrzeuge erhalten, werden aber aus dem Set
+  gelöst.
+- `Als neues Set importieren`: RailKeeper vergibt eine neue Set-Inventarnummer und bei notwendigen
+  Kopien neue Fahrzeug-Inventarnummern. Es werden keine bestehenden Fahrzeuge umgehängt.
+- `Dieses Set nicht importieren`: Das Set und alle zugehörigen Fahrzeugdatensätze werden
+  übersprungen.
+
+Kollidiert ein importiertes Mitglied mit einem Fahrzeug außerhalb des zu aktualisierenden Sets,
+darf dieses Fahrzeug nicht automatisch ersetzt oder umgehängt werden. Die Vorschau verlangt dann
+eine sichere Set-Gesamtaktion oder das Überspringen.
+
+Fahrzeuge werden zuerst vorbereitet, die Set-Mitgliedschaften anschließend innerhalb derselben
+SQLite-Transaktion geschrieben. Die Anwendung führt unmittelbar vor dem Schreiben erneut
+Fingerabdruck-, Konflikt- und Vollständigkeitsprüfungen aus. Bei einer Abweichung wird die gesamte
+Transaktion verworfen.
+
+## Technische Einordnung
+
+- `application` definiert Paketversion 3, Set-Transfermodelle, Parser, Gruppierung, Vorschau und
+  Validierungsregeln.
+- `infrastructure` liest Set-Stammdaten und Mitgliedschaften im konsistenten Snapshot und schreibt
+  Fahrzeuge sowie Sets atomar.
+- `api` behält die bestehenden Importendpunkte. Neue Vorschaufelder und Konfliktcodes werden im
+  OpenAPI-Vertrag dokumentiert.
+- `frontend` rendert Set-Gruppen, bewahrt den bestätigten Mappingstatus und behebt Tabellen- sowie
+  Profilinteraktionen.
+
+Die vorhandenen Profile und Bereichsauswahlen bleiben kompatibel. Ein Fahrzeugprofil nimmt Sets
+automatisch mit, sofern sie im Exportbestand oder in der Importdatei vorkommen.
+
+## Fehlerbehandlung
+
+- Ungültige Set-Strukturen werden in der Vorschau nachvollziehbar dem Set und den betroffenen
+  Mitgliedern zugeordnet.
+- Unbekannte oder widersprüchliche Set-Spalten bleiben vor der Bestätigung blockierend.
+- Revisionskonflikte laden die persistente Vorschau neu. Nur wenn Quelle oder Zuordnung tatsächlich
+  nicht mehr dieselbe ist, ist ein erneuter Upload erforderlich.
+- Serverfehler lassen Dialog und Auswahlzustand sichtbar, damit der Nutzer korrigieren oder erneut
+  versuchen kann.
+
+## Tests und Abnahme
+
+Backendtests decken mindestens ab:
+
+- JSON-Roundtrip eines Sets mit Set-Stammdaten, Mitgliedern, Labels und Reihenfolge,
+- CSV-Roundtrip mit gruppierten Set-Spalten,
+- unveränderte Einzelfahrzeugimporte,
+- Kompatibilität der Paketversionen 1 und 2,
+- unvollständige Sets, doppelte oder lückenhafte Positionen und widersprüchliche Stammdaten,
+- Aktualisieren, Kopieren und Überspringen eines Set-Konflikts,
+- Kollision eines Mitglieds außerhalb des Zielsets,
+- vollständigen Transaktionsabbruch bei einem Set- oder Mitgliedsfehler.
+
+Frontendtests decken mindestens ab:
+
+- Profilbearbeitung per Klick, `Enter` und Leertaste,
+- isolierte Start- und Menüaktionen innerhalb einer Profilzeile,
+- stabile Desktop- und mobile Aktionsanordnung,
+- unveränderte Tabellengeometrie der Spalte `Datensatz`,
+- Verbleib auf `Prüfung` beziehungsweise Wechsel zu `Bestätigung` nach einer Auswahl,
+- verständliche deutsche und englische Aktionstexte,
+- Anzeige und Gesamtentscheidung erkannter Set-Gruppen.
+
+Abschließend laufen `go test ./...`, die vollständige Frontend-Testfolge, der Frontend-Build und
+die Dokumentationsprüfung. Die betroffenen Ansichten werden auf Desktop und Mobil, in hellem und
+dunklem Theme, mit Tastaturfokus und langen deutschen Texten visuell geprüft.

--- a/docs/designs/2026-08-27-import-export-sets-and-review-fixes-design.md
+++ b/docs/designs/2026-08-27-import-export-sets-and-review-fixes-design.md
@@ -1,6 +1,6 @@
 # Import/Export: Set-Roundtrip und Prüfkorrekturen
 
-Datum: 2026-08-27  
+Datum: 2026-08-27
 Status: freigegeben
 
 ## Ziel

--- a/docs/site/de/guide/import-export/index.md
+++ b/docs/site/de/guide/import-export/index.md
@@ -4,7 +4,7 @@ description: Fahrzeug-, Zubehör- und Messedaten über geprüfte Transferaufträ
 audience: user
 status: stable
 reviewedVersion: 0.1.20.2
-lastReviewed: 2026-08-16
+lastReviewed: 2026-08-27
 ---
 
 # Import und Export
@@ -51,12 +51,27 @@ Ein Transferprofil speichert nur die wiederverwendbare Auswahl für einen Auftra
   Ausstellungslisten benötigen RailKeeper-JSON.
 - **Format**: CSV für tabellarische Einzelbereiche, RailKeeper-JSON für vollständige, auch
   bereichsübergreifende Pakete.
-- **CSV-Zuordnung**: Bei Fahrzeugimporten kann die Zuordnung von Quellspalten zu den 62
-  RailKeeper-Feldern als Profilstandard gespeichert werden.
+- **CSV-Zuordnung**: Bei Fahrzeugimporten kann die Zuordnung von Quellspalten zu 62 Fahrzeugfeldern
+  und 26 Fahrzeugset-Feldern als Profilstandard gespeichert werden.
 
 Die Tabelle **Transferprofile** zeigt Import-, Export- und deaktivierte Profile gemeinsam. Nur
 aktive Profile besitzen eine Startaktion. Ein aktiver Profilname darf je Richtung nur einmal
 vorkommen, derselbe Name darf aber einmal für Import und einmal für Export verwendet werden.
+
+## Fahrzeugsets übertragen
+
+Ein Fahrzeugprofil nimmt zugehörige Fahrzeugsets automatisch mit. Die Datensatzanzahl zählt dabei
+weiterhin Fahrzeuge, nicht zusätzliche Set-Metadaten.
+
+- RailKeeper-JSON verwendet ab Paketversion 3 die normalisierte Struktur `vehicleSets`. Dateien der
+  Paketversionen 1 und 2 bleiben für Einzelfahrzeugimporte kompatibel.
+- CSV wiederholt die `vehicleSet*`-Felder in jeder Mitgliedszeile. RailKeeper gruppiert die Zeilen
+  über `vehicleSetInventoryNumber` und übernimmt Reihenfolge sowie individuelle Mitgliedslabels.
+- Erkannte Sets erscheinen als eigene Gruppen in der Importprüfung. Bei einer vorhandenen
+  Set-Inventarnummer kann das gesamte Set aktualisiert, als neues Set importiert oder übersprungen
+  werden. Bei extern gebundenen Mitgliedern sind nur Set-Kopie oder Überspringen zulässig.
+- Jede Set-Aktion gilt für die vollständige Gruppe. RailKeeper hängt kein bereits anderweitig
+  gebundenes Fahrzeug stillschweigend um.
 
 ## Sicherer Arbeitsablauf
 
@@ -84,6 +99,8 @@ vorkommen, derselbe Name darf aber einmal für Import und einmal für Export ver
 - Transferpakete enthalten keine Benutzer, Rollen, Sitzungen, Passwort-Hashes oder andere lokale
   Authentifizierungsdaten. Für vollständige lokale Bestands- und Upload-Wiederherstellung die
   Anwendungssicherung verwenden.
+- Fahrzeugbilder und andere Unterdaten gehören weiterhin in die Anwendungssicherung und nicht in
+  einen Fahrzeug-Transfer.
 - Digitalzentralen-Lese- und Schreibvorgänge gelangen nie automatisch in einen Transferauftrag.
 
 ## Fehlerbehebung
@@ -101,4 +118,4 @@ vorkommen, derselbe Name darf aber einmal für Import und einmal für Export ver
 
 ## Dokumentierte RailKeeper-Version
 
-Dieses Kapitel dokumentiert RailKeeper **v0.1.20.2** und wurde zuletzt am 16.08.2026 geprüft.
+Dieses Kapitel dokumentiert RailKeeper **v0.1.20.2** und wurde zuletzt am 27.08.2026 geprüft.

--- a/docs/site/guide/import-export/index.md
+++ b/docs/site/guide/import-export/index.md
@@ -4,7 +4,7 @@ description: Exchange vehicle, accessory, and exhibition data through reviewed t
 audience: user
 status: stable
 reviewedVersion: 0.1.20.2
-lastReviewed: 2026-08-16
+lastReviewed: 2026-08-27
 ---
 
 # Import and export
@@ -49,12 +49,27 @@ A transfer profile stores only the reusable selection for a job:
   exhibition lists require RailKeeper JSON.
 - **Format**: CSV for tabular single-area exchange, RailKeeper JSON for complete packages that may
   span areas.
-- **CSV mapping**: vehicle imports can save source-column assignments to the 62 RailKeeper fields
-  as profile defaults.
+- **CSV mapping**: vehicle imports can save source-column assignments to 62 vehicle fields and 26
+  vehicle-set fields as profile defaults.
 
 The **Transfer profiles** table lists import, export, and disabled profiles together. Only enabled
 profiles have a start action. An enabled profile name may occur only once per direction, while the
 same name may be used once for import and once for export.
+
+## Transfer vehicle sets
+
+A vehicle profile automatically includes associated vehicle sets. Record totals continue to count
+vehicles, not additional set metadata.
+
+- RailKeeper JSON uses the normalized `vehicleSets` structure from package version 3. Package
+  versions 1 and 2 remain compatible for individual-vehicle imports.
+- CSV repeats the `vehicleSet*` fields on every member row. RailKeeper groups rows by
+  `vehicleSetInventoryNumber` and preserves member order and individual labels.
+- Detected sets appear as separate groups during import review. If a set inventory number already
+  exists, the complete set can be updated, imported as a new set, or skipped. For members already
+  bound externally, only copying or skipping the set is allowed.
+- Every set action applies to the complete group. RailKeeper never silently moves a vehicle that is
+  already assigned elsewhere.
 
 ## Safe working sequence
 
@@ -78,6 +93,8 @@ same name may be used once for import and once for export.
   snapshot transactionally; a failed apply does not leave a partially imported job.
 - Transfer packages never contain users, roles, sessions, password hashes, or other local
   authentication state. Use application backup for full local inventory and upload recovery.
+- Vehicle images and other subordinate data still require application backup and are not included
+  in a vehicle transfer.
 - Digital-center reads and writes never enter a generic transfer job automatically.
 
 ## Troubleshooting
@@ -95,4 +112,4 @@ same name may be used once for import and once for export.
 
 ## Documented RailKeeper version
 
-This chapter documents stable RailKeeper **v0.1.20.2** and was last reviewed on 2026-08-16.
+This chapter documents stable RailKeeper **v0.1.20.2** and was last reviewed on 2026-08-27.

--- a/frontend/src/features/importExport/ImportExportView.test.tsx
+++ b/frontend/src/features/importExport/ImportExportView.test.tsx
@@ -239,6 +239,10 @@ describe("ImportExportView", () => {
     expect(onRun).toHaveBeenCalledTimes(1);
 
     onEdit.mockClear();
+    fireEvent.keyDown(screen.getByRole("button", { name: "Fahrzeugimport starten" }), { key: "Enter" });
+    fireEvent.keyDown(screen.getByRole("button", { name: "Fahrzeugimport bearbeiten" }), { key: " " });
+    expect(onEdit).not.toHaveBeenCalled();
+
     rerender(<TransferProfilesTable
       canCreate={false}
       canEdit={false}

--- a/frontend/src/features/importExport/ImportExportView.test.tsx
+++ b/frontend/src/features/importExport/ImportExportView.test.tsx
@@ -10,6 +10,7 @@ import type {
   DataTransferSummary
 } from "./dataTransferModel";
 import { ImportExportView } from "./ImportExportView";
+import { TransferProfilesTable } from "./TransferProfilesTable";
 
 const reviewJob = jobFixture({
   id: "job-review",
@@ -185,6 +186,77 @@ describe("ImportExportView", () => {
 
     fireEvent.click(importAction);
     expect(screen.getByRole("dialog", { name: "Import prüfen" })).toBeInTheDocument();
+  });
+
+  it.each([
+    ["mouse click", "click"],
+    ["Enter", "Enter"],
+    ["Space", " "]
+  ])("opens profile editor from the row using %s", async (_interaction, key) => {
+    vi.mocked(api.dataTransferProfiles).mockResolvedValue([
+      profileFixture({ id: "profile-import", name: "Fahrzeugimport", direction: "import", format: "csv" })
+    ]);
+
+    render(<ImportExportView roles={["Admin"]} />);
+    const profilesPanel = (await screen.findByRole("heading", { name: "Transferprofile" })).closest("section")!;
+    const row = within(profilesPanel).getByText("Fahrzeugimport").closest("tr")!;
+    if (key === "click") fireEvent.click(row);
+    else fireEvent.keyDown(row, { key });
+
+    expect(screen.getByRole("dialog", { name: "Transferprofil bearbeiten" })).toBeInTheDocument();
+  });
+
+  it("keeps profile row actions isolated and non-editable rows inert", () => {
+    const profile = profileFixture({ id: "profile-import", name: "Fahrzeugimport", direction: "import" });
+    const onEdit = vi.fn();
+    const onRun = vi.fn();
+    const t = (key: string) => ({
+      "importExport.dashboard.profiles.start": "starten",
+      "importExport.dashboard.profiles.edit": "bearbeiten",
+      "importExport.dashboard.profiles.run.import": "Import starten"
+    })[key] ?? key;
+    const { rerender } = render(<TransferProfilesTable
+      canCreate={false}
+      canEdit
+      canExport
+      canImport
+      language="de"
+      mutating={false}
+      onCreate={vi.fn()}
+      onEdit={onEdit}
+      onRun={onRun}
+      profiles={[profile]}
+      t={t}
+    />);
+
+    const editableRow = screen.getByText("Fahrzeugimport").closest("tr")!;
+    expect(editableRow).toHaveAttribute("tabindex", "0");
+    fireEvent.click(screen.getByRole("button", { name: "Fahrzeugimport starten" }));
+    expect(onRun).toHaveBeenCalledTimes(1);
+    expect(onEdit).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: "Fahrzeugimport bearbeiten" }));
+    expect(onEdit).toHaveBeenCalledTimes(1);
+    expect(onRun).toHaveBeenCalledTimes(1);
+
+    onEdit.mockClear();
+    rerender(<TransferProfilesTable
+      canCreate={false}
+      canEdit={false}
+      canExport
+      canImport
+      language="de"
+      mutating={false}
+      onCreate={vi.fn()}
+      onEdit={onEdit}
+      onRun={onRun}
+      profiles={[profile]}
+      t={t}
+    />);
+    const inertRow = screen.getByText("Fahrzeugimport").closest("tr")!;
+    expect(inertRow).not.toHaveAttribute("tabindex");
+    expect(inertRow).not.toHaveClass("transfer-profile-row");
+    fireEvent.click(inertRow);
+    expect(onEdit).not.toHaveBeenCalled();
   });
 
   it("lets Admin delete a cancelled job from jobs or history after confirmation", async () => {

--- a/frontend/src/features/importExport/TransferDialogs.test.tsx
+++ b/frontend/src/features/importExport/TransferDialogs.test.tsx
@@ -427,13 +427,13 @@ describe("data transfer operational dialogs", () => {
     }));
     const vehicleSets: DataTransferVehicleSetPreview[] = [
       vehicleSetPreviewFixture({
-        recordKey: "Set-001",
+        recordKey: "vehicle-set:id:source-1",
         classification: "ready",
         memberRecordKeys: ["RK-A", "RK-B"],
         data: vehicleSetDataFixture("Set-001", "Nahverkehr", ["RK-A", "RK-B"])
       }),
       vehicleSetPreviewFixture({
-        recordKey: "Set-002",
+        recordKey: "vehicle-set:id:source-2",
         classification: "error",
         proposedAction: "replace",
         memberRecordKeys: ["RK-B", "RK-C"],
@@ -443,7 +443,7 @@ describe("data transfer operational dialogs", () => {
     const setIssue: DataTransferIssue = {
       ...importIssue,
       id: "issue-set-2",
-      recordKey: "Set-002",
+      recordKey: "vehicle-set:id:source-2",
       rowNumber: null,
       field: "inventoryNumber",
       code: "duplicate_vehicle_set_inventory_number",
@@ -491,6 +491,7 @@ describe("data transfer operational dialogs", () => {
     const setReview = screen.getByRole("heading", { name: "Erkannte Fahrzeugsets" }).closest("section")!;
     expect(setReview).toBeVisible();
     expect(within(setReview).getByText("Set-001")).toBeVisible();
+    expect(within(setReview).queryByText("vehicle-set:id:source-1")).not.toBeInTheDocument();
     expect(within(setReview).getByText("Nahverkehr")).toBeVisible();
     expect(within(setReview).getAllByText("2 Mitglieder")).toHaveLength(2);
     expect(within(setReview).getByText("Bereit")).toBeVisible();

--- a/frontend/src/features/importExport/TransferDialogs.test.tsx
+++ b/frontend/src/features/importExport/TransferDialogs.test.tsx
@@ -9,7 +9,8 @@ import type {
   DataTransferJob,
   DataTransferPreview,
   DataTransferProfile,
-  DataTransferSummary
+  DataTransferSummary,
+  DataTransferVehicleSetPreview
 } from "./dataTransferModel";
 import { ImportExportView } from "./ImportExportView";
 import { TransferImportDialog } from "./TransferImportDialog";
@@ -352,6 +353,150 @@ describe("data transfer operational dialogs", () => {
     expect(screen.getByRole("option", { name: "Use existing vehicle" })).toBeInTheDocument();
     expect(screen.getByRole("option", { name: "Import as an additional new vehicle" })).toBeInTheDocument();
     expect(screen.getByRole("option", { name: "Do not import this record" })).toBeInTheDocument();
+  });
+
+  it("shows detected vehicle sets and resolves a set as one unit", async () => {
+    const user = userEvent.setup();
+    const records = ["RK-A", "RK-B", "RK-C"].map((recordKey, index) => ({
+      area: "vehicles" as const,
+      recordKey,
+      rowNumber: index + 2,
+      classification: "ready" as const,
+      proposedAction: "create" as const,
+      data: { inventoryNumber: recordKey, manufacturer: "Märklin", name: `Fahrzeug ${index + 1}` }
+    }));
+    const vehicleSets: DataTransferVehicleSetPreview[] = [
+      vehicleSetPreviewFixture({
+        recordKey: "Set-001",
+        classification: "ready",
+        memberRecordKeys: ["RK-A", "RK-B"],
+        data: vehicleSetDataFixture("Set-001", "Nahverkehr", ["RK-A", "RK-B"])
+      }),
+      vehicleSetPreviewFixture({
+        recordKey: "Set-002",
+        classification: "error",
+        proposedAction: "replace",
+        memberRecordKeys: ["RK-B", "RK-C"],
+        data: vehicleSetDataFixture("Set-002", "Güterzug", ["RK-B", "RK-C"])
+      })
+    ];
+    const setIssue: DataTransferIssue = {
+      ...importIssue,
+      id: "issue-set-2",
+      recordKey: "Set-002",
+      rowNumber: null,
+      field: "inventoryNumber",
+      code: "duplicate_vehicle_set_inventory_number",
+      message: "Set-Inventarnummer ist bereits vorhanden."
+    };
+    const persistedJob = jobFixture({
+      id: "job-set-import",
+      profileId: jsonImportProfile.id,
+      profileName: jsonImportProfile.name,
+      direction: "import",
+      format: "railkeeper-json",
+      areas: ["vehicles"],
+      state: "review_required",
+      stage: "review",
+      sourceName: "fahrzeugsets.json",
+      revision: 2,
+      totalRecords: 3,
+      errorRecords: 1,
+      preview: { records, vehicleSets }
+    });
+    const readyJob = {
+      ...persistedJob,
+      state: "ready" as const,
+      revision: 3,
+      readyRecords: 3,
+      errorRecords: 0
+    };
+    const onResolve = vi.fn(async () => readyJob);
+
+    render(<TransferImportDialog
+      initialDetails={{ job: persistedJob, issues: [setIssue], artifacts: [] }}
+      initialJob={persistedJob}
+      initialRequiresReupload={false}
+      language="de"
+      onCancelJob={vi.fn(async () => undefined)}
+      onClose={vi.fn()}
+      onConfirm={vi.fn(async () => undefined)}
+      onCreateJob={vi.fn(async () => draftImportJob)}
+      onRefreshJob={vi.fn(async () => ({ job: readyJob, issues: [], artifacts: [] }))}
+      onResolve={onResolve}
+      onUpload={vi.fn(async () => previewFixture)}
+      profiles={[jsonImportProfile]}
+    />);
+
+    const setReview = screen.getByRole("heading", { name: "Erkannte Fahrzeugsets" }).closest("section")!;
+    expect(setReview).toBeVisible();
+    expect(within(setReview).getByText("Set-001")).toBeVisible();
+    expect(within(setReview).getByText("Nahverkehr")).toBeVisible();
+    expect(within(setReview).getAllByText("2 Mitglieder")).toHaveLength(2);
+    expect(within(setReview).getByText("Bereit")).toBeVisible();
+    await user.click(screen.getByLabelText("Auflösung für Set Set-002"));
+    expect(screen.getByRole("option", { name: "Bestehendes Set aktualisieren" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Als neues Set importieren" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Dieses Set nicht importieren" })).toBeInTheDocument();
+    await user.click(screen.getByRole("option", { name: "Bestehendes Set aktualisieren" }));
+
+    expect(onResolve).toHaveBeenCalledWith("job-set-import", "issue-set-2", "replace");
+    expect(await screen.findByRole("button", { name: "3 Datensätze importieren" })).toBeEnabled();
+  });
+
+  it("excludes every member when a detected vehicle set is skipped", () => {
+    const records = ["RK-A", "RK-B", "RK-C"].map((recordKey) => ({
+      area: "vehicles" as const,
+      recordKey,
+      classification: "ready" as const,
+      proposedAction: "create" as const,
+      data: { inventoryNumber: recordKey }
+    }));
+    const vehicleSets = [vehicleSetPreviewFixture({
+      recordKey: "Set-001",
+      classification: "warning",
+      memberRecordKeys: ["RK-A", "RK-B"],
+      data: vehicleSetDataFixture("Set-001", "Nahverkehr", ["RK-A", "RK-B"])
+    })];
+    const skippedIssue: DataTransferIssue = {
+      ...importIssue,
+      id: "issue-set-skip",
+      recordKey: "Set-001",
+      rowNumber: null,
+      code: "duplicate_vehicle_set_inventory_number",
+      selectedResolution: "skip"
+    };
+    const readyJob = jobFixture({
+      id: "job-set-skip",
+      profileId: jsonImportProfile.id,
+      profileName: jsonImportProfile.name,
+      direction: "import",
+      format: "railkeeper-json",
+      areas: ["vehicles"],
+      state: "ready",
+      stage: "review",
+      sourceName: "fahrzeugsets.json",
+      totalRecords: 3,
+      readyRecords: 3,
+      preview: { records, vehicleSets }
+    });
+
+    render(<TransferImportDialog
+      initialDetails={{ job: readyJob, issues: [skippedIssue], artifacts: [] }}
+      initialJob={readyJob}
+      initialRequiresReupload={false}
+      language="de"
+      onCancelJob={vi.fn(async () => undefined)}
+      onClose={vi.fn()}
+      onConfirm={vi.fn(async () => undefined)}
+      onCreateJob={vi.fn(async () => draftImportJob)}
+      onRefreshJob={vi.fn(async () => ({ job: readyJob, issues: [skippedIssue], artifacts: [] }))}
+      onResolve={vi.fn(async () => readyJob)}
+      onUpload={vi.fn(async () => previewFixture)}
+      profiles={[jsonImportProfile]}
+    />);
+
+    expect(screen.getByRole("button", { name: "1 Datensatz importieren" })).toBeEnabled();
   });
 
   it("retries into a fresh draft flow without confirming the historical import", async () => {
@@ -822,6 +967,52 @@ function jobFixture(overrides: Partial<DataTransferJob> = {}): DataTransferJob {
     createdAt: "2026-08-20T08:00:00Z",
     updatedAt: "2026-08-20T08:00:00Z",
     ...overrides
+  };
+}
+
+function vehicleSetPreviewFixture(
+  overrides: Partial<DataTransferVehicleSetPreview> = {}
+): DataTransferVehicleSetPreview {
+  return {
+    recordKey: "Set-001",
+    classification: "ready",
+    proposedAction: "create",
+    memberRecordKeys: ["RK-A", "RK-B"],
+    data: vehicleSetDataFixture("Set-001", "Fahrzeugset", ["RK-A", "RK-B"]),
+    ...overrides
+  };
+}
+
+function vehicleSetDataFixture(inventoryNumber: string, name: string, memberKeys: string[]) {
+  return {
+    inventoryNumber,
+    name,
+    manufacturer: "Märklin",
+    articleNumber: "12345",
+    articleSourceUrl: "",
+    gauge: "H0",
+    epoch: "VI",
+    railwayCompany: "DB AG",
+    category: "Set",
+    gattung: "",
+    description: "",
+    ean: "",
+    productionPeriod: "",
+    listPrice: "",
+    acquisitionType: "",
+    acquiredFrom: "",
+    purchasePrice: "",
+    purchaseDate: "",
+    storageLocation: "",
+    storageDetails: "",
+    condition: "",
+    conditionDetails: "",
+    packaging: "",
+    members: memberKeys.map((vehicleInventoryNumber, index) => ({
+      vehicleId: "",
+      vehicleInventoryNumber,
+      position: index + 1
+    }))
   };
 }
 

--- a/frontend/src/features/importExport/TransferDialogs.test.tsx
+++ b/frontend/src/features/importExport/TransferDialogs.test.tsx
@@ -355,6 +355,66 @@ describe("data transfer operational dialogs", () => {
     expect(screen.getByRole("option", { name: "Do not import this record" })).toBeInTheDocument();
   });
 
+  it("uses explicit English accessory actions for manufacturer and article matches", async () => {
+    const user = userEvent.setup();
+    const matchingIssue: DataTransferIssue = {
+      ...importIssue,
+      area: "accessories",
+      code: "matching_manufacturer_article_number",
+      proposedResolution: "use_existing",
+      message: "Manufacturer and article number match an existing accessory."
+    };
+    render(<TransferReviewTable
+      busy={false}
+      issues={[matchingIssue]}
+      language="en"
+      onResolve={vi.fn(async () => undefined)}
+      records={[{
+        ...previewFixture.records[0],
+        area: "accessories",
+        classification: "warning",
+        proposedAction: "use_existing"
+      }]}
+    />);
+
+    await user.click(screen.getByLabelText("Resolution for RK-1001"));
+    expect(screen.getByRole("option", { name: "Choose action" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Use existing accessory" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Import as an additional new accessory" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Do not import this record" })).toBeInTheDocument();
+  });
+
+  it("uses explicit German accessory actions for manufacturer and article matches", async () => {
+    const user = userEvent.setup();
+    const matchingIssue: DataTransferIssue = {
+      ...importIssue,
+      area: "accessories",
+      code: "matching_manufacturer_article_number",
+      proposedResolution: "use_existing",
+      message: "Hersteller und Artikelnummer stimmen mit vorhandenem Zubehör überein."
+    };
+    render(<TransferReviewTable
+      busy={false}
+      issues={[matchingIssue]}
+      language="de"
+      onResolve={vi.fn(async () => undefined)}
+      records={[{
+        ...previewFixture.records[0],
+        area: "accessories",
+        classification: "warning",
+        proposedAction: "use_existing"
+      }]}
+    />);
+
+    await user.click(screen.getByLabelText("Auflösung für RK-1001"));
+    expect(screen.getByRole("option", { name: "Aktion wählen" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Vorhandenen Zubehörartikel verwenden" })).toBeInTheDocument();
+    expect(screen.getByRole("option", {
+      name: "Zusätzlich als neuen Zubehörartikel importieren"
+    })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Diesen Datensatz nicht importieren" })).toBeInTheDocument();
+  });
+
   it("shows detected vehicle sets and resolves a set as one unit", async () => {
     const user = userEvent.setup();
     const records = ["RK-A", "RK-B", "RK-C"].map((recordKey, index) => ({

--- a/frontend/src/features/importExport/TransferDialogs.test.tsx
+++ b/frontend/src/features/importExport/TransferDialogs.test.tsx
@@ -725,9 +725,14 @@ describe("data transfer operational dialogs", () => {
     vi.mocked(api.dataTransferJobs).mockResolvedValue([historicalJob]);
     vi.spyOn(api, "dataTransferJob").mockResolvedValue({ job: historicalJob, issues: [], artifacts: [] });
 
-    render(<ImportExportView roles={["Editor"]} />);
+    render(<ImportExportView roles={["Admin"]} />);
     fireEvent.click(await screen.findByRole("button", { name: "Werkstattbestand bearbeiten" }));
     const dialog = screen.getByRole("dialog", { name: "Transferprofil bearbeiten" });
+    const dangerActions = dialog.querySelector(".data-transfer-dialog-actions-danger");
+    const mainActions = dialog.querySelector(".data-transfer-dialog-actions-main");
+    expect(dangerActions).toContainElement(within(dialog).getByRole("button", { name: "Profil deaktivieren" }));
+    expect(mainActions).toContainElement(within(dialog).getByRole("button", { name: "Abbrechen" }));
+    expect(mainActions).toContainElement(within(dialog).getByRole("button", { name: "Änderungen speichern" }));
     const name = within(dialog).getByLabelText("Profilname");
     await user.clear(name);
     await user.type(name, "Werkstattbestand neu");

--- a/frontend/src/features/importExport/TransferDialogs.test.tsx
+++ b/frontend/src/features/importExport/TransferDialogs.test.tsx
@@ -12,6 +12,8 @@ import type {
   DataTransferSummary
 } from "./dataTransferModel";
 import { ImportExportView } from "./ImportExportView";
+import { TransferImportDialog } from "./TransferImportDialog";
+import { TransferReviewTable } from "./TransferReviewTable";
 
 const importProfile = profileFixture({
   id: "profile-import",
@@ -309,14 +311,47 @@ describe("data transfer operational dialogs", () => {
     const blockedConfirm = await within(dialog).findByRole("button", { name: "0 Datensätze importieren" });
     expect(blockedConfirm).toBeDisabled();
     expect(api.confirmDataTransferImport).not.toHaveBeenCalled();
+    const resolutionSelect = within(dialog).getByLabelText("Auflösung für RK-1001");
+    await user.click(resolutionSelect);
+    expect(screen.getByRole("option", { name: "Aktion wählen" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Bestehenden Datensatz überschreiben" })).toBeInTheDocument();
+    expect(screen.getByRole("option", {
+      name: "Als neuen Datensatz mit neuer Inventarnummer importieren"
+    })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Diesen Datensatz nicht importieren" })).toBeInTheDocument();
+    const recordCellContent = within(dialog).getByText("RK-1001").closest(".transfer-review-record");
+    expect(recordCellContent).not.toBeNull();
+    expect(recordCellContent?.parentElement?.tagName).toBe("TD");
 
-    await selectAppOption(user, within(dialog).getByLabelText("Auflösung für RK-1001"),
-      "Vorhandenen Datensatz ersetzen");
+    await user.click(screen.getByRole("option", { name: "Bestehenden Datensatz überschreiben" }));
     const enabledConfirm = await within(dialog).findByRole("button", { name: "1 Datensatz importieren" });
     expect(enabledConfirm).toBeEnabled();
     await user.click(enabledConfirm);
 
     await waitFor(() => expect(api.confirmDataTransferImport).toHaveBeenCalledWith("job-import", 3));
+  });
+
+  it("uses explicit English vehicle actions for manufacturer and article matches", async () => {
+    const user = userEvent.setup();
+    const matchingIssue: DataTransferIssue = {
+      ...importIssue,
+      code: "matching_manufacturer_article_number",
+      proposedResolution: "use_existing",
+      message: "Manufacturer and article number match an existing vehicle."
+    };
+    render(<TransferReviewTable
+      busy={false}
+      issues={[matchingIssue]}
+      language="en"
+      onResolve={vi.fn(async () => undefined)}
+      records={[{ ...previewFixture.records[0], classification: "warning", proposedAction: "use_existing" }]}
+    />);
+
+    await user.click(screen.getByLabelText("Resolution for RK-1001"));
+    expect(screen.getByRole("option", { name: "Choose action" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Use existing vehicle" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Import as an additional new vehicle" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Do not import this record" })).toBeInTheDocument();
   });
 
   it("retries into a fresh draft flow without confirming the historical import", async () => {
@@ -415,9 +450,101 @@ describe("data transfer operational dialogs", () => {
     await user.upload(within(dialog).getByLabelText("Importdatei"), new File(["a;b"], "fahrzeuge.csv"));
     await user.click(within(dialog).getByRole("button", { name: "Weiter zur Prüfung" }));
     await selectAppOption(user, within(dialog).getByLabelText("Auflösung für RK-1001"),
-      "Vorhandenen Datensatz ersetzen");
+      "Bestehenden Datensatz überschreiben");
     expect(await within(dialog).findByRole("alert")).toHaveTextContent("persistente Vorschau wurde neu gelesen");
     expect(within(dialog).getByRole("heading", { name: "Erkannte CSV-Zuordnung" })).toBeInTheDocument();
+  });
+
+  it("keeps accepted CSV mapping after resolving a conflict in the same preview", async () => {
+    const user = userEvent.setup();
+    const persistedReviewJob = {
+      ...previewFixture.job,
+      preview: {
+        records: previewFixture.records,
+        csvMapping: previewFixture.csvMapping,
+        vehicleFields: previewFixture.vehicleFields
+      }
+    };
+    const readyJob = {
+      ...persistedReviewJob,
+      state: "ready" as const,
+      revision: 3,
+      readyRecords: 1,
+      errorRecords: 0
+    };
+    const baseProps = {
+      initialRequiresReupload: false,
+      language: "de" as const,
+      onCancelJob: vi.fn(async () => undefined),
+      onClose: vi.fn(),
+      onConfirm: vi.fn(async () => undefined),
+      onCreateJob: vi.fn(async () => draftImportJob),
+      onRefreshJob: vi.fn(async () => ({ job: readyJob, issues: [], artifacts: [] })),
+      onUpload: vi.fn(async () => previewFixture),
+      profiles: [importProfile]
+    };
+    const onResolve = vi.fn(async () => readyJob);
+    const { rerender } = render(<TransferImportDialog {...baseProps}
+      initialJob={persistedReviewJob}
+      initialDetails={{ job: persistedReviewJob, issues: [importIssue], artifacts: [] }}
+      onResolve={onResolve} />);
+
+    await user.click(screen.getByRole("button", { name: "Weiter zur Prüfung" }));
+    await selectAppOption(user, screen.getByLabelText("Auflösung für RK-1001"),
+      "Bestehenden Datensatz überschreiben");
+    rerender(<TransferImportDialog {...baseProps}
+      initialJob={readyJob}
+      initialDetails={{ job: readyJob, issues: [{ ...importIssue, selectedResolution: "replace" }], artifacts: [] }}
+      onResolve={onResolve} />);
+
+    expect(screen.queryByRole("heading", { name: "Erkannte CSV-Zuordnung" })).not.toBeInTheDocument();
+    expect(screen.getByText("Alle Konflikte sind aufgelöst. Der geprüfte Stand kann importiert werden.")).toBeVisible();
+    expect(screen.getByRole("button", { name: "1 Datensatz importieren" })).toBeEnabled();
+  });
+
+  it.each([
+    ["job", (job: DataTransferJob) => ({ ...job, id: "job-other" }), false],
+    ["source", (job: DataTransferJob) => ({ ...job, sourceSha256: "sha-other" }), false],
+    ["mapping", (job: DataTransferJob) => ({ ...job, preview: {
+      ...job.preview,
+      csvMapping: [{ ...previewFixture.csvMapping![0], targetField: "manufacturer" }]
+    } }), false],
+    ["reupload requirement", (job: DataTransferJob) => job, true]
+  ] as const)("resets accepted CSV mapping after a changed %s", async (_name, changeJob, requiresReupload) => {
+    const user = userEvent.setup();
+    const persistedJob = {
+      ...previewFixture.job,
+      preview: {
+        records: previewFixture.records,
+        csvMapping: previewFixture.csvMapping,
+        vehicleFields: previewFixture.vehicleFields
+      }
+    };
+    const props = {
+      language: "de" as const,
+      onCancelJob: vi.fn(async () => undefined),
+      onClose: vi.fn(),
+      onConfirm: vi.fn(async () => undefined),
+      onCreateJob: vi.fn(async () => draftImportJob),
+      onRefreshJob: vi.fn(async () => ({ job: persistedJob, issues: [importIssue], artifacts: [] })),
+      onResolve: vi.fn(async () => persistedJob),
+      onUpload: vi.fn(async () => previewFixture),
+      profiles: [importProfile]
+    };
+    const { rerender } = render(<TransferImportDialog {...props}
+      initialJob={persistedJob}
+      initialDetails={{ job: persistedJob, issues: [importIssue], artifacts: [] }}
+      initialRequiresReupload={false} />);
+    await user.click(screen.getByRole("button", { name: "Weiter zur Prüfung" }));
+    expect(screen.getByRole("heading", { name: "Vorschau" })).toBeInTheDocument();
+
+    const changedJob = changeJob(persistedJob);
+    rerender(<TransferImportDialog {...props}
+      initialJob={changedJob}
+      initialDetails={{ job: changedJob, issues: [importIssue], artifacts: [] }}
+      initialRequiresReupload={requiresReupload} />);
+
+    expect(await screen.findByRole("heading", { name: "Erkannte CSV-Zuordnung" })).toBeInTheDocument();
   });
 
   it("re-reads a draft export after an execution conflict", async () => {
@@ -449,7 +576,7 @@ describe("data transfer operational dialogs", () => {
     await user.upload(within(dialog).getByLabelText("Importdatei"), new File(["a;b"], "fahrzeuge.csv"));
     await user.click(within(dialog).getByRole("button", { name: "Weiter zur Prüfung" }));
     await selectAppOption(user, within(dialog).getByLabelText("Auflösung für RK-1001"),
-      "Vorhandenen Datensatz ersetzen");
+      "Bestehenden Datensatz überschreiben");
     await user.click(await within(dialog).findByRole("button", { name: "1 Datensatz importieren" }));
     expect(await within(dialog).findByRole("alert")).toHaveTextContent("erneut hochladen");
     expect(within(dialog).getByRole("button", { name: "Weiter zur Prüfung" })).toBeDisabled();
@@ -483,7 +610,7 @@ describe("data transfer operational dialogs", () => {
     await selectAppOption(user, within(dialog).getByLabelText("Importprofil"), jsonImportProfile.name);
     await user.upload(within(dialog).getByLabelText("Importdatei"), new File(["{}"], "backup.json"));
     await selectAppOption(user, within(dialog).getByLabelText("Auflösung für RK-1001"),
-      "Vorhandenen Datensatz ersetzen");
+      "Bestehenden Datensatz überschreiben");
     await user.click(await within(dialog).findByRole("button", { name: "1 Datensatz importieren" }));
 
     expect(await within(dialog).findByRole("alert")).toHaveTextContent("erneut hochladen");

--- a/frontend/src/features/importExport/TransferImportDialog.tsx
+++ b/frontend/src/features/importExport/TransferImportDialog.tsx
@@ -73,6 +73,7 @@ export function TransferImportDialog({
   const [mappingAccepted, setMappingAccepted] = useState(
     Boolean(previewFromDetails(initialJob, initialDetails) && !vehicleCSVMappingRequired(initialJob))
   );
+  const acceptedMappingIdentityRef = useRef<string | null>(null);
   const [requiresReupload, setRequiresReupload] = useState(initialRequiresReupload);
   const requiresReuploadRef = useRef(initialRequiresReupload);
   const [busy, setBusy] = useState(false);
@@ -107,7 +108,12 @@ export function TransferImportDialog({
       setPreview((current) => current?.job.id === persistedPreview.job.id &&
         current.job.revision > persistedPreview.job.revision ? current : persistedPreview);
       setCSVMapping(persistedPreview.csvMapping ?? []);
-      if (!requiresReuploadRef.current) setMappingAccepted(!vehicleCSVMappingRequired(initialJob));
+      if (!requiresReuploadRef.current) {
+        const persistedIdentity = csvMappingIdentity(initialJob, persistedPreview.csvMapping ?? []);
+        const keepAccepted = acceptedMappingIdentityRef.current === persistedIdentity;
+        if (!keepAccepted) acceptedMappingIdentityRef.current = null;
+        setMappingAccepted(!vehicleCSVMappingRequired(initialJob) || keepAccepted);
+      }
     }
   }, [initialDetails, initialJob]);
 
@@ -115,6 +121,7 @@ export function TransferImportDialog({
     requiresReuploadRef.current = initialRequiresReupload;
     setRequiresReupload(initialRequiresReupload);
     if (initialRequiresReupload) {
+      acceptedMappingIdentityRef.current = null;
       setMappingAccepted(false);
       setError(copy.confirmConflictRecovery);
     }
@@ -141,6 +148,7 @@ export function TransferImportDialog({
       setCSVMapping([]);
       setSaveMappingToProfile(false);
       setMappingDirty(false);
+      acceptedMappingIdentityRef.current = null;
       setMappingAccepted(false);
       setRequiresReupload(false);
       requiresReuploadRef.current = false;
@@ -163,6 +171,7 @@ export function TransferImportDialog({
   }
 
   async function uploadFile(nextFile: File) {
+    acceptedMappingIdentityRef.current = null;
     setFile(nextFile);
     setBusy(true);
     setError("");
@@ -200,6 +209,7 @@ export function TransferImportDialog({
   async function applyMapping() {
     if (!preview || !job || !mappingReady) return;
     if (!mappingDirty && !saveMappingToProfile) {
+      acceptedMappingIdentityRef.current = csvMappingIdentity(job, csvMapping);
       setMappingAccepted(true);
       return;
     }
@@ -216,8 +226,10 @@ export function TransferImportDialog({
       });
       setJob(nextPreview.job);
       setPreview(clonePreview(nextPreview));
-      setCSVMapping(cloneCSVMapping(nextPreview.csvMapping));
+      const nextMapping = cloneCSVMapping(nextPreview.csvMapping);
+      setCSVMapping(nextMapping);
       setMappingDirty(false);
+      acceptedMappingIdentityRef.current = csvMappingIdentity(nextPreview.job, nextMapping);
       setMappingAccepted(true);
     } catch (reason) {
       await recoverConflict(reason, job.id, copy.mappingError);
@@ -270,14 +282,20 @@ export function TransferImportDialog({
     if (reuploadRequired) {
       requiresReuploadRef.current = true;
       setRequiresReupload(true);
+      acceptedMappingIdentityRef.current = null;
       setMappingAccepted(false);
     }
     try {
       const details = await onRefreshJob(jobId);
+      const refreshedPreview = previewFromDetails(details.job, details);
+      const refreshedMapping = refreshedPreview?.csvMapping ?? [];
+      const refreshedIdentity = csvMappingIdentity(details.job, refreshedMapping);
+      const keepAccepted = acceptedMappingIdentityRef.current === refreshedIdentity;
+      if (!keepAccepted) acceptedMappingIdentityRef.current = null;
       setJob(details.job);
-      setPreview(previewFromDetails(details.job, details));
-      setCSVMapping(previewFromDetails(details.job, details)?.csvMapping ?? []);
-      setMappingAccepted(!vehicleCSVMappingRequired(details.job) && !reuploadRequired);
+      setPreview(refreshedPreview);
+      setCSVMapping(refreshedMapping);
+      setMappingAccepted(!reuploadRequired && (!vehicleCSVMappingRequired(details.job) || keepAccepted));
       setRequiresReupload(reuploadRequired);
       setError(reuploadRequired ? copy.confirmConflictRecovery : copy.conflictRecovery);
     } catch (refreshError) {
@@ -522,6 +540,15 @@ function clonePreview(preview: DataTransferPreview): DataTransferPreview {
 
 function cloneCSVMapping(mapping: DataTransferCSVColumnMapping[] | undefined) {
   return mapping?.map((column) => ({ ...column })) ?? [];
+}
+
+function csvMappingIdentity(job: DataTransferJob, mapping: DataTransferCSVColumnMapping[]) {
+  const columns = [...mapping]
+    .sort((left, right) => left.index - right.index)
+    .map(({ index, sourceHeader, normalizedHeader, targetField }) =>
+      [index, sourceHeader, normalizedHeader, targetField]
+    );
+  return JSON.stringify([job.id, job.sourceSha256, columns]);
 }
 
 function csvMappingFromPreview(value: unknown): DataTransferCSVColumnMapping[] {

--- a/frontend/src/features/importExport/TransferImportDialog.tsx
+++ b/frontend/src/features/importExport/TransferImportDialog.tsx
@@ -16,10 +16,13 @@ import type {
   DataTransferJobDetails,
   DataTransferPreview,
   DataTransferPreviewRecord,
-  DataTransferProfile
+  DataTransferProfile,
+  DataTransferVehicleSet,
+  DataTransferVehicleSetPreview
 } from "./dataTransferModel";
 import { TransferConfirmDialog, type TransferPendingAction } from "./TransferConfirmDialog";
 import { TransferReviewTable } from "./TransferReviewTable";
+import { TransferSetReview } from "./TransferSetReview";
 
 export type ImportDialogStep = "profile" | "file" | "mapping" | "review" | "confirm";
 
@@ -92,7 +95,16 @@ export function TransferImportDialog({
     const skipped = new Set(preview.issues
       .filter((issue) => issue.selectedResolution === "skip")
       .map((issue) => `${issue.area}:${issue.recordKey}`));
-    return preview.records.filter((record) => !skipped.has(`${record.area}:${record.recordKey}`)).length;
+    const skippedSetMembers = new Set<string>();
+    for (const set of preview.vehicleSets ?? []) {
+      if (skipped.has(`vehicles:${set.recordKey}`)) {
+        for (const memberKey of set.memberRecordKeys) skippedSetMembers.add(memberKey);
+      }
+    }
+    return preview.records.filter((record) =>
+      !skipped.has(`${record.area}:${record.recordKey}`) &&
+      !(record.area === "vehicles" && skippedSetMembers.has(record.recordKey))
+    ).length;
   }, [preview, unresolvedIssues.length]);
   const step = currentStep(profileId, file, preview, job, mappingAccepted, requiresReupload);
   const mappingReady = csvMapping.length === 0 || csvMapping.every((column) => column.origin !== "unmapped");
@@ -431,6 +443,8 @@ export function TransferImportDialog({
               </div>
               <TransferReviewTable busy={busy} issues={preview.issues} language={language} onResolve={resolve}
                 records={preview.records} />
+              <TransferSetReview busy={busy} issues={preview.issues} language={language} onResolve={resolve}
+                sets={preview.vehicleSets ?? []} />
               {unresolvedIssues.length > 0 ? (
                 <p className="form-message error" role="status">{copy.unresolved.replace("{count}", String(unresolvedIssues.length))}</p>
               ) : (
@@ -507,7 +521,8 @@ function previewFromDetails(job?: DataTransferJob, details?: DataTransferJobDeta
     warningRecords: job.warningRecords,
     errorRecords: job.errorRecords,
     csvMapping: csvMappingFromPreview(job.preview.csvMapping),
-    vehicleFields: vehicleFieldsFromPreview(job.preview.vehicleFields)
+    vehicleFields: vehicleFieldsFromPreview(job.preview.vehicleFields),
+    vehicleSets: vehicleSetPreviewsFromPreview(job.preview.vehicleSets)
   };
 }
 
@@ -534,7 +549,21 @@ function clonePreview(preview: DataTransferPreview): DataTransferPreview {
     vehicleFields: preview.vehicleFields?.map((field) => ({
       ...field,
       aliases: field.aliases ? [...field.aliases] : undefined
-    }))
+    })),
+    vehicleSets: preview.vehicleSets?.map(cloneVehicleSetPreview)
+  };
+}
+
+function cloneVehicleSetPreview(set: DataTransferVehicleSetPreview): DataTransferVehicleSetPreview {
+  return {
+    ...set,
+    memberRecordKeys: [...set.memberRecordKeys],
+    rowNumbers: set.rowNumbers ? [...set.rowNumbers] : undefined,
+    diagnostics: set.diagnostics?.map((diagnostic) => ({ ...diagnostic })),
+    data: {
+      ...set.data,
+      members: set.data.members.map((member) => ({ ...member }))
+    }
   };
 }
 
@@ -570,6 +599,70 @@ function vehicleFieldsFromPreview(value: unknown): DataTransferPreview["vehicleF
     return typeof field.key === "string" && typeof field.labelDE === "string" &&
       typeof field.labelEN === "string" && ["string", "integer", "boolean"].includes(String(field.kind));
   }).map((field) => ({ ...field }));
+}
+
+const vehicleSetStringFields = [
+  "inventoryNumber", "name", "manufacturer", "articleNumber", "articleSourceUrl", "gauge", "epoch",
+  "railwayCompany", "category", "gattung", "description", "ean", "productionPeriod", "listPrice",
+  "acquisitionType", "acquiredFrom", "purchasePrice", "purchaseDate", "storageLocation", "storageDetails",
+  "condition", "conditionDetails", "packaging"
+] as const satisfies readonly (keyof DataTransferVehicleSet)[];
+const vehicleSetOptionalStringFields = ["id", "createdAt", "updatedAt"] as const;
+const vehicleSetPreviewOptionalStringFields = ["targetId", "targetUpdatedAt", "targetFingerprint"] as const;
+
+function vehicleSetPreviewsFromPreview(value: unknown): DataTransferVehicleSetPreview[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter(isVehicleSetPreview).map(cloneVehicleSetPreview);
+}
+
+function isVehicleSetPreview(value: unknown): value is DataTransferVehicleSetPreview {
+  if (!isRecord(value)) return false;
+  return typeof value.recordKey === "string" &&
+    typeof value.classification === "string" &&
+    ["ready", "warning", "error"].includes(value.classification) &&
+    typeof value.proposedAction === "string" &&
+    ["create", "replace", "use_existing", "copy"].includes(value.proposedAction) &&
+    hasOptionalStrings(value, vehicleSetPreviewOptionalStringFields) &&
+    isStringArray(value.memberRecordKeys) &&
+    (value.rowNumbers === undefined || isNumberArray(value.rowNumbers)) &&
+    (value.diagnostics === undefined || isVehicleSetDiagnostics(value.diagnostics)) &&
+    isVehicleSet(value.data);
+}
+
+function isVehicleSet(value: unknown): value is DataTransferVehicleSet {
+  if (!isRecord(value) || !vehicleSetStringFields.every((field) => typeof value[field] === "string")) return false;
+  if (!hasOptionalStrings(value, vehicleSetOptionalStringFields)) return false;
+  if (!Array.isArray(value.members)) return false;
+  return value.members.every((member) => isRecord(member) &&
+    typeof member.vehicleId === "string" &&
+    typeof member.vehicleInventoryNumber === "string" &&
+    typeof member.position === "number" &&
+    (member.label === undefined || typeof member.label === "string")
+  );
+}
+
+function isVehicleSetDiagnostics(value: unknown): boolean {
+  return Array.isArray(value) && value.every((diagnostic) => isRecord(diagnostic) &&
+    typeof diagnostic.rowNumber === "number" &&
+    typeof diagnostic.field === "string" &&
+    typeof diagnostic.code === "string"
+  );
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+function isNumberArray(value: unknown): value is number[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "number");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object";
+}
+
+function hasOptionalStrings(value: Record<string, unknown>, fields: readonly string[]) {
+  return fields.every((field) => value[field] === undefined || typeof value[field] === "string");
 }
 
 function mappingOriginLabel(origin: DataTransferCSVColumnMapping["origin"], language: Language) {

--- a/frontend/src/features/importExport/TransferProfileDialog.tsx
+++ b/frontend/src/features/importExport/TransferProfileDialog.tsx
@@ -192,19 +192,21 @@ export function TransferProfileDialog({
 
           {error ? <p className="form-message error" role="alert">{error}</p> : null}
           <footer className="data-transfer-dialog-actions">
-            {profile && canDisable ? (
-              <button type="button" className="danger-button" disabled={busy}
-                onClick={() => setDisableConfirmationOpen(true)}>
-                <Trash2 size={16} aria-hidden="true" />{copy.disable}
-              </button>
-            ) : <span />}
-            <span>
+            <div className="data-transfer-dialog-actions-danger">
+              {profile && canDisable ? (
+                <button type="button" className="danger-button" disabled={busy}
+                  onClick={() => setDisableConfirmationOpen(true)}>
+                  <Trash2 size={16} aria-hidden="true" />{copy.disable}
+                </button>
+              ) : null}
+            </div>
+            <div className="data-transfer-dialog-actions-main">
               <button type="button" className="secondary-button" disabled={busy} onClick={onClose}>{copy.cancel}</button>
               <button type="submit" className="primary-button"
                 disabled={busy || !name.trim() || areas.length === 0 || (format === "csv" && csvUnavailable)}>
                 <Save size={16} aria-hidden="true" />{profile ? copy.save : copy.create}
               </button>
-            </span>
+            </div>
           </footer>
         </form>
         <TransferConfirmDialog action={disableAction} cancelLabel={copy.cancel}

--- a/frontend/src/features/importExport/TransferProfilesTable.tsx
+++ b/frontend/src/features/importExport/TransferProfilesTable.tsx
@@ -1,4 +1,5 @@
 import { Database, FileDown, FileUp, MoreVertical, Plus } from "lucide-react";
+import type { KeyboardEvent } from "react";
 
 import { formatDateTime, type Language } from "../../shared/i18n";
 import type { DataTransferArea, DataTransferProfile } from "./dataTransferModel";
@@ -61,7 +62,13 @@ export function TransferProfilesTable({
             ) : profiles.map((profile) => {
               const RunIcon = profile.direction === "import" ? FileUp : FileDown;
               const runTitle = t(`importExport.dashboard.profiles.run.${profile.direction}`);
-              return <tr key={profile.id}>
+              return <tr
+                className={canEdit ? "transfer-profile-row" : undefined}
+                key={profile.id}
+                onClick={canEdit ? () => onEdit(profile.id) : undefined}
+                onKeyDown={canEdit ? (event) => editFromKeyboard(event, profile.id, onEdit) : undefined}
+                tabIndex={canEdit ? 0 : undefined}
+              >
                 <td><strong className="data-transfer-truncate" title={profile.name}>{profile.name}</strong></td>
                 <td>{t(`importExport.dashboard.profiles.${profile.direction}`)}</td>
                 <td>
@@ -83,7 +90,10 @@ export function TransferProfilesTable({
                         aria-label={`${profile.name} ${t("importExport.dashboard.profiles.start")}`}
                         title={runTitle}
                         disabled={mutating}
-                        onClick={() => onRun(profile)}
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          onRun(profile);
+                        }}
                       >
                         <RunIcon size={16} aria-hidden="true" />
                       </button>
@@ -94,7 +104,10 @@ export function TransferProfilesTable({
                         className="icon-button transfer-row-menu"
                         aria-label={`${profile.name} ${t("importExport.dashboard.profiles.edit")}`}
                         title={t("importExport.dashboard.profiles.edit")}
-                        onClick={() => onEdit(profile.id)}
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          onEdit(profile.id);
+                        }}
                       >
                         <MoreVertical size={16} aria-hidden="true" />
                       </button>
@@ -108,6 +121,16 @@ export function TransferProfilesTable({
       </div>
     </section>
   );
+}
+
+function editFromKeyboard(
+  event: KeyboardEvent<HTMLTableRowElement>,
+  profileId: string,
+  onEdit: (profileId: string) => void
+) {
+  if (event.key !== "Enter" && event.key !== " ") return;
+  event.preventDefault();
+  onEdit(profileId);
 }
 
 function areaLabels(areas: DataTransferArea[], t: Translate) {

--- a/frontend/src/features/importExport/TransferProfilesTable.tsx
+++ b/frontend/src/features/importExport/TransferProfilesTable.tsx
@@ -128,6 +128,7 @@ function editFromKeyboard(
   profileId: string,
   onEdit: (profileId: string) => void
 ) {
+  if (event.target !== event.currentTarget) return;
   if (event.key !== "Enter" && event.key !== " ") return;
   event.preventDefault();
   onEdit(profileId);

--- a/frontend/src/features/importExport/TransferReviewTable.tsx
+++ b/frontend/src/features/importExport/TransferReviewTable.tsx
@@ -18,19 +18,19 @@ type TransferReviewTableProps = {
 
 const resolutionLabels = {
   de: {
-    replace: "Vorhandenen Datensatz ersetzen",
+    replace: "Bestehenden Datensatz überschreiben",
     merge: "Einträge zusammenführen",
     copy: "Als Kopie anlegen",
-    skip: "Überspringen",
+    skip: "Diesen Datensatz nicht importieren",
     use_existing: "Vorhandenen Datensatz verwenden",
     create: "Neu anlegen",
     link: "Fahrzeug verknüpfen"
   },
   en: {
-    replace: "Replace existing record",
+    replace: "Overwrite existing record",
     merge: "Merge entries",
     copy: "Create a copy",
-    skip: "Skip",
+    skip: "Do not import this record",
     use_existing: "Use existing record",
     create: "Create new record",
     link: "Link vehicle"
@@ -40,9 +40,9 @@ const resolutionLabels = {
 export function TransferReviewTable({ busy, issues, language, onResolve, records }: TransferReviewTableProps) {
   const copy = language === "de"
     ? { area: "Bereich", record: "Datensatz", status: "Status", action: "Vorschlag", issue: "Prüfung",
-      choose: "Auflösung wählen", row: "Zeile", ready: "Bereit", warning: "Hinweis", error: "Fehler" }
+      choose: "Aktion wählen", row: "Zeile", ready: "Bereit", warning: "Hinweis", error: "Fehler" }
     : { area: "Area", record: "Record", status: "Status", action: "Proposed action", issue: "Review",
-      choose: "Choose resolution", row: "Row", ready: "Ready", warning: "Warning", error: "Error" };
+      choose: "Choose action", row: "Row", ready: "Ready", warning: "Warning", error: "Error" };
 
   return (
     <div className="data-transfer-table-wrap transfer-review-wrap">
@@ -68,8 +68,10 @@ export function TransferReviewTable({ busy, issues, language, onResolve, records
               <tr className={`transfer-review-${record.classification}`} key={`${record.area}-${record.recordKey}-${index}`}>
                 <td>{areaLabel(record.area, language)}</td>
                 <td>
-                  <strong>{record.recordKey || "–"}</strong>
-                  {record.rowNumber ? <small>{copy.row} {record.rowNumber}</small> : null}
+                  <span className="transfer-review-record">
+                    <strong>{record.recordKey || "–"}</strong>
+                    {record.rowNumber ? <small>{copy.row} {record.rowNumber}</small> : null}
+                  </span>
                 </td>
                 <td>
                   <span className={`transfer-review-status ${record.classification}`}>
@@ -93,7 +95,7 @@ export function TransferReviewTable({ busy, issues, language, onResolve, records
                       >
                         <option value="">{copy.choose}</option>
                         {resolutionsFor(issue).map((resolution) => (
-                          <option key={resolution} value={resolution}>{resolutionLabels[language][resolution]}</option>
+                          <option key={resolution} value={resolution}>{resolutionLabel(issue, resolution, language)}</option>
                         ))}
                       </AppSelect>
                     </label>
@@ -106,6 +108,29 @@ export function TransferReviewTable({ busy, issues, language, onResolve, records
       </table>
     </div>
   );
+}
+
+function resolutionLabel(
+  issue: DataTransferIssue,
+  resolution: DataTransferIssueResolution,
+  language: Language
+) {
+  if (issue.code === "duplicate_inventory_number" && resolution === "copy") {
+    return language === "de"
+      ? "Als neuen Datensatz mit neuer Inventarnummer importieren"
+      : "Import as a new record with a new inventory number";
+  }
+  if (issue.code === "matching_manufacturer_article_number") {
+    if (resolution === "use_existing") {
+      return language === "de" ? "Vorhandenes Fahrzeug verwenden" : "Use existing vehicle";
+    }
+    if (resolution === "create") {
+      return language === "de"
+        ? "Zusätzlich als neues Fahrzeug importieren"
+        : "Import as an additional new vehicle";
+    }
+  }
+  return resolutionLabels[language][resolution];
 }
 
 function resolutionsFor(issue: DataTransferIssue): DataTransferIssueResolution[] {

--- a/frontend/src/features/importExport/TransferReviewTable.tsx
+++ b/frontend/src/features/importExport/TransferReviewTable.tsx
@@ -122,9 +122,17 @@ function resolutionLabel(
   }
   if (issue.code === "matching_manufacturer_article_number") {
     if (resolution === "use_existing") {
+      if (issue.area === "accessories") {
+        return language === "de" ? "Vorhandenen Zubehörartikel verwenden" : "Use existing accessory";
+      }
       return language === "de" ? "Vorhandenes Fahrzeug verwenden" : "Use existing vehicle";
     }
     if (resolution === "create") {
+      if (issue.area === "accessories") {
+        return language === "de"
+          ? "Zusätzlich als neuen Zubehörartikel importieren"
+          : "Import as an additional new accessory";
+      }
       return language === "de"
         ? "Zusätzlich als neues Fahrzeug importieren"
         : "Import as an additional new vehicle";

--- a/frontend/src/features/importExport/TransferSetReview.tsx
+++ b/frontend/src/features/importExport/TransferSetReview.tsx
@@ -37,13 +37,14 @@ export function TransferSetReview({ busy, issues, language, onResolve, sets }: T
         {sets.map((set) => {
           const setIssues = issues.filter((item) => item.recordKey === set.recordKey);
           const issue = setIssues.find(isSetConflictIssue);
+          const setLabel = set.data.inventoryNumber.trim() || set.recordKey;
           const Icon = set.classification === "error"
             ? CircleAlert
             : set.classification === "warning" ? AlertTriangle : CheckCircle2;
           return (
             <article className={`transfer-set-review-card ${set.classification}`} key={set.recordKey}>
               <div className="transfer-set-review-main">
-                <strong>{set.recordKey}</strong>
+                <strong>{setLabel}</strong>
                 <span>{set.data.name || copy.unnamed}</span>
                 <small>{memberCount(set.memberRecordKeys.length, language)}</small>
               </div>
@@ -55,7 +56,7 @@ export function TransferSetReview({ busy, issues, language, onResolve, sets }: T
                 <label className="transfer-set-review-resolution">
                   <span>{issue.message}</span>
                   <AppSelect
-                    aria-label={`${copy.resolutionFor} ${set.recordKey}`}
+                    aria-label={`${copy.resolutionFor} ${setLabel}`}
                     disabled={busy}
                     value={issue.selectedResolution}
                     onChange={(event) => {

--- a/frontend/src/features/importExport/TransferSetReview.tsx
+++ b/frontend/src/features/importExport/TransferSetReview.tsx
@@ -1,0 +1,132 @@
+import { AlertTriangle, CheckCircle2, CircleAlert, Layers3 } from "lucide-react";
+
+import type { Language } from "../../shared/i18n";
+import { AppSelect } from "../../shared/ui/AppSelect";
+import type {
+  DataTransferIssue,
+  DataTransferIssueResolution,
+  DataTransferVehicleSetPreview
+} from "./dataTransferModel";
+
+type TransferSetReviewProps = {
+  busy: boolean;
+  issues: DataTransferIssue[];
+  language: Language;
+  onResolve: (issue: DataTransferIssue, resolution: DataTransferIssueResolution) => Promise<void>;
+  sets: DataTransferVehicleSetPreview[];
+};
+
+type SetResolution = Extract<DataTransferIssueResolution, "replace" | "copy" | "skip">;
+
+const setResolutions = {
+  duplicate_vehicle_set_inventory_number: ["replace", "copy", "skip"],
+  vehicle_set_member_external_conflict: ["copy", "skip"]
+} satisfies Record<string, SetResolution[]>;
+
+export function TransferSetReview({ busy, issues, language, onResolve, sets }: TransferSetReviewProps) {
+  if (sets.length === 0) return null;
+  const copy = setReviewCopy(language);
+
+  return (
+    <section className="transfer-set-review" aria-labelledby="transfer-set-review-title">
+      <header>
+        <Layers3 size={18} aria-hidden="true" />
+        <h4 id="transfer-set-review-title">{copy.title}</h4>
+      </header>
+      <div className="transfer-set-review-list">
+        {sets.map((set) => {
+          const setIssues = issues.filter((item) => item.recordKey === set.recordKey);
+          const issue = setIssues.find(isSetConflictIssue);
+          const Icon = set.classification === "error"
+            ? CircleAlert
+            : set.classification === "warning" ? AlertTriangle : CheckCircle2;
+          return (
+            <article className={`transfer-set-review-card ${set.classification}`} key={set.recordKey}>
+              <div className="transfer-set-review-main">
+                <strong>{set.recordKey}</strong>
+                <span>{set.data.name || copy.unnamed}</span>
+                <small>{memberCount(set.memberRecordKeys.length, language)}</small>
+              </div>
+              <span className={`transfer-review-status ${set.classification}`}>
+                <Icon size={15} aria-hidden="true" />
+                {copy[set.classification]}
+              </span>
+              {issue ? (
+                <label className="transfer-set-review-resolution">
+                  <span>{issue.message}</span>
+                  <AppSelect
+                    aria-label={`${copy.resolutionFor} ${set.recordKey}`}
+                    disabled={busy}
+                    value={issue.selectedResolution}
+                    onChange={(event) => {
+                      const resolution = event.target.value as DataTransferIssueResolution;
+                      if (resolution) void onResolve(issue, resolution);
+                    }}
+                  >
+                    <option value="">{copy.choose}</option>
+                    {resolutionsForSetIssue(issue).map((resolution) => (
+                      <option key={resolution} value={resolution}>{copy.resolutions[resolution]}</option>
+                    ))}
+                  </AppSelect>
+                </label>
+              ) : setIssues.length || set.diagnostics?.length ? (
+                <span className="transfer-set-review-diagnostic">
+                  {setIssues.length
+                    ? setIssues.map((item) => item.message).join(" ")
+                    : set.diagnostics?.map((diagnostic) => diagnostic.code).join(", ")}
+                </span>
+              ) : null}
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+function isSetConflictIssue(issue: DataTransferIssue) {
+  return issue.code === "duplicate_vehicle_set_inventory_number" ||
+    issue.code === "vehicle_set_member_external_conflict";
+}
+
+function resolutionsForSetIssue(issue: DataTransferIssue): SetResolution[] {
+  if (issue.code === "duplicate_vehicle_set_inventory_number") {
+    return setResolutions.duplicate_vehicle_set_inventory_number;
+  }
+  return setResolutions.vehicle_set_member_external_conflict;
+}
+
+function memberCount(count: number, language: Language) {
+  if (language === "de") return `${count} ${count === 1 ? "Mitglied" : "Mitglieder"}`;
+  return `${count} ${count === 1 ? "member" : "members"}`;
+}
+
+function setReviewCopy(language: Language) {
+  return language === "de" ? {
+    title: "Erkannte Fahrzeugsets",
+    unnamed: "Unbenanntes Set",
+    ready: "Bereit",
+    warning: "Hinweis",
+    error: "Fehler",
+    choose: "Aktion wählen",
+    resolutionFor: "Auflösung für Set",
+    resolutions: {
+      replace: "Bestehendes Set aktualisieren",
+      copy: "Als neues Set importieren",
+      skip: "Dieses Set nicht importieren"
+    }
+  } : {
+    title: "Detected vehicle sets",
+    unnamed: "Unnamed set",
+    ready: "Ready",
+    warning: "Warning",
+    error: "Error",
+    choose: "Choose action",
+    resolutionFor: "Resolution for set",
+    resolutions: {
+      replace: "Update existing set",
+      copy: "Import as a new set",
+      skip: "Do not import this set"
+    }
+  };
+}

--- a/frontend/src/features/importExport/dataTransferDashboardStyles.test.ts
+++ b/frontend/src/features/importExport/dataTransferDashboardStyles.test.ts
@@ -45,4 +45,11 @@ describe("data transfer dashboard styles", () => {
     expect(dialogStyles).toMatch(/\.data-transfer-dialog-body\s*\{[^}]*scrollbar-gutter:\s*stable/s);
     expect(dialogStyles).toMatch(/\.transfer-review-wrap\s*\{[^}]*overflow:\s*auto/s);
   });
+
+  it("keeps the review table cell in the table formatting context", () => {
+    const dialogStyles = readFileSync(resolve(process.cwd(), "src/styles/data-transfer-dialogs.css"), "utf8");
+
+    expect(dialogStyles).not.toMatch(/\.transfer-review-table td:nth-child\(2\)\s*\{[^}]*display:\s*grid/s);
+    expect(dialogStyles).toMatch(/\.transfer-review-record\s*\{[^}]*display:\s*grid/s);
+  });
 });

--- a/frontend/src/features/importExport/dataTransferDashboardStyles.test.ts
+++ b/frontend/src/features/importExport/dataTransferDashboardStyles.test.ts
@@ -62,5 +62,8 @@ describe("data transfer dashboard styles", () => {
     expect(dialogStyles).toMatch(
       /@media \(max-width:\s*680px\)[\s\S]*\.data-transfer-dialog-actions-main[^}]*width:\s*100%/
     );
+    expect(dialogStyles).toMatch(
+      /@media \(max-width:\s*680px\)[\s\S]*\.confirm-layer\.data-transfer-dialog-layer\s*\{[^}]*padding:\s*8px/
+    );
   });
 });

--- a/frontend/src/features/importExport/dataTransferDashboardStyles.test.ts
+++ b/frontend/src/features/importExport/dataTransferDashboardStyles.test.ts
@@ -52,4 +52,15 @@ describe("data transfer dashboard styles", () => {
     expect(dialogStyles).not.toMatch(/\.transfer-review-table td:nth-child\(2\)\s*\{[^}]*display:\s*grid/s);
     expect(dialogStyles).toMatch(/\.transfer-review-record\s*\{[^}]*display:\s*grid/s);
   });
+
+  it("keeps editable profile rows visible on focus and dialog actions aligned", () => {
+    const dashboardStyles = readFileSync(resolve(process.cwd(), "src/styles/data-transfer-dashboard.css"), "utf8");
+    const dialogStyles = readFileSync(resolve(process.cwd(), "src/styles/data-transfer-dialogs.css"), "utf8");
+
+    expect(dashboardStyles).toMatch(/\.transfer-profile-row:focus-visible\s*\{[^}]*outline:/s);
+    expect(dialogStyles).toMatch(/\.data-transfer-dialog-actions-main\s*\{[^}]*flex-wrap:\s*nowrap/s);
+    expect(dialogStyles).toMatch(
+      /@media \(max-width:\s*680px\)[\s\S]*\.data-transfer-dialog-actions-main[^}]*width:\s*100%/
+    );
+  });
 });

--- a/frontend/src/features/importExport/dataTransferModel.ts
+++ b/frontend/src/features/importExport/dataTransferModel.ts
@@ -154,6 +154,62 @@ export type DataTransferPreviewRecord = {
   data: Record<string, unknown>;
 };
 
+export type DataTransferVehicleSetMember = {
+  vehicleId: string;
+  vehicleInventoryNumber: string;
+  position: number;
+  label?: string;
+};
+
+export type DataTransferVehicleSet = {
+  id?: string;
+  inventoryNumber: string;
+  name: string;
+  manufacturer: string;
+  articleNumber: string;
+  articleSourceUrl: string;
+  gauge: string;
+  epoch: string;
+  railwayCompany: string;
+  category: string;
+  gattung: string;
+  description: string;
+  ean: string;
+  productionPeriod: string;
+  listPrice: string;
+  acquisitionType: string;
+  acquiredFrom: string;
+  purchasePrice: string;
+  purchaseDate: string;
+  storageLocation: string;
+  storageDetails: string;
+  condition: string;
+  conditionDetails: string;
+  packaging: string;
+  members: DataTransferVehicleSetMember[];
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+export type DataTransferVehicleSetDiagnostic = {
+  rowNumber: number;
+  field: string;
+  code: string;
+};
+
+export type DataTransferVehicleSetPreview = {
+  recordKey: string;
+  classification: "ready" | "warning" | "error";
+  proposedAction: DataTransferProposedAction;
+  targetId?: string;
+  targetUpdatedAt?: string;
+  targetFingerprint?: string;
+  memberRecordKeys: string[];
+  rowNumbers?: number[];
+  diagnostics?: DataTransferVehicleSetDiagnostic[];
+  data: DataTransferVehicleSet;
+};
+
 export type DataTransferPreview = {
   job: DataTransferJob;
   records: DataTransferPreviewRecord[];
@@ -164,6 +220,7 @@ export type DataTransferPreview = {
   errorRecords: number;
   csvMapping?: DataTransferCSVColumnMapping[];
   vehicleFields?: VehicleTransferField[];
+  vehicleSets?: DataTransferVehicleSetPreview[];
 };
 
 export type DataTransferSummary = {

--- a/frontend/src/styles/data-transfer-dashboard.css
+++ b/frontend/src/styles/data-transfer-dashboard.css
@@ -477,6 +477,20 @@
   color: var(--accent-strong);
 }
 
+.transfer-profile-row {
+  cursor: pointer;
+}
+
+.transfer-profile-row:hover td,
+.transfer-profile-row:focus-visible td {
+  background: color-mix(in srgb, var(--accent) 5%, var(--panel));
+}
+
+.transfer-profile-row:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
 .transfer-profile-actions {
   display: inline-flex;
   align-items: center;

--- a/frontend/src/styles/data-transfer-dialogs.css
+++ b/frontend/src/styles/data-transfer-dialogs.css
@@ -198,6 +198,19 @@
   gap: 8px;
 }
 
+.data-transfer-dialog-actions-danger,
+.data-transfer-dialog-actions-main {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.data-transfer-dialog-actions-main {
+  flex-wrap: nowrap;
+  justify-content: flex-end;
+  margin-left: auto;
+}
+
 .data-transfer-dialog-actions button,
 .transfer-export-result a,
 .data-transfer-file-drop .secondary-button {
@@ -618,5 +631,15 @@
   .data-transfer-dialog-actions > span,
   .data-transfer-dialog-actions button {
     width: 100%;
+  }
+
+  .data-transfer-dialog-actions-danger,
+  .data-transfer-dialog-actions-main {
+    width: 100%;
+    flex-direction: column;
+  }
+
+  .data-transfer-dialog-actions-main {
+    margin-left: 0;
   }
 }

--- a/frontend/src/styles/data-transfer-dialogs.css
+++ b/frontend/src/styles/data-transfer-dialogs.css
@@ -402,12 +402,12 @@
   min-width: 760px;
 }
 
-.transfer-review-table td:nth-child(2) {
+.transfer-review-record {
   display: grid;
   gap: 2px;
 }
 
-.transfer-review-table td:nth-child(2) small {
+.transfer-review-record small {
   color: var(--muted);
   font-size: var(--font-size-xs);
 }

--- a/frontend/src/styles/data-transfer-dialogs.css
+++ b/frontend/src/styles/data-transfer-dialogs.css
@@ -425,6 +425,73 @@
   font-size: var(--font-size-xs);
 }
 
+.transfer-set-review {
+  display: grid;
+  gap: 9px;
+}
+
+.transfer-set-review > header {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.transfer-set-review > header svg {
+  color: var(--accent-strong);
+}
+
+.transfer-set-review h4 {
+  margin: 0;
+  font-size: var(--font-size-md);
+}
+
+.transfer-set-review-list {
+  display: grid;
+  gap: 8px;
+}
+
+.transfer-set-review-card {
+  display: grid;
+  min-width: 0;
+  grid-template-columns: minmax(170px, 0.8fr) auto minmax(280px, 1.4fr);
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--panel-subtle);
+}
+
+.transfer-set-review-main {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+}
+
+.transfer-set-review-main strong,
+.transfer-set-review-main span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.transfer-set-review-main small,
+.transfer-set-review-diagnostic {
+  color: var(--muted);
+  font-size: var(--font-size-xs);
+}
+
+.transfer-set-review-resolution {
+  display: grid;
+  min-width: 0;
+  gap: 6px;
+}
+
+.transfer-set-review-resolution > span {
+  color: var(--muted);
+  font-size: var(--font-size-xs);
+}
+
 .transfer-review-error td {
   background: color-mix(in srgb, var(--danger) 5%, var(--panel));
 }
@@ -621,6 +688,10 @@
   .data-transfer-file-drop .secondary-button,
   .transfer-export-result .secondary-button {
     grid-column: 1 / -1;
+  }
+
+  .transfer-set-review-card {
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .data-transfer-dialog-actions {

--- a/frontend/src/styles/data-transfer-dialogs.css
+++ b/frontend/src/styles/data-transfer-dialogs.css
@@ -1,5 +1,5 @@
 /* Persistent data-transfer dialogs. Dashboard topology and colors remain owned by data-transfer-dashboard.css. */
-.data-transfer-dialog-layer {
+.confirm-layer.data-transfer-dialog-layer {
   padding: 16px;
   overflow: auto;
 }
@@ -74,7 +74,7 @@
   font: inherit;
 }
 
-.data-transfer-confirm-layer {
+.confirm-layer.data-transfer-confirm-layer {
   z-index: 140;
   padding: 16px;
 }
@@ -660,7 +660,11 @@
 }
 
 @media (max-width: 680px) {
-  .data-transfer-dialog-layer {
+  .confirm-layer.data-transfer-dialog-layer {
+    padding: 8px;
+  }
+
+  .confirm-layer.data-transfer-confirm-layer {
     padding: 8px;
   }
 

--- a/openapi/railkeeper.yaml
+++ b/openapi/railkeeper.yaml
@@ -273,6 +273,9 @@ components:
           $ref: "#/components/schemas/TransferIssueSeverity"
         code:
           type: string
+          description: >-
+            Stable conflict or validation code. Vehicle-set groups additionally use
+            duplicate_vehicle_set_inventory_number and vehicle_set_member_external_conflict.
         message:
           type: string
         proposedResolution:
@@ -314,6 +317,88 @@ components:
         data:
           type: object
           additionalProperties: true
+    DataTransferVehicleSetMember:
+      type: object
+      required: [vehicleId, vehicleInventoryNumber, position]
+      properties:
+        vehicleId:
+          type: string
+          description: Source vehicle ID used only to resolve members inside the transfer package.
+        vehicleInventoryNumber:
+          type: string
+        position:
+          type: integer
+          minimum: 1
+        label:
+          type: string
+    DataTransferVehicleSet:
+      allOf:
+        - $ref: "#/components/schemas/VehicleSetInput"
+        - type: object
+          required: [inventoryNumber, members]
+          properties:
+            id:
+              type: string
+              description: Source set ID. Target installations assign their own ID.
+            inventoryNumber:
+              type: string
+            members:
+              type: array
+              minItems: 2
+              items:
+                $ref: "#/components/schemas/DataTransferVehicleSetMember"
+            createdAt:
+              type: string
+              format: date-time
+            updatedAt:
+              type: string
+              format: date-time
+    DataTransferVehicleSetDiagnostic:
+      type: object
+      required: [rowNumber, field, code]
+      properties:
+        rowNumber:
+          type: integer
+          minimum: 0
+        field:
+          type: string
+        code:
+          type: string
+          description: Stable code for an invalid or inconsistent vehicle-set group.
+    DataTransferVehicleSetPreview:
+      type: object
+      required: [recordKey, classification, proposedAction, memberRecordKeys, data]
+      properties:
+        recordKey:
+          type: string
+        classification:
+          type: string
+          enum: [ready, warning, error]
+        proposedAction:
+          $ref: "#/components/schemas/TransferProposedAction"
+        targetId:
+          type: string
+        targetUpdatedAt:
+          type: string
+        targetFingerprint:
+          type: string
+          description: SHA-256 fingerprint of the complete target set and its memberships.
+        memberRecordKeys:
+          type: array
+          minItems: 2
+          items:
+            type: string
+        rowNumbers:
+          type: array
+          items:
+            type: integer
+            minimum: 1
+        diagnostics:
+          type: array
+          items:
+            $ref: "#/components/schemas/DataTransferVehicleSetDiagnostic"
+        data:
+          $ref: "#/components/schemas/DataTransferVehicleSet"
     DataTransferCSVColumnMapping:
       type: object
       required: [index, sourceHeader, normalizedHeader, targetField, origin]
@@ -363,12 +448,16 @@ components:
             $ref: "#/components/schemas/DataTransferIssue"
         totalRecords:
           type: integer
+          description: Number of vehicle and other area records. Vehicle-set metadata is not counted separately.
         readyRecords:
           type: integer
+          description: Ready area records. Vehicle-set metadata is not counted separately.
         warningRecords:
           type: integer
+          description: Area records with warnings. Vehicle-set metadata is not counted separately.
         errorRecords:
           type: integer
+          description: Area records with errors. Vehicle-set metadata is not counted separately.
         csvMapping:
           type: array
           items:
@@ -377,6 +466,11 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/VehicleTransferField"
+        vehicleSets:
+          type: array
+          description: Detected vehicle-set groups reviewed and resolved as one unit.
+          items:
+            $ref: "#/components/schemas/DataTransferVehicleSetPreview"
     DataTransferSummary:
       type: object
       required: [openJobs, selectedRecords, lastExportAt, artifactCount, artifactBytes,


### PR DESCRIPTION
## Zusammenfassung / Summary

### Deutsch
- Überträgt Fahrzeugsets automatisch mit dem Fahrzeugbereich in RailKeeper-JSON v3 und CSV.
- Erhält Set-Stammdaten, Mitgliedsreihenfolge und Mitgliedslabels, mit atomarem Aktualisieren, Kopieren oder Überspringen ganzer Sets.
- Behebt den verlorenen CSV-Zuordnungszustand, Tabellenversätze, Profilzeilen-Interaktionen und mobile Dialogüberläufe.
- Ergänzt die Set-Gruppenprüfung sowie deutsche und englische Benutzerdokumentation.

### English
- Transfers vehicle sets automatically with the vehicle area in RailKeeper JSON v3 and CSV.
- Preserves set metadata, member order, and member labels, with atomic update, copy, or skip actions for whole sets.
- Fixes lost CSV mapping state, table alignment, profile-row interactions, and mobile dialog overflow.
- Adds grouped set review plus German and English user documentation.

## Validierung / Validation
- `go test ./... -count=1`
- `npm.cmd run test:run -- --reporter=verbose`: 134 Testdateien, 795 Tests bestanden
- `npm.cmd run build`
- `npm.cmd run check` in `docs`: 19 Tests, Validierung und VitePress-Build bestanden
- Browser-Smoke: dreiteiliges CSV-Fahrzeugset importiert und im Bestand geprüft
- Desktop/Mobil, Hell/Dunkel, Maus/Tastatur und Überlauf geprüft

## Dokumentation und API / Documentation and API
- OpenAPI und TypeScript-Vertrag um Set-Vorschauen erweitert, ohne neue Endpunkte.
- JSON-Paketversion 3 dokumentiert; Versionen 1 und 2 bleiben importierbar.
- Deutsche und englische Import/Export-Anleitung aktualisiert.

## Sicherheit und Datenwirkung / Security and data impact
- Rollenprüfung, CSRF-Schutz, persistente Vorschau, Revisionsprüfung und Audit-Log bleiben erhalten.
- Set-Importe laufen atomar in einer SQLite-Transaktion; externe Mitglieder werden nicht still umgehängt.
- Keine Secrets, Laufzeitdaten, generierten Builds oder privaten Backups enthalten.

## Screenshots
- Visuell in der lokalen Anwendung geprüft; keine Binärartefakte in den PR aufgenommen.

## Checkliste / Checklist
- [x] Relevante Go- und Frontendtests sowie Builds ausgeführt.
- [x] Dokumentation und API-Vertrag aktualisiert.
- [x] Keine Secrets, Laufzeitdaten, generierten Builds oder privaten Backups enthalten.
- [x] Beitrag unter AGPL-3.0-only lizenziert und zur Einreichung berechtigt.

Closes #159
Closes #140