### PR TITLE
Kleine Typografie semantisch begrenzen / Bound small typography semantically

### DIFF
--- a/frontend/src/features/overview/OverviewView.test.tsx
+++ b/frontend/src/features/overview/OverviewView.test.tsx
@@ -250,9 +250,11 @@ describe("OverviewView", () => {
     const css = readFileSync(resolve(process.cwd(), "src/styles/overview-dashboard.css"), "utf8");
     const baseCss = readFileSync(resolve(process.cwd(), "src/styles/base.css"), "utf8");
 
-    expect(baseCss).toMatch(/--font-size-3xs:\s*11px/);
-    expect(baseCss).toMatch(/--font-size-2xs:\s*12px/);
-    expect(baseCss).toMatch(/--font-size-xs:\s*12px/);
+    expect(baseCss).toMatch(/--font-size-micro:\s*11px/);
+    expect(baseCss).toMatch(/--font-size-caption:\s*12px/);
+    expect(baseCss).toMatch(/--font-size-3xs:\s*var\(--font-size-micro\)/);
+    expect(baseCss).toMatch(/--font-size-2xs:\s*var\(--font-size-caption\)/);
+    expect(baseCss).toMatch(/--font-size-xs:\s*var\(--font-size-caption\)/);
     expect(baseCss).toMatch(/--font-size-sm:\s*13px/);
     expect(baseCss).toMatch(/--font-size-base:\s*15px/);
     expect(css).toContain("--overview-interactive:");

--- a/frontend/src/styles/base.css
+++ b/frontend/src/styles/base.css
@@ -42,9 +42,12 @@
   --ease-out: ease-out;
   --font-sans: "SF Pro Display", "SF Pro Text", "Segoe UI", system-ui, sans-serif;
   --font-mono: ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", monospace;
-  --font-size-3xs: 11px;
-  --font-size-2xs: 12px;
-  --font-size-xs: 12px;
+  /* 11px is reserved for short machine metadata; user-facing copy starts at caption. */
+  --font-size-micro: 11px;
+  --font-size-caption: 12px;
+  --font-size-3xs: var(--font-size-micro);
+  --font-size-2xs: var(--font-size-caption);
+  --font-size-xs: var(--font-size-caption);
   --font-size-sm: 13px;
   --font-size-md: 14px;
   --font-size-base: 15px;

--- a/frontend/src/styles/base.test.ts
+++ b/frontend/src/styles/base.test.ts
@@ -1,5 +1,5 @@
 import { readFileSync, readdirSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { basename, join, resolve } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
@@ -59,5 +59,35 @@ describe("base design system", () => {
     expect(baseCss).toMatch(/animation-iteration-count:\s*1\s*!important/);
     expect(baseCss).toMatch(/transition-duration:\s*0\.01ms\s*!important/);
     expect(baseCss).toMatch(/scroll-behavior:\s*auto\s*!important/);
+  });
+
+  it("bounds micro type to machine metadata and keeps user-facing small copy at caption size", () => {
+    expect(baseCss).toContain("--font-size-micro: 11px");
+    expect(baseCss).toContain("--font-size-caption: 12px");
+
+    const styles = new Map(
+      cssFiles(stylesDirectory).map((file) => [basename(file), readFileSync(file, "utf8")])
+    );
+    const combinedStyles = [...styles.entries()]
+      .filter(([name]) => name !== "base.css")
+      .map(([, css]) => css)
+      .join("\n");
+
+    expect(combinedStyles).not.toMatch(/font-size:\s*(?:11px|var\(--font-size-3xs\))/);
+    expect(combinedStyles.match(/font-size:\s*var\(--font-size-micro\)/g)).toHaveLength(1);
+    expect(styles.get("vehicle-uploads.css")).toMatch(
+      /\.pending-image-card figcaption > span\s*\{[^}]*font-size:\s*var\(--font-size-micro\)/s
+    );
+
+    const captionRoles: Array<[string, RegExp]> = [
+      ["forms-controls.css", /\.image-placeholder\s*\{[^}]*font-size:\s*var\(--font-size-caption\)/s],
+      ["overview-dashboard.css", /\.overview-quality-list b\s*\{[^}]*font-size:\s*var\(--font-size-caption\)/s],
+      ["exhibition.css", /\.event-list-state small\s*\{[^}]*font-size:\s*var\(--font-size-caption\)/s],
+      ["exhibition.css", /\.exhibition-day-tabs small\s*\{[^}]*font-size:\s*var\(--font-size-caption\)/s],
+      ["exhibition.css", /\.exhibition-quick-filters span\s*\{[^}]*font-size:\s*var\(--font-size-caption\)/s],
+      ["vehicle-uploads.css", /\.pending-image-card input\s*\{[^}]*font-size:\s*var\(--font-size-caption\)/s]
+    ];
+
+    for (const [file, role] of captionRoles) expect(styles.get(file)).toMatch(role);
   });
 });

--- a/frontend/src/styles/exhibition.css
+++ b/frontend/src/styles/exhibition.css
@@ -518,7 +518,7 @@
 
 .event-list-state small {
   color: var(--muted);
-  font-size: var(--font-size-3xs);
+  font-size: var(--font-size-caption);
 }
 
 .exhibition-all-events {
@@ -569,7 +569,7 @@
 
 .exhibition-day-tabs small {
   display: block;
-  font-size: var(--font-size-3xs);
+  font-size: var(--font-size-caption);
   font-weight: var(--font-weight-regular);
 }
 
@@ -611,7 +611,7 @@
   border-radius: 999px;
   background: color-mix(in srgb, var(--text) 9%, transparent);
   color: var(--text);
-  font-size: var(--font-size-3xs);
+  font-size: var(--font-size-caption);
 }
 
 .exhibition-search {

--- a/frontend/src/styles/forms-controls.css
+++ b/frontend/src/styles/forms-controls.css
@@ -1421,7 +1421,7 @@ td {
   border-radius: 6px;
   background: var(--panel-subtle);
   color: var(--muted);
-  font-size: var(--font-size-3xs);
+  font-size: var(--font-size-caption);
   font-weight: var(--font-weight-strong);
   line-height: var(--line-height-tight);
   text-align: center;

--- a/frontend/src/styles/overview-dashboard.css
+++ b/frontend/src/styles/overview-dashboard.css
@@ -692,7 +692,7 @@ a.overview-metric-card:focus-visible {
   border-radius: 50%;
   background: conic-gradient(var(--accent-strong) calc(var(--quality-value) * 1%), var(--line) 0);
   color: var(--text);
-  font-size: var(--font-size-3xs);
+  font-size: var(--font-size-caption);
   font-weight: var(--font-weight-bold);
 }
 

--- a/frontend/src/styles/vehicle-uploads.css
+++ b/frontend/src/styles/vehicle-uploads.css
@@ -182,7 +182,7 @@
   background: color-mix(in srgb, var(--input-bg) 88%, transparent);
   color: var(--text);
   font: inherit;
-  font-size: var(--font-size-3xs);
+  font-size: var(--font-size-caption);
   font-weight: var(--font-weight-medium);
 }
 
@@ -211,7 +211,7 @@
 
 .pending-image-card figcaption > span {
   color: var(--accent-strong);
-  font-size: var(--font-size-3xs);
+  font-size: var(--font-size-micro);
   font-weight: var(--font-weight-semibold);
 }
 


### PR DESCRIPTION
## Deutsch

- führt benannte Rollen `micro` (11 px) und `caption` (12 px) ein
- reserviert `micro` für den kurzen technischen Quellenhinweis importierter Bilder
- migriert benutzerrelevante 11-px-Texte in Formularen, Übersicht, Ausstellung und Bildtitel auf `caption`
- erhält die bisherigen 12-px-Aliase und damit die kompakte Informationsdichte
- schützt die Rollen und alle geprüften Selektoren statisch

### Verifikation

- 35 relevante UI- und Style-Tests grün
- `npm.cmd run build` grün
- visuell geprüft mit gebautem RailKeeper-CSS: Desktop Light und 390 px Dark, inklusive langer deutscher Texte
- keine horizontale Überläufe; Status, Tabdatum, Filterzähler und Formularhinweise bleiben lesbar
- die lokale Playwright-Sitzung war abgemeldet, deshalb erfolgte die visuelle Prüfung in einer isolierten Prüffläche mit den betroffenen Originalklassen, ohne Benutzer- oder Testdaten zu verändern

Schließt #147.

---

## English

- introduces named `micro` (11 px) and `caption` (12 px) roles
- reserves `micro` for the short technical source label of imported images
- migrates user-facing 11 px copy in forms, overview, exhibition, and image titles to `caption`
- preserves the existing 12 px aliases and therefore the compact information density
- statically protects the roles and every reviewed selector

### Verification

- 35 relevant UI and style tests passing
- `npm.cmd run build` passing
- visually checked with the built RailKeeper CSS: desktop light and 390 px dark, including long German copy
- no horizontal overflow; status, tab date, filter count, and form guidance remain readable
- the local Playwright session was signed out, so the visual check used an isolated fixture with the affected original classes without changing user or test data

Closes #147.