### PR TITLE
Ausstellungskontrolle kontextbezogen anzeigen / Render exhibition control contextually

### DIFF
--- a/frontend/src/features/vehicles/VehicleInventoryTable.test.tsx
+++ b/frontend/src/features/vehicles/VehicleInventoryTable.test.tsx
@@ -95,8 +95,10 @@ describe("VehicleInventoryTable", () => {
     expect(screen.getByRole("table")).toHaveStyle("--vehicle-data-column-count: 3");
   });
 
-  it("keeps selection and exhibition controls operational", () => {
-    const vehicle = vehicleFixture({ exhibition: true });
+  it("keeps the exhibition control operational for eligible vehicles", async () => {
+    const user = userEvent.setup();
+    const vehicle = vehicleFixture({ exhibition: false });
+    const onToggleExhibition = vi.fn();
     render(
       <VehicleInventoryTable
         vehicles={[vehicle]}
@@ -108,12 +110,83 @@ describe("VehicleInventoryTable", () => {
         onToggleSelection={vi.fn()}
         onToggleAllVisibleSelection={vi.fn()}
         onOpenDetail={vi.fn()}
-        onToggleExhibition={vi.fn()}
+        onToggleExhibition={onToggleExhibition}
         renderQuickMenu={() => null}
       />
     );
 
     const row = screen.getAllByRole("row")[1];
     expect(within(row).getAllByRole("checkbox")).toHaveLength(2);
+    const exhibitionControl = within(row).getByRole("checkbox", { name: "Ausstellungsstatus ändern" });
+    expect(exhibitionControl).toBeEnabled();
+    expect(exhibitionControl).not.toBeChecked();
+
+    await user.click(exhibitionControl);
+    expect(onToggleExhibition).toHaveBeenCalledWith(vehicle, true);
+  });
+
+  it("keeps the exhibition control operational for already active vehicles", async () => {
+    const user = userEvent.setup();
+    const vehicle = vehicleFixture({
+      exhibition: true,
+      digital: false,
+      digitalDecoderNumber: ""
+    });
+    const onToggleExhibition = vi.fn();
+    render(
+      <VehicleInventoryTable
+        vehicles={[vehicle]}
+        columns={["exhibition"]}
+        allVisibleSelected={false}
+        selectedVehicleIDs={new Set()}
+        sort={{ key: "inventoryNumber", direction: "asc" }}
+        onToggleSort={vi.fn()}
+        onToggleSelection={vi.fn()}
+        onToggleAllVisibleSelection={vi.fn()}
+        onOpenDetail={vi.fn()}
+        onToggleExhibition={onToggleExhibition}
+        renderQuickMenu={() => null}
+      />
+    );
+
+    const exhibitionControl = screen.getByRole("checkbox", { name: "Ausstellungsstatus ändern" });
+    expect(exhibitionControl).toBeEnabled();
+    expect(exhibitionControl).toBeChecked();
+
+    await user.click(exhibitionControl);
+    expect(onToggleExhibition).toHaveBeenCalledWith(vehicle, false);
+  });
+
+  it("explains an unavailable exhibition status without rendering a disabled control", () => {
+    const vehicle = vehicleFixture({
+      exhibition: false,
+      digital: false,
+      digitalDecoderNumber: ""
+    });
+    render(
+      <VehicleInventoryTable
+        vehicles={[vehicle]}
+        columns={["exhibition"]}
+        allVisibleSelected={false}
+        selectedVehicleIDs={new Set()}
+        sort={{ key: "inventoryNumber", direction: "asc" }}
+        onToggleSort={vi.fn()}
+        onToggleSelection={vi.fn()}
+        onToggleAllVisibleSelection={vi.fn()}
+        onOpenDetail={vi.fn()}
+        onToggleExhibition={vi.fn()}
+        renderQuickMenu={() => null}
+      />
+    );
+
+    const row = screen.getAllByRole("row")[1];
+    expect(
+      within(row).queryByRole("checkbox", { name: "Ausstellungsstatus ändern" })
+    ).not.toBeInTheDocument();
+    expect(within(row).getByText("Digital ja + Decoder-Nr. erforderlich")).toBeVisible();
+    const status = within(row).getByLabelText(
+      "Ausstellung ist erst aktiv, wenn Digital ja und eine Decoder-Nr. gepflegt ist."
+    );
+    expect(status.querySelector("svg")).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/vehicles/VehicleInventoryTable.tsx
+++ b/frontend/src/features/vehicles/VehicleInventoryTable.tsx
@@ -3,6 +3,7 @@ import {
   ArrowUpDown,
   ChevronDown,
   ChevronUp,
+  CircleOff,
   Eye,
   ImageOff,
   Pencil,
@@ -122,17 +123,25 @@ export function VehicleInventoryTable({
       );
     }
     if (column === "exhibition") {
+      if (!vehicle.exhibition && !vehicleExhibitionEligible(vehicle)) {
+        return (
+          <span
+            className="inventory-exhibition-unavailable"
+            aria-label={t("vehicles.exhibition.requiresDecoder")}
+          >
+            <CircleOff size={14} aria-hidden="true" />
+            <span>{t("vehicles.exhibition.unavailable")}</span>
+          </span>
+        );
+      }
       return (
         <label
           className={vehicle.exhibition ? "inventory-inline-switch active" : "inventory-inline-switch"}
-          title={vehicle.exhibition || vehicleExhibitionEligible(vehicle)
-            ? t("vehicles.exhibition.toggle")
-            : t("vehicles.exhibition.requiresDecoder")}
+          title={t("vehicles.exhibition.toggle")}
         >
           <input
             type="checkbox"
             checked={Boolean(vehicle.exhibition)}
-            disabled={!vehicle.exhibition && !vehicleExhibitionEligible(vehicle)}
             onChange={(event) => onToggleExhibition(vehicle, event.target.checked)}
             aria-label={t("vehicles.exhibition.toggle")}
           />

--- a/frontend/src/shared/i18n/de.ts
+++ b/frontend/src/shared/i18n/de.ts
@@ -1449,6 +1449,7 @@ export const deTranslations: Record<string, string> = {
     "vehicles.exhibition.noOpenLists": "Keine offene Ausstellungsliste vorhanden.",
     "vehicles.exhibition.requiresDecoder": "Ausstellung ist erst aktiv, wenn Digital ja und eine Decoder-Nr. gepflegt ist.",
     "vehicles.exhibition.toggle": "Ausstellungsstatus ändern",
+    "vehicles.exhibition.unavailable": "Digital ja + Decoder-Nr. erforderlich",
     "vehicles.image": "Bild",
     "vehicles.view": "Anzeigen",
     "vehicles.quickMenu": "Kurzmenü",

--- a/frontend/src/shared/i18n/en.ts
+++ b/frontend/src/shared/i18n/en.ts
@@ -1449,6 +1449,7 @@ export const enTranslations: Record<string, string> = {
     "vehicles.exhibition.noOpenLists": "No open exhibition list available.",
     "vehicles.exhibition.requiresDecoder": "Exhibition is only available when Digital is yes and a decoder no. is set.",
     "vehicles.exhibition.toggle": "Change exhibition status",
+    "vehicles.exhibition.unavailable": "Digital yes + decoder no. required",
     "vehicles.image": "Image",
     "vehicles.view": "View",
     "vehicles.quickMenu": "Quick menu",

--- a/frontend/src/styles/vehicle-inventory.css
+++ b/frontend/src/styles/vehicle-inventory.css
@@ -190,6 +190,23 @@
   text-align: center;
 }
 
+.inventory-exhibition-unavailable {
+  display: inline-flex;
+  max-width: 100%;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  color: var(--muted);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-bold);
+  line-height: var(--line-height-control-sm);
+  white-space: normal;
+}
+
+.inventory-exhibition-unavailable > svg {
+  flex: 0 0 auto;
+}
+
 .vehicle-inventory-table th.vehicle-column-inventoryNumber .sort-button,
 .vehicle-inventory-table th.vehicle-column-manufacturer .sort-button,
 .vehicle-inventory-table th.vehicle-column-articleNumber .sort-button,


### PR DESCRIPTION
## Deutsch

- zeigt den Ausstellungsschalter nur für geeignete oder bereits aktive Fahrzeuge
- ersetzt den deaktivierten Schalter bei ungeeigneten Fahrzeugen durch einen sichtbaren Icon-Text-Status
- ergänzt deutsche und englische Texte sowie Component-Tests für alle drei Zustände
- lässt die bestehende Eignungsregel unverändert

### Verifikation

- gezielte Component-Tests: 13 Tests grün
- vollständige Frontend-Suite: 135 Testdateien, 807 Tests grün
- `npm.cmd run build`: grün
- reale Browser-Abnahme: Desktop-Tabelle und mobile Kartenansicht bei 390 px, kein Seitenüberlauf, Schalter öffnet den Eintragungsdialog
- GitHub CI, CodeQL und Trivy: grün

Schließt #148.

---

## English

- shows the exhibition switch only for eligible or already active vehicles
- replaces the disabled switch for ineligible vehicles with a visible icon-and-text status
- adds German and English copy plus component coverage for all three states
- keeps the existing eligibility rule unchanged

### Verification

- focused component tests: 13 tests passing
- full frontend suite: 135 test files, 807 tests passing
- `npm.cmd run build`: passing
- real-browser verification: desktop table and mobile card view at 390 px, no page overflow, switch opens the assignment dialog
- GitHub CI, CodeQL, and Trivy: passing

Closes #148.