### PR TITLE
Mobile Fahrzeugübersicht stabilisieren / Stabilize mobile vehicle inventory

### DIFF
--- a/frontend/src/features/vehicles/VehicleInventoryPanel.tsx
+++ b/frontend/src/features/vehicles/VehicleInventoryPanel.tsx
@@ -245,6 +245,14 @@ export function VehicleInventoryPanel({
             <em>{maintenanceReminderSummary.upcoming} geplant</em>
           </button>
         </article>
+        <article className={inventoryFilter === "withoutImages" ? "inventory-status-card active" : "inventory-status-card"}>
+          <button type="button" onClick={() => onInventoryFilterChange("withoutImages")} aria-label={t("vehicles.status.imagesAria")}>
+            <span><Image size={16} aria-hidden="true" /></span>
+            <small>{t("vehicles.imageCare")}</small>
+            <strong>{vehicles.length ? Math.round((inventorySummary.withImages / vehicles.length) * 100) : 0}%</strong>
+            <em>{t("vehicles.withImage", { count: inventorySummary.withImages })}</em>
+          </button>
+        </article>
         <article className="inventory-status-card wide">
           {nextMaintenanceReminder ? (
             <button type="button" onClick={() => onOpenDetail(nextMaintenanceReminder.vehicle, "maintenance")}>
@@ -261,14 +269,6 @@ export function VehicleInventoryPanel({
               <em>{t("vehicles.noDueMaintenance")}</em>
             </>
           )}
-        </article>
-        <article className={inventoryFilter === "withoutImages" ? "inventory-status-card active" : "inventory-status-card"}>
-          <button type="button" onClick={() => onInventoryFilterChange("withoutImages")} aria-label={t("vehicles.status.imagesAria")}>
-            <span><Image size={16} aria-hidden="true" /></span>
-            <small>{t("vehicles.imageCare")}</small>
-            <strong>{vehicles.length ? Math.round((inventorySummary.withImages / vehicles.length) * 100) : 0}%</strong>
-            <em>{t("vehicles.withImage", { count: inventorySummary.withImages })}</em>
-          </button>
         </article>
       </section>
 

--- a/frontend/src/features/vehicles/vehicleInventoryResponsive.test.ts
+++ b/frontend/src/features/vehicles/vehicleInventoryResponsive.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 
 const css = readFileSync(resolve(process.cwd(), "src/styles/vehicle-inventory.css"), "utf8");
 const appCss = readFileSync(resolve(process.cwd(), "src/app/styles.css"), "utf8");
+const responsiveCss = readFileSync(resolve(process.cwd(), "src/styles/overrides-responsive.css"), "utf8");
 
 describe("vehicle inventory column layout", () => {
   it("imports a focused vehicle inventory stylesheet", () => {
@@ -43,5 +44,20 @@ describe("vehicle inventory column layout", () => {
     expect(css).toMatch(/\.vehicle-inventory-table\s*\{[^}]*width:\s*100%[^}]*min-width:\s*100%[^}]*table-layout:\s*fixed/s);
     expect(css).toMatch(/\.vehicle-inventory-table th:not\(\.select-cell\):not\(\.actions-cell\),[\s\S]*width:\s*calc\(\(100%\s*-\s*186px\)\s*\/\s*var\(--vehicle-data-column-count,\s*8\)\)/s);
     expect(css).toMatch(/\.vehicle-inventory-table \[class\*="vehicle-column-"\]\s*\{[^}]*max-width:\s*280px/s);
+  });
+
+  it("keeps the next appointment card wide until the status row stacks", () => {
+    expect(responsiveCss).toMatch(
+      /@media\s*\(max-width:\s*640px\)[\s\S]*?\.inventory-status-row\s*\{[^}]*grid-template-columns:\s*repeat\(2,\s*minmax\(0,\s*1fr\)\)[\s\S]*?\.inventory-status-card\.wide\s*\{[^}]*grid-column:\s*1\s*\/\s*-1/s,
+    );
+    expect(responsiveCss).toMatch(
+      /@media\s*\(max-width:\s*420px\)[\s\S]*?\.inventory-status-row\s*\{[^}]*grid-template-columns:\s*minmax\(0,\s*1fr\)/s,
+    );
+  });
+
+  it("contains the mobile filter scroller without clipping its controls", () => {
+    expect(responsiveCss).toMatch(
+      /@media\s*\(max-width:\s*640px\)[\s\S]*?\.inventory-filter-row\s*\{[^}]*min-width:\s*0[^}]*max-width:\s*100%[^}]*overflow-x:\s*auto[^}]*overscroll-behavior-x:\s*contain[^}]*scrollbar-gutter:\s*stable[^}]*scroll-padding-inline:\s*2px/s,
+    );
   });
 });

--- a/frontend/src/features/vehicles/vehicleInventoryResponsive.test.ts
+++ b/frontend/src/features/vehicles/vehicleInventoryResponsive.test.ts
@@ -5,6 +5,10 @@ import { describe, expect, it } from "vitest";
 const css = readFileSync(resolve(process.cwd(), "src/styles/vehicle-inventory.css"), "utf8");
 const appCss = readFileSync(resolve(process.cwd(), "src/app/styles.css"), "utf8");
 const responsiveCss = readFileSync(resolve(process.cwd(), "src/styles/overrides-responsive.css"), "utf8");
+const inventoryPanelSource = readFileSync(
+  resolve(process.cwd(), "src/features/vehicles/VehicleInventoryPanel.tsx"),
+  "utf8",
+);
 
 describe("vehicle inventory column layout", () => {
   it("imports a focused vehicle inventory stylesheet", () => {
@@ -52,6 +56,12 @@ describe("vehicle inventory column layout", () => {
     );
     expect(responsiveCss).toMatch(
       /@media\s*\(max-width:\s*420px\)[\s\S]*?\.inventory-status-row\s*\{[^}]*grid-template-columns:\s*minmax\(0,\s*1fr\)/s,
+    );
+  });
+
+  it("places four compact status cards before the wide next appointment card", () => {
+    expect(inventoryPanelSource.indexOf('t("vehicles.imageCare")')).toBeLessThan(
+      inventoryPanelSource.indexOf('t("vehicles.nextAppointment")'),
     );
   });
 

--- a/frontend/src/styles/overrides-responsive.css
+++ b/frontend/src/styles/overrides-responsive.css
@@ -723,11 +723,14 @@
     gap: 8px;
   }
 
-  .inventory-status-card,
-  .inventory-status-card.wide {
+  .inventory-status-card {
     grid-column: auto;
     min-height: 92px;
     padding: 10px;
+  }
+
+  .inventory-status-card.wide {
+    grid-column: 1 / -1;
   }
 
   .inventory-status-card > span,
@@ -774,8 +777,13 @@
 
   .inventory-filter-row {
     flex-wrap: nowrap;
+    min-width: 0;
+    max-width: 100%;
     overflow-x: auto;
-    padding-bottom: 4px;
+    overscroll-behavior-x: contain;
+    scrollbar-gutter: stable;
+    scroll-padding-inline: 2px;
+    padding: 2px 2px 6px;
     scrollbar-width: thin;
   }
 
@@ -991,5 +999,11 @@
   .barcode-search-dialog .form-head p {
     grid-column: 1 / -1;
     font-size: var(--font-size-sm);
+  }
+}
+
+@media (max-width: 420px) {
+  .inventory-status-row {
+    grid-template-columns: minmax(0, 1fr);
   }
 }


### PR DESCRIPTION
## Deutsch

Behebt #149.

- Statuskarten bis 640 px zweispaltig, „Nächster Termin“ über beide Spalten
- bis 420 px einspaltige Anordnung
- Filterleiste als begrenzter horizontaler Scroller ohne Seitenüberlauf
- vier kompakte Karten füllen zuerst das 2×2-Raster, danach folgt die breite Termin-Karte
- Regressionstests für Breakpoints und Scroll-Containment

### Prüfung

- `npm.cmd run test:run -- src/features/vehicles/vehicleInventoryResponsive.test.ts`: 9 Tests bestanden
- `npm.cmd run test:run`: 134 Testdateien, 800 Tests bestanden
- `npm.cmd run build`: erfolgreich
- `go test ./...`: erfolgreich
- `git diff --check`: sauber
- visuell bei 390 × 844 in Light und Dark geprüft, einschließlich langem aktivem Filter und Fokus
- gemessener Seitenüberlauf bei 390 px: `clientWidth = scrollWidth = 390`; nur die Filterleiste scrollt intern
- bei 500 px: zwei Statusspalten, „Nächster Termin“ entspricht der vollen Zeilenbreite
- Review-Fix bei 500 px: zwei vollständig belegte 227-px-Zeilen, danach eine 462-px-Terminzeile

## English

Fixes #149.

- keeps status cards in two columns up to 640 px, with “Next appointment” spanning both columns
- switches to one column at widths up to 420 px
- contains the filter row in a bounded horizontal scroller without page overflow
- fills the 2×2 grid with four compact cards before the wide appointment card
- adds regression coverage for breakpoints and scroll containment

### Verification

- `npm.cmd run test:run -- src/features/vehicles/vehicleInventoryResponsive.test.ts`: 9 tests passed
- `npm.cmd run test:run`: 134 test files, 800 tests passed
- `npm.cmd run build`: passed
- `go test ./...`: passed
- `git diff --check`: clean
- visually checked at 390 × 844 in light and dark mode, including a long active filter and focus
- measured page overflow at 390 px: `clientWidth = scrollWidth = 390`; only the filter row scrolls internally
- at 500 px: two status columns, with “Next appointment” matching the full row width
- review fix at 500 px: two fully occupied 227 px rows, followed by one 462 px appointment row
