### PR TITLE
CSV-Set-Mitgliedsbezeichnungen bei Ersetzung erhalten / Preserve CSV set member labels on replacement

### DIFF
--- a/backend/internal/application/data_transfer_export.go
+++ b/backend/internal/application/data_transfer_export.go
@@ -361,7 +361,7 @@ func marshalDataTransferExport(
 }
 
 func marshalDataTransferPackage(snapshot DataTransferSnapshot, createdAt string) ([]byte, error) {
-	sortDataTransferSnapshot(&snapshot)
+	prepareDataTransferSnapshotForExport(&snapshot)
 	document := DataTransferPackage{
 		Format: DataTransferPackageFormat, Version: DataTransferPackageVersion, CreatedAt: createdAt,
 		Areas: DataTransferPackageAreas(snapshot),
@@ -374,7 +374,7 @@ func marshalDataTransferPackage(snapshot DataTransferSnapshot, createdAt string)
 }
 
 func marshalDataTransferCSV(area TransferArea, snapshot DataTransferSnapshot) ([]byte, error) {
-	sortDataTransferSnapshot(&snapshot)
+	prepareDataTransferSnapshotForExport(&snapshot)
 	var builder strings.Builder
 	writer := csv.NewWriter(&builder)
 	writer.Comma = ';'
@@ -739,6 +739,31 @@ func sortDataTransferSnapshot(snapshot *DataTransferSnapshot) {
 			return compareTransferKeys(left.LocomotiveName, right.LocomotiveName, left.ID, right.ID)
 		})
 	}
+}
+
+func prepareDataTransferSnapshotForExport(snapshot *DataTransferSnapshot) {
+	normalizedSets := make([]TransferVehicleSet, 0, len(snapshot.VehicleSets))
+	for _, set := range snapshot.VehicleSets {
+		if len(set.Members) < 2 {
+			continue
+		}
+		set.Members = slices.Clone(set.Members)
+		slices.SortStableFunc(set.Members, func(left, right TransferVehicleSetMember) int {
+			if left.Position != right.Position {
+				return left.Position - right.Position
+			}
+			return compareTransferKeys(
+				left.VehicleInventoryNumber, right.VehicleInventoryNumber,
+				left.SourceVehicleID, right.SourceVehicleID,
+			)
+		})
+		for index := range set.Members {
+			set.Members[index].Position = index + 1
+		}
+		normalizedSets = append(normalizedSets, set)
+	}
+	snapshot.VehicleSets = normalizedSets
+	sortDataTransferSnapshot(snapshot)
 }
 
 func compareTransferKeys(values ...string) int {

--- a/backend/internal/application/data_transfer_export.go
+++ b/backend/internal/application/data_transfer_export.go
@@ -742,27 +742,29 @@ func sortDataTransferSnapshot(snapshot *DataTransferSnapshot) {
 }
 
 func prepareDataTransferSnapshotForExport(snapshot *DataTransferSnapshot) {
-	normalizedSets := make([]TransferVehicleSet, 0, len(snapshot.VehicleSets))
-	for _, set := range snapshot.VehicleSets {
-		if len(set.Members) < 2 {
-			continue
-		}
-		set.Members = slices.Clone(set.Members)
-		slices.SortStableFunc(set.Members, func(left, right TransferVehicleSetMember) int {
-			if left.Position != right.Position {
-				return left.Position - right.Position
+	if snapshot.VehicleSets != nil {
+		normalizedSets := make([]TransferVehicleSet, 0, len(snapshot.VehicleSets))
+		for _, set := range snapshot.VehicleSets {
+			if len(set.Members) < 2 {
+				continue
 			}
-			return compareTransferKeys(
-				left.VehicleInventoryNumber, right.VehicleInventoryNumber,
-				left.SourceVehicleID, right.SourceVehicleID,
-			)
-		})
-		for index := range set.Members {
-			set.Members[index].Position = index + 1
+			set.Members = slices.Clone(set.Members)
+			slices.SortStableFunc(set.Members, func(left, right TransferVehicleSetMember) int {
+				if left.Position != right.Position {
+					return left.Position - right.Position
+				}
+				return compareTransferKeys(
+					left.VehicleInventoryNumber, right.VehicleInventoryNumber,
+					left.SourceVehicleID, right.SourceVehicleID,
+				)
+			})
+			for index := range set.Members {
+				set.Members[index].Position = index + 1
+			}
+			normalizedSets = append(normalizedSets, set)
 		}
-		normalizedSets = append(normalizedSets, set)
+		snapshot.VehicleSets = normalizedSets
 	}
-	snapshot.VehicleSets = normalizedSets
 	sortDataTransferSnapshot(snapshot)
 }
 

--- a/backend/internal/application/data_transfer_export_test.go
+++ b/backend/internal/application/data_transfer_export_test.go
@@ -70,6 +70,38 @@ func TestDataTransferPackageVersionThreeRoundTripsVehicleSet(t *testing.T) {
 	}
 }
 
+func TestDataTransferExportNormalizesVehicleSetsOnlyDuringSerialization(t *testing.T) {
+	snapshot := validTransferVehicleSetSnapshot()
+	snapshot.VehicleSets[0].Members[1].Position = 3
+	singleton := snapshot.VehicleSets[0]
+	singleton.ID = "source-singleton"
+	singleton.InventoryNumber = "Set-Singleton"
+	singleton.Members = append([]TransferVehicleSetMember(nil), singleton.Members[:1]...)
+	snapshot.VehicleSets = append(snapshot.VehicleSets, singleton)
+
+	payload, err := marshalDataTransferPackage(snapshot, "2026-08-27T10:00:00Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+	document, err := decodeDataTransferPackage(bytes.NewReader(payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(document.Areas.VehicleSets) != 1 {
+		t.Fatalf("exported vehicle sets = %#v", document.Areas.VehicleSets)
+	}
+	set := document.Areas.VehicleSets[0]
+	if len(set.Members) != 2 || set.Members[0].Position != 1 || set.Members[1].Position != 2 {
+		t.Fatalf("normalized exported members = %#v", set.Members)
+	}
+	if err := ValidateTransferVehicleSet(set); err != nil {
+		t.Fatalf("serialized vehicle set is not importable: %v", err)
+	}
+	if snapshot.VehicleSets[0].Members[1].Position != 3 || len(snapshot.VehicleSets) != 2 {
+		t.Fatalf("serialization mutated source snapshot: %#v", snapshot.VehicleSets)
+	}
+}
+
 func TestDataTransferExportVehicleCSVUsesStableSemicolonColumns(t *testing.T) {
 	snapshot := DataTransferSnapshot{Vehicles: []TransferVehicle{
 		{InventoryNumber: "RK-002", Manufacturer: "Märklin", Name: "BR 218; Cargo", Gauge: "H0"},
@@ -202,13 +234,21 @@ func TestDataTransferExportCombinedJSONHasStableOrdering(t *testing.T) {
 
 func TestDataTransferExportJSONSortsVehicleSetsAndMembers(t *testing.T) {
 	snapshot := DataTransferSnapshot{
-		Vehicles: []TransferVehicle{{ID: "v-1", InventoryNumber: "RK-1"}},
+		Vehicles: []TransferVehicle{
+			{ID: "v-1", InventoryNumber: "RK-1"},
+			{ID: "v-2", InventoryNumber: "RK-2"},
+			{ID: "v-3", InventoryNumber: "RK-3"},
+			{ID: "v-4", InventoryNumber: "RK-4"},
+		},
 		VehicleSets: []TransferVehicleSet{
 			{ID: "set-z", InventoryNumber: "Set-010", Members: []TransferVehicleSetMember{
 				{SourceVehicleID: "v-2", VehicleInventoryNumber: "RK-2", Position: 2},
 				{SourceVehicleID: "v-1", VehicleInventoryNumber: "RK-1", Position: 1},
 			}},
-			{ID: "set-a", InventoryNumber: "Set-002"},
+			{ID: "set-a", InventoryNumber: "Set-002", Members: []TransferVehicleSetMember{
+				{SourceVehicleID: "v-4", VehicleInventoryNumber: "RK-4", Position: 2},
+				{SourceVehicleID: "v-3", VehicleInventoryNumber: "RK-3", Position: 1},
+			}},
 		},
 	}
 	payload, err := marshalDataTransferPackage(snapshot, "2026-08-27T10:00:00Z")
@@ -219,7 +259,7 @@ func TestDataTransferExportJSONSortsVehicleSetsAndMembers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if document.Areas.VehicleSets[0].ID != "set-a" ||
+	if document.Areas.VehicleSets[0].ID != "set-a" || document.Areas.VehicleSets[0].Members[0].Position != 1 ||
 		document.Areas.VehicleSets[1].Members[0].Position != 1 {
 		t.Fatalf("unstable vehicle set ordering: %#v", document.Areas.VehicleSets)
 	}

--- a/backend/internal/application/data_transfer_export_test.go
+++ b/backend/internal/application/data_transfer_export_test.go
@@ -102,6 +102,20 @@ func TestDataTransferExportNormalizesVehicleSetsOnlyDuringSerialization(t *testi
 	}
 }
 
+func TestDataTransferExportPreservesUnselectedVehicleSets(t *testing.T) {
+	snapshot := DataTransferSnapshot{Accessories: []TransferAccessory{{
+		InventoryNumber: "RK-ART-1", Manufacturer: "Viessmann", ArticleNumber: "4011",
+		Name: "Signal", Category: "signal", TrackingMode: "bulk",
+	}}}
+	payload, err := marshalDataTransferPackage(snapshot, "2026-08-27T10:00:00Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(payload, []byte(`"vehicleSets"`)) {
+		t.Fatalf("accessory-only export contains unselected vehicle sets: %s", payload)
+	}
+}
+
 func TestDataTransferExportVehicleCSVUsesStableSemicolonColumns(t *testing.T) {
 	snapshot := DataTransferSnapshot{Vehicles: []TransferVehicle{
 		{InventoryNumber: "RK-002", Manufacturer: "Märklin", Name: "BR 218; Cargo", Gauge: "H0"},

--- a/backend/internal/application/data_transfer_vehicle_sets.go
+++ b/backend/internal/application/data_transfer_vehicle_sets.go
@@ -58,6 +58,7 @@ func classifyDataTransferVehicleSets(
 		currentSetsByInventory[transferIdentity(set.InventoryNumber)] = set
 	}
 	seenMembers := map[string]string{}
+	seenSetIDs := map[string]bool{}
 	seenSetInventories := map[string]bool{}
 	for index, set := range incoming.VehicleSets {
 		recordKey := transferVehicleSetRecordKey(set, index)
@@ -65,6 +66,14 @@ func classifyDataTransferVehicleSets(
 			RecordKey: recordKey, Classification: "ready", ProposedAction: "create", Data: set,
 		}
 		preview.Diagnostics = append(preview.Diagnostics, validateTransferVehicleSetStructure(set)...)
+		sourceSetID := strings.TrimSpace(set.ID)
+		if sourceSetID != "" && seenSetIDs[sourceSetID] {
+			preview.Diagnostics = append(preview.Diagnostics, TransferVehicleSetDiagnostic{
+				Field: "id", Code: "duplicate_import_vehicle_set_id",
+			})
+		} else if sourceSetID != "" {
+			seenSetIDs[sourceSetID] = true
+		}
 		setInventoryIdentity := transferIdentity(set.InventoryNumber)
 		if setInventoryIdentity != "" && seenSetInventories[setInventoryIdentity] {
 			preview.Diagnostics = append(preview.Diagnostics, TransferVehicleSetDiagnostic{
@@ -301,6 +310,7 @@ func compactTransferVehicleSetDiagnostics(
 func transferVehicleSetDiagnosticMessage(code string) string {
 	messages := map[string]string{
 		"missing_vehicle_set_inventory_number":          "Vehicle set inventory number is required.",
+		"duplicate_import_vehicle_set_id":               "Vehicle set source ID occurs more than once in the import.",
 		"duplicate_import_vehicle_set_inventory_number": "Vehicle set inventory number occurs more than once in the import.",
 		"invalid_vehicle_set":                           "Vehicle set data violates aggregate validation.",
 		"vehicle_set_too_small":                         "A vehicle set requires at least two members.",

--- a/backend/internal/application/data_transfer_vehicle_sets_test.go
+++ b/backend/internal/application/data_transfer_vehicle_sets_test.go
@@ -120,6 +120,34 @@ func TestClassifyDataTransferVehicleSetsRejectsDuplicateImportedInventoryNumbers
 	assertTransferIssueCode(t, issues, "duplicate_import_vehicle_set_inventory_number")
 }
 
+func TestClassifyDataTransferVehicleSetsRejectsDuplicateSourceIDs(t *testing.T) {
+	incoming := validTransferVehicleSetSnapshot()
+	incoming.Vehicles = append(incoming.Vehicles,
+		TransferVehicle{ID: "source-c", InventoryNumber: "RK-C", Manufacturer: "Roco", Name: "Wagen C",
+			Gauge: "H0", Category: "Wagen", Gattung: "Reisezugwagen"},
+		TransferVehicle{ID: "source-d", InventoryNumber: "RK-D", Manufacturer: "Roco", Name: "Wagen D",
+			Gauge: "H0", Category: "Wagen", Gattung: "Reisezugwagen"},
+	)
+	setInput := incoming.VehicleSets[0].VehicleSetInput
+	incoming.VehicleSets = append(incoming.VehicleSets, TransferVehicleSet{
+		ID: incoming.VehicleSets[0].ID, InventoryNumber: "RK-SET-2", VehicleSetInput: setInput,
+		Members: []TransferVehicleSetMember{
+			{SourceVehicleID: "source-c", VehicleInventoryNumber: "RK-C", Position: 1,
+				DeclaredMemberCount: 2, SourceSetInput: setInput},
+			{SourceVehicleID: "source-d", VehicleInventoryNumber: "RK-D", Position: 2,
+				DeclaredMemberCount: 2, SourceSetInput: setInput},
+		},
+	})
+	records, _ := classifyDataTransferImport("job-duplicate-set-id", incoming, DataTransferSnapshot{}, nil)
+	previews, issues := classifyDataTransferVehicleSets(
+		"job-duplicate-set-id", incoming, DataTransferSnapshot{}, records,
+	)
+	if len(previews) != 2 || previews[0].Classification != "ready" || previews[1].Classification != "error" {
+		t.Fatalf("set previews = %#v", previews)
+	}
+	assertTransferIssueCode(t, issues, "duplicate_import_vehicle_set_id")
+}
+
 func TestClassifyDataTransferVehicleSetConflicts(t *testing.T) {
 	incoming := validTransferVehicleSetSnapshot()
 	current := validTransferVehicleSetSnapshot()

--- a/backend/internal/infrastructure/data_transfer_apply_vehicle_sets_test.go
+++ b/backend/internal/infrastructure/data_transfer_apply_vehicle_sets_test.go
@@ -103,7 +103,7 @@ func TestDataTransferApplyCSVReplacePreservesUnmappedVehicleSetFields(t *testing
 	db := testDB(t)
 	repository := infrastructure.NewDataTransferRepository(db)
 	insertApplyVehicleSet(t, db, "target-set", "RK-SET-CSV", []applyVehicleSetMemberFixture{
-		{ID: "target-a", InventoryNumber: "RK-CSV-A", Position: 1},
+		{ID: "target-a", InventoryNumber: "RK-CSV-A", Position: 1, Label: "Lokale Bezeichnung"},
 		{ID: "target-old", InventoryNumber: "RK-CSV-OLD", Position: 2},
 	})
 	if _, err := db.Exec(`
@@ -122,6 +122,8 @@ WHERE id='target-set'`); err != nil {
 	setPreview.TargetID = targetSet.ID
 	setPreview.TargetFingerprint = application.DataTransferTargetFingerprint(targetSet)
 	setPreview.Data.Name = "CSV-Name"
+	setPreview.Data.Members[0].Label = ""
+	setPreview.Data.Members[1].Label = ""
 	job := createApplyJobWithVehicleSets(
 		t, repository, "sha-set-csv-preserve", records, []application.DataTransferVehicleSetPreview{setPreview},
 	)
@@ -160,6 +162,62 @@ SELECT name, description, storage_location FROM vehicle_sets WHERE id='target-se
 	}
 	if name != "CSV-Name" || description != "Lokale Beschreibung" || storageLocation != "Vitrine 7" {
 		t.Fatalf("CSV replace set fields = %q/%q/%q", name, description, storageLocation)
+	}
+	var memberLabel string
+	if err := db.QueryRow(`
+SELECT label FROM vehicle_set_members
+WHERE vehicle_set_id='target-set' AND vehicle_id='target-a'`).Scan(&memberLabel); err != nil {
+		t.Fatal(err)
+	}
+	if memberLabel != "Lokale Bezeichnung" {
+		t.Fatalf("CSV replace member label = %q, want preserved local label", memberLabel)
+	}
+}
+
+func TestDataTransferApplyCSVReplaceClearsMappedVehicleSetMemberLabel(t *testing.T) {
+	db := testDB(t)
+	repository := infrastructure.NewDataTransferRepository(db)
+	insertApplyVehicleSet(t, db, "target-set", "RK-SET-CSV-LABEL", []applyVehicleSetMemberFixture{
+		{ID: "target-a", InventoryNumber: "RK-CSV-LABEL-A", Position: 1, Label: "Lokale Bezeichnung"},
+		{ID: "target-old", InventoryNumber: "RK-CSV-LABEL-OLD", Position: 2},
+	})
+	targetSet, targetVehicles := applyVehicleSetSnapshot(t, repository, "target-set")
+	records, setPreview := applyVehicleSetPreview(
+		t, "RK-SET-CSV-LABEL", "RK-CSV-LABEL-A", "RK-CSV-LABEL-B",
+	)
+	records[0].ProposedAction = "replace"
+	records[0].TargetID = "target-a"
+	records[0].TargetFingerprint = application.DataTransferTargetFingerprint(targetVehicles["RK-CSV-LABEL-A"])
+	setPreview.Classification = "warning"
+	setPreview.ProposedAction = "replace"
+	setPreview.TargetID = targetSet.ID
+	setPreview.TargetFingerprint = application.DataTransferTargetFingerprint(targetSet)
+	setPreview.Data.Members[0].Label = ""
+	setPreview.Data.Members[1].Label = ""
+	job := createApplyJobWithVehicleSets(
+		t, repository, "sha-set-csv-clear-label", records, []application.DataTransferVehicleSetPreview{setPreview},
+	)
+	job.Preview["csvMapping"] = []application.DataTransferCSVColumnMapping{{TargetField: "vehicleSetMemberLabel"}}
+	var err error
+	job, err = repository.UpdateJob(t.Context(), job)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolveApplyVehicleSetIssue(
+		t, repository, job.ID, setPreview, "duplicate_vehicle_set_inventory_number", "replace",
+	)
+
+	if err := repository.ApplyImport(t.Context(), job, "editor-1"); err != nil {
+		t.Fatal(err)
+	}
+	var memberLabel string
+	if err := db.QueryRow(`
+SELECT label FROM vehicle_set_members
+WHERE vehicle_set_id='target-set' AND vehicle_id='target-a'`).Scan(&memberLabel); err != nil {
+		t.Fatal(err)
+	}
+	if memberLabel != "" {
+		t.Fatalf("CSV replace mapped blank member label = %q, want cleared label", memberLabel)
 	}
 }
 
@@ -357,6 +415,7 @@ type applyVehicleSetMemberFixture struct {
 	ID              string
 	InventoryNumber string
 	Position        int
+	Label           string
 }
 
 func insertApplyVehicleSet(
@@ -380,7 +439,7 @@ INSERT INTO vehicle_sets(
 	for _, member := range members {
 		if _, err := db.Exec(`
 INSERT INTO vehicle_set_members(vehicle_set_id, vehicle_id, position, label)
-VALUES(?, ?, ?, '')`, setID, member.ID, member.Position); err != nil {
+VALUES(?, ?, ?, ?)`, setID, member.ID, member.Position, member.Label); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/backend/internal/infrastructure/data_transfer_snapshot.go
+++ b/backend/internal/infrastructure/data_transfer_snapshot.go
@@ -27,7 +27,6 @@ func (repository *DataTransferRepository) Snapshot(
 			snapshot.Vehicles, err = transferVehicleSnapshot(ctx, tx)
 			if err == nil {
 				snapshot.VehicleSets, err = transferVehicleSetSnapshot(ctx, tx)
-				snapshot.VehicleSets = normalizeTransferVehicleSetsForExport(snapshot.VehicleSets)
 			}
 		case application.TransferAccessories:
 			snapshot.Accessories, err = transferAccessorySnapshot(ctx, tx)
@@ -44,23 +43,6 @@ func (repository *DataTransferRepository) Snapshot(
 		return application.DataTransferSnapshot{}, fmt.Errorf("commit transfer snapshot: %w", err)
 	}
 	return snapshot, nil
-}
-
-func normalizeTransferVehicleSetsForExport(
-	sets []application.TransferVehicleSet,
-) []application.TransferVehicleSet {
-	normalized := make([]application.TransferVehicleSet, 0, len(sets))
-	for _, set := range sets {
-		if len(set.Members) < 2 {
-			continue
-		}
-		set.Members = append([]application.TransferVehicleSetMember(nil), set.Members...)
-		for index := range set.Members {
-			set.Members[index].Position = index + 1
-		}
-		normalized = append(normalized, set)
-	}
-	return normalized
 }
 
 func (repository *DataTransferRepository) GetArtifact(

--- a/backend/internal/infrastructure/data_transfer_snapshot.go
+++ b/backend/internal/infrastructure/data_transfer_snapshot.go
@@ -27,6 +27,7 @@ func (repository *DataTransferRepository) Snapshot(
 			snapshot.Vehicles, err = transferVehicleSnapshot(ctx, tx)
 			if err == nil {
 				snapshot.VehicleSets, err = transferVehicleSetSnapshot(ctx, tx)
+				snapshot.VehicleSets = normalizeTransferVehicleSetsForExport(snapshot.VehicleSets)
 			}
 		case application.TransferAccessories:
 			snapshot.Accessories, err = transferAccessorySnapshot(ctx, tx)
@@ -43,6 +44,23 @@ func (repository *DataTransferRepository) Snapshot(
 		return application.DataTransferSnapshot{}, fmt.Errorf("commit transfer snapshot: %w", err)
 	}
 	return snapshot, nil
+}
+
+func normalizeTransferVehicleSetsForExport(
+	sets []application.TransferVehicleSet,
+) []application.TransferVehicleSet {
+	normalized := make([]application.TransferVehicleSet, 0, len(sets))
+	for _, set := range sets {
+		if len(set.Members) < 2 {
+			continue
+		}
+		set.Members = append([]application.TransferVehicleSetMember(nil), set.Members...)
+		for index := range set.Members {
+			set.Members[index].Position = index + 1
+		}
+		normalized = append(normalized, set)
+	}
+	return normalized
 }
 
 func (repository *DataTransferRepository) GetArtifact(

--- a/backend/internal/infrastructure/data_transfer_snapshot_test.go
+++ b/backend/internal/infrastructure/data_transfer_snapshot_test.go
@@ -216,7 +216,7 @@ func TestDataTransferSnapshotIncludesVehicleSets(t *testing.T) {
 	}
 }
 
-func TestDataTransferSnapshotNormalizesReachableVehicleSetMemberships(t *testing.T) {
+func TestDataTransferSnapshotPreservesVehicleSetMembershipsForImportComparison(t *testing.T) {
 	db := testDB(t)
 	for _, statement := range []string{
 		`INSERT INTO vehicles(id, inventory_number, manufacturer, name, gauge, category, gattung, created_at, updated_at)
@@ -250,15 +250,17 @@ func TestDataTransferSnapshotNormalizesReachableVehicleSetMemberships(t *testing
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(snapshot.VehicleSets) != 1 || snapshot.VehicleSets[0].ID != "set-gap" {
-		t.Fatalf("exportable vehicle sets = %#v", snapshot.VehicleSets)
+	if len(snapshot.VehicleSets) != 2 || snapshot.VehicleSets[0].ID != "set-gap" ||
+		snapshot.VehicleSets[1].ID != "set-single" {
+		t.Fatalf("snapshot vehicle sets = %#v", snapshot.VehicleSets)
 	}
-	set := snapshot.VehicleSets[0]
-	if len(set.Members) != 2 || set.Members[0].Position != 1 || set.Members[1].Position != 2 {
-		t.Fatalf("normalized vehicle set members = %#v", set.Members)
+	gapSet := snapshot.VehicleSets[0]
+	if len(gapSet.Members) != 2 || gapSet.Members[0].Position != 1 || gapSet.Members[1].Position != 3 {
+		t.Fatalf("raw gapped vehicle set members = %#v", gapSet.Members)
 	}
-	if err := application.ValidateTransferVehicleSet(set); err != nil {
-		t.Fatalf("normalized vehicle set is not importable: %v", err)
+	singleton := snapshot.VehicleSets[1]
+	if len(singleton.Members) != 1 || singleton.Members[0].Position != 2 {
+		t.Fatalf("raw singleton vehicle set members = %#v", singleton.Members)
 	}
 }
 

--- a/backend/internal/infrastructure/data_transfer_snapshot_test.go
+++ b/backend/internal/infrastructure/data_transfer_snapshot_test.go
@@ -216,6 +216,52 @@ func TestDataTransferSnapshotIncludesVehicleSets(t *testing.T) {
 	}
 }
 
+func TestDataTransferSnapshotNormalizesReachableVehicleSetMemberships(t *testing.T) {
+	db := testDB(t)
+	for _, statement := range []string{
+		`INSERT INTO vehicles(id, inventory_number, manufacturer, name, gauge, category, gattung, created_at, updated_at)
+         VALUES('vehicle-a', 'RK-A', 'Roco', 'Wagen A', 'H0', 'Wagen', 'Reisezugwagen',
+           '2026-08-27T10:00:00Z', '2026-08-27T10:00:00Z')`,
+		`INSERT INTO vehicles(id, inventory_number, manufacturer, name, gauge, category, gattung, created_at, updated_at)
+         VALUES('vehicle-c', 'RK-C', 'Roco', 'Wagen C', 'H0', 'Wagen', 'Reisezugwagen',
+           '2026-08-27T10:00:00Z', '2026-08-27T10:00:00Z')`,
+		`INSERT INTO vehicles(id, inventory_number, manufacturer, name, gauge, category, gattung, created_at, updated_at)
+         VALUES('vehicle-d', 'RK-D', 'Roco', 'Wagen D', 'H0', 'Wagen', 'Reisezugwagen',
+           '2026-08-27T10:00:00Z', '2026-08-27T10:00:00Z')`,
+		`INSERT INTO vehicle_sets(id, inventory_number, name, manufacturer, gauge, category, gattung, created_at, updated_at)
+         VALUES('set-gap', 'Set-Gap', 'Set mit Lücke', 'Roco', 'H0', 'Set', 'Reisezug',
+           '2026-08-27T10:00:00Z', '2026-08-27T10:00:00Z')`,
+		`INSERT INTO vehicle_sets(id, inventory_number, name, manufacturer, gauge, category, gattung, created_at, updated_at)
+         VALUES('set-single', 'Set-Single', 'Einzelrest', 'Roco', 'H0', 'Set', 'Reisezug',
+           '2026-08-27T10:00:00Z', '2026-08-27T10:00:00Z')`,
+		`INSERT INTO vehicle_set_members(vehicle_set_id, vehicle_id, position, label)
+         VALUES('set-gap', 'vehicle-a', 1, 'A')`,
+		`INSERT INTO vehicle_set_members(vehicle_set_id, vehicle_id, position, label)
+         VALUES('set-gap', 'vehicle-c', 3, 'C')`,
+		`INSERT INTO vehicle_set_members(vehicle_set_id, vehicle_id, position, label)
+         VALUES('set-single', 'vehicle-d', 2, 'D')`,
+	} {
+		if _, err := db.Exec(statement); err != nil {
+			t.Fatal(err)
+		}
+	}
+	repository := infrastructure.NewDataTransferRepository(db)
+	snapshot, err := repository.Snapshot(t.Context(), []application.TransferArea{application.TransferVehicles})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snapshot.VehicleSets) != 1 || snapshot.VehicleSets[0].ID != "set-gap" {
+		t.Fatalf("exportable vehicle sets = %#v", snapshot.VehicleSets)
+	}
+	set := snapshot.VehicleSets[0]
+	if len(set.Members) != 2 || set.Members[0].Position != 1 || set.Members[1].Position != 2 {
+		t.Fatalf("normalized vehicle set members = %#v", set.Members)
+	}
+	if err := application.ValidateTransferVehicleSet(set); err != nil {
+		t.Fatalf("normalized vehicle set is not importable: %v", err)
+	}
+}
+
 func TestDataTransferSnapshotAccessoryIncludesCurrentStateOnly(t *testing.T) {
 	db := testDB(t)
 	for _, statement := range []string{

--- a/backend/internal/infrastructure/data_transfer_vehicle_sets.go
+++ b/backend/internal/infrastructure/data_transfer_vehicle_sets.go
@@ -337,7 +337,7 @@ func applyTransferVehicleSets(
 				return fmt.Errorf("clear transfer vehicle set members: %w", err)
 			}
 		}
-		for index, member := range preview.Data.Members {
+		for index, member := range setData.Members {
 			if _, err := tx.ExecContext(ctx, `
 INSERT INTO vehicle_set_members(vehicle_set_id, vehicle_id, position, label)
 VALUES(?, ?, ?, ?)`, setID, memberResults[index].ID, member.Position, member.Label); err != nil {

--- a/backend/internal/infrastructure/data_transfer_vehicle_sets.go
+++ b/backend/internal/infrastructure/data_transfer_vehicle_sets.go
@@ -315,6 +315,17 @@ func applyTransferVehicleSets(
 					return dataTransferApplyConflict("vehicle set replacement target is missing")
 				}
 				setData = application.PreserveUnmappedTransferVehicleSetFields(setData, existing, csvMapping)
+				if !transferCSVFieldMapped(csvMapping, "vehicleSetMemberLabel") {
+					existingLabels := make(map[string]string, len(existing.Members))
+					for _, member := range existing.Members {
+						existingLabels[member.SourceVehicleID] = member.Label
+					}
+					for index, result := range memberResults {
+						if label, found := existingLabels[result.ID]; found {
+							setData.Members[index].Label = label
+						}
+					}
+				}
 				inventoryNumber = setData.InventoryNumber
 			}
 			if err := updateTransferVehicleSet(
@@ -341,6 +352,15 @@ VALUES(?, NULLIF(?, ''), 'VehicleSetImported', 'vehicle_set', ?, ?, ?)`,
 		}
 	}
 	return nil
+}
+
+func transferCSVFieldMapped(mapping []application.DataTransferCSVColumnMapping, targetField string) bool {
+	for _, column := range mapping {
+		if column.TargetField == targetField {
+			return true
+		}
+	}
+	return false
 }
 
 func insertTransferVehicleSet(


### PR DESCRIPTION
## Deutsch

### Zusammenfassung
- erhält lokale Set-Mitgliedsbezeichnungen bei CSV-Ersetzungen, wenn `vehicleSetMemberLabel` nicht gemappt ist
- ordnet vorhandene Bezeichnungen anhand der aufgelösten Fahrzeug-ID zu
- lässt ein bewusst gemapptes leeres Feld die Bezeichnung weiterhin löschen

### Tests
- `go test ./internal/infrastructure -run 'TestDataTransferApplyCSVReplace(PreservesUnmappedVehicleSetFields|ClearsMappedVehicleSetMemberLabel)$' -count=1`
- `go test ./... -count=1`

Folgekorrektur zum Review von #160.

## English

### Summary
- preserves local set member labels during CSV replacement when `vehicleSetMemberLabel` is unmapped
- matches existing labels by resolved vehicle ID
- still allows an intentionally mapped blank field to clear the label

### Tests
- `go test ./internal/infrastructure -run 'TestDataTransferApplyCSVReplace(PreservesUnmappedVehicleSetFields|ClearsMappedVehicleSetMemberLabel)$' -count=1`
- `go test ./... -count=1`

Follow-up fix for the review of #160.