### PR TITLE
CSS nach Design-Audit konsolidieren / Consolidate CSS after design audit (#151)

### DIFF
--- a/frontend/src/app/styles.css
+++ b/frontend/src/app/styles.css
@@ -21,3 +21,4 @@
 @import "../styles/track-libraries.css";
 @import "../styles/digital-centers.css";
 @import "../styles/overrides-responsive.css";
+@import "../styles/vehicle-inventory-responsive.css";

--- a/frontend/src/features/vehicles/vehicleInventoryResponsive.test.ts
+++ b/frontend/src/features/vehicles/vehicleInventoryResponsive.test.ts
@@ -5,6 +5,10 @@ import { describe, expect, it } from "vitest";
 const css = readFileSync(resolve(process.cwd(), "src/styles/vehicle-inventory.css"), "utf8");
 const appCss = readFileSync(resolve(process.cwd(), "src/app/styles.css"), "utf8");
 const responsiveCss = readFileSync(resolve(process.cwd(), "src/styles/overrides-responsive.css"), "utf8");
+const inventoryResponsiveCss = readFileSync(
+  resolve(process.cwd(), "src/styles/vehicle-inventory-responsive.css"),
+  "utf8",
+);
 const inventoryPanelSource = readFileSync(
   resolve(process.cwd(), "src/features/vehicles/VehicleInventoryPanel.tsx"),
   "utf8",
@@ -13,6 +17,10 @@ const inventoryPanelSource = readFileSync(
 describe("vehicle inventory column layout", () => {
   it("imports a focused vehicle inventory stylesheet", () => {
     expect(appCss).toContain('@import "../styles/vehicle-inventory.css";');
+    expect(appCss).toContain('@import "../styles/vehicle-inventory-responsive.css";');
+    expect(appCss.indexOf('@import "../styles/overrides-responsive.css";')).toBeLessThan(
+      appCss.indexOf('@import "../styles/vehicle-inventory-responsive.css";'),
+    );
   });
 
   it("bounds the long picker and uses a fixed mobile sheet", () => {
@@ -51,10 +59,10 @@ describe("vehicle inventory column layout", () => {
   });
 
   it("keeps the next appointment card wide until the status row stacks", () => {
-    expect(responsiveCss).toMatch(
+    expect(inventoryResponsiveCss).toMatch(
       /@media\s*\(max-width:\s*640px\)[\s\S]*?\.inventory-status-row\s*\{[^}]*grid-template-columns:\s*repeat\(2,\s*minmax\(0,\s*1fr\)\)[\s\S]*?\.inventory-status-card\.wide\s*\{[^}]*grid-column:\s*1\s*\/\s*-1/s,
     );
-    expect(responsiveCss).toMatch(
+    expect(inventoryResponsiveCss).toMatch(
       /@media\s*\(max-width:\s*420px\)[\s\S]*?\.inventory-status-row\s*\{[^}]*grid-template-columns:\s*minmax\(0,\s*1fr\)/s,
     );
   });
@@ -66,8 +74,21 @@ describe("vehicle inventory column layout", () => {
   });
 
   it("contains the mobile filter scroller without clipping its controls", () => {
-    expect(responsiveCss).toMatch(
+    expect(inventoryResponsiveCss).toMatch(
       /@media\s*\(max-width:\s*640px\)[\s\S]*?\.inventory-filter-row\s*\{[^}]*min-width:\s*0[^}]*max-width:\s*100%[^}]*overflow-x:\s*auto[^}]*overscroll-behavior-x:\s*contain[^}]*scrollbar-gutter:\s*stable[^}]*scroll-padding-inline:\s*2px/s,
     );
+  });
+
+  it("keeps inventory breakpoints out of the shared responsive layer", () => {
+    [
+      ".inventory-head",
+      ".inventory-status-row",
+      ".inventory-toolbar",
+      ".inventory-filter-row",
+      ".inventory-mobile-list",
+      ".inventory-desktop-content",
+      ".inventory-card {",
+      ".inventory-card-media",
+    ].forEach((selector) => expect(responsiveCss).not.toContain(selector));
   });
 });

--- a/frontend/src/styles/cssConsolidation.test.ts
+++ b/frontend/src/styles/cssConsolidation.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const readStyle = (name: string) =>
+  readFileSync(resolve(process.cwd(), `src/styles/${name}.css`), "utf8");
+
+describe("CSS ownership after the design audit", () => {
+  it("owns the shared switch control in forms instead of settings", () => {
+    const formsCss = readStyle("forms-controls");
+    const settingsCss = readStyle("settings");
+
+    expect(formsCss).toMatch(/\.switch-field\s*\{[^}]*display:\s*inline-flex/s);
+    expect(formsCss.indexOf(".switch-field {")).toBeLessThan(
+      formsCss.indexOf(".switch-field input:disabled + span"),
+    );
+    expect(settingsCss).not.toMatch(/(?:^|\n)\.switch-field(?:\s|>|\{|input|span)/);
+    expect(settingsCss).toContain(".smtp-settings-card .smtp-toggle-row .switch-field");
+  });
+
+  it("owns the inventory switch alongside the inventory feature", () => {
+    const formsCss = readStyle("forms-controls");
+    const inventoryCss = readStyle("vehicle-inventory");
+
+    expect(inventoryCss).toMatch(/\.inventory-inline-switch\s*\{/);
+    expect(formsCss).not.toContain(".inventory-inline-switch");
+  });
+});

--- a/frontend/src/styles/forms-controls.css
+++ b/frontend/src/styles/forms-controls.css
@@ -556,6 +556,48 @@
   min-height: 40px;
 }
 
+.switch-field {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.switch-field input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.switch-field span {
+  position: relative;
+  width: 36px;
+  height: 20px;
+  border-radius: var(--radius-pill);
+  background: #b8c2cc;
+  cursor: pointer;
+  transition: background var(--duration-slow) var(--ease-standard);
+}
+
+.switch-field span::after {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 14px;
+  height: 14px;
+  border-radius: var(--radius-pill);
+  background: var(--input-bg);
+  content: "";
+  transition: transform var(--duration-slow) var(--ease-standard);
+}
+
+.switch-field input:checked + span {
+  background: #22c55e;
+}
+
+.switch-field input:checked + span::after {
+  transform: translateX(16px);
+}
+
 .switch-field input:disabled + span,
 .inline-switch-input input:disabled {
   cursor: not-allowed;
@@ -814,72 +856,6 @@
   width: 16px;
   height: 16px;
   accent-color: var(--accent);
-}
-
-.inventory-inline-switch {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  color: var(--muted);
-  font-size: var(--font-size-sm);
-  font-weight: var(--font-weight-black);
-}
-
-.inventory-inline-switch input {
-  position: absolute;
-  inline-size: 1px;
-  block-size: 1px;
-  opacity: 0;
-}
-
-.inventory-inline-switch span {
-  position: relative;
-  display: inline-block;
-  width: 34px;
-  height: 18px;
-  border-radius: var(--radius-pill);
-  background: color-mix(in srgb, var(--muted) 26%, var(--panel-subtle));
-  border: 1px solid var(--line);
-  transition:
-    background var(--duration-normal) var(--ease-standard),
-    border-color var(--duration-normal) var(--ease-standard);
-}
-
-.inventory-inline-switch span::after {
-  content: "";
-  position: absolute;
-  top: 2px;
-  left: 2px;
-  width: 12px;
-  height: 12px;
-  border-radius: var(--radius-pill);
-  background: color-mix(in srgb, var(--text) 80%, #fff);
-  transition:
-    transform var(--duration-normal) var(--ease-standard),
-    background var(--duration-normal) var(--ease-standard);
-}
-
-.inventory-inline-switch input:checked + span {
-  background: color-mix(in srgb, var(--accent) 74%, var(--panel));
-  border-color: color-mix(in srgb, var(--accent) 68%, var(--line));
-}
-
-.inventory-inline-switch input:checked + span::after {
-  transform: translateX(16px);
-  background: #07110a;
-}
-
-.inventory-inline-switch input:disabled + span {
-  opacity: 0.42;
-  cursor: not-allowed;
-}
-
-.inventory-inline-switch.active {
-  color: var(--accent-strong);
-}
-
-.inventory-inline-switch em {
-  font-style: normal;
 }
 
 .inventory-table tr.selected-row {

--- a/frontend/src/styles/overrides-responsive.css
+++ b/frontend/src/styles/overrides-responsive.css
@@ -225,52 +225,10 @@
     justify-content: flex-start;
   }
 
-  .inventory-head {
-    display: grid;
-  }
-
-  .inventory-list-head {
-    display: grid;
-    gap: 10px;
-    padding: 12px;
-  }
-
-  .inventory-toolbar {
-    align-items: stretch;
-    flex-direction: column;
-  }
-
-  .inventory-search {
-    width: 100%;
-  }
-
-  .inventory-list-head .table-actions,
-  .inventory-toolbar-actions {
-    justify-content: flex-start;
-    flex-wrap: wrap;
-  }
-
-  .inventory-mobile-list {
-    display: grid;
-    gap: 8px;
-    padding: 10px;
-    background: var(--panel-subtle);
-  }
-
-  .inventory-desktop-content {
-    display: none;
-  }
-
-  .inventory-card-grid {
-    grid-template-columns: 1fr;
-    padding: 12px;
-  }
-
   .overview-grid,
   .exhibition-layout,
-  .inventory-status-row,
-    .import-export-grid,
-    .transfer-actions,
+  .import-export-grid,
+  .transfer-actions,
   .settings-dashboard-grid,
   .auth-settings-grid,
   .digital-settings-grid,
@@ -309,10 +267,6 @@
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  .inventory-status-card.wide {
-    grid-column: auto;
-  }
-
   .auth-settings-grid .auth-status-card,
   .auth-settings-grid .current-user-settings-card,
   .auth-settings-grid .user-management-card,
@@ -334,14 +288,6 @@
 
   .digital-overview-grid {
     grid-template-columns: 1fr;
-  }
-
-  .inventory-card {
-    grid-template-rows: 130px auto;
-  }
-
-  .inventory-card-media {
-    height: 130px;
   }
 
   .settings-grid {
@@ -718,104 +664,6 @@
     line-height: var(--line-height-copy-lg);
   }
 
-  .inventory-status-row {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 8px;
-  }
-
-  .inventory-status-card {
-    grid-column: auto;
-    min-height: 92px;
-    padding: 10px;
-  }
-
-  .inventory-status-card.wide {
-    grid-column: 1 / -1;
-  }
-
-  .inventory-status-card > span,
-  .inventory-status-card button > span {
-    width: 20px;
-    height: 20px;
-  }
-
-  .inventory-status-card strong {
-    font-size: var(--font-size-title-lg);
-    line-height: var(--line-height-title-md);
-  }
-
-  .inventory-status-card small,
-  .inventory-status-card em {
-    font-size: var(--font-size-2xs);
-    line-height: 14px;
-  }
-
-  .inventory-list-head {
-    grid-template-columns: 1fr;
-    gap: 8px;
-    padding: 10px;
-  }
-
-  .inventory-title-line {
-    align-items: start;
-    flex-direction: column;
-    gap: 3px;
-  }
-
-  .inventory-toolbar {
-    display: grid;
-    gap: 8px;
-  }
-
-  .inventory-search {
-    width: 100%;
-  }
-
-  .inventory-toolbar-actions {
-    justify-content: flex-start;
-  }
-
-  .inventory-filter-row {
-    flex-wrap: nowrap;
-    min-width: 0;
-    max-width: 100%;
-    overflow-x: auto;
-    overscroll-behavior-x: contain;
-    scrollbar-gutter: stable;
-    scroll-padding-inline: 2px;
-    padding: 2px 2px 6px;
-    scrollbar-width: thin;
-  }
-
-  .inventory-filter-group,
-  .inventory-filter-toggle,
-  .inventory-filter-select,
-  .inventory-filter-clear,
-  .inventory-filter-result {
-    flex: 0 0 auto;
-  }
-
-  .inventory-filter-select,
-  .app-select.inventory-filter-select {
-    width: 158px;
-    min-width: 158px;
-    max-width: none;
-  }
-
-  .inventory-filter-result {
-    margin-left: 0;
-  }
-
-  .inventory-mobile-list {
-    gap: 7px;
-    padding: 8px;
-  }
-
-  .inventory-card,
-  .inventory-mobile-list article {
-    border-radius: 8px;
-  }
-
   .settings-dashboard-grid,
   .settings-card-stack {
     gap: 12px;
@@ -999,11 +847,5 @@
   .barcode-search-dialog .form-head p {
     grid-column: 1 / -1;
     font-size: var(--font-size-sm);
-  }
-}
-
-@media (max-width: 420px) {
-  .inventory-status-row {
-    grid-template-columns: minmax(0, 1fr);
   }
 }

--- a/frontend/src/styles/settings.css
+++ b/frontend/src/styles/settings.css
@@ -721,48 +721,6 @@
   }
 }
 
-.switch-field {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.switch-field input {
-  position: absolute;
-  opacity: 0;
-  pointer-events: none;
-}
-
-.switch-field span {
-  position: relative;
-  width: 36px;
-  height: 20px;
-  border-radius: var(--radius-pill);
-  background: #b8c2cc;
-  cursor: pointer;
-  transition: background var(--duration-slow) var(--ease-standard);
-}
-
-.switch-field span::after {
-  position: absolute;
-  top: 3px;
-  left: 3px;
-  width: 14px;
-  height: 14px;
-  border-radius: var(--radius-pill);
-  background: var(--input-bg);
-  content: "";
-  transition: transform var(--duration-slow) var(--ease-standard);
-}
-
-.switch-field input:checked + span {
-  background: #22c55e;
-}
-
-.switch-field input:checked + span::after {
-  transform: translateX(16px);
-}
-
 .settings-card-actions {
   display: flex;
   justify-content: flex-end;

--- a/frontend/src/styles/vehicle-inventory-responsive.css
+++ b/frontend/src/styles/vehicle-inventory-responsive.css
@@ -1,0 +1,165 @@
+/* Responsive inventory rules, imported after the shared responsive layer to preserve the cascade. */
+@media (max-width: 900px) {
+  .inventory-head {
+    display: grid;
+  }
+
+  .inventory-list-head {
+    display: grid;
+    gap: 10px;
+    padding: 12px;
+  }
+
+  .inventory-toolbar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .inventory-search {
+    width: 100%;
+  }
+
+  .inventory-list-head .table-actions,
+  .inventory-toolbar-actions {
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .inventory-mobile-list {
+    display: grid;
+    gap: 8px;
+    padding: 10px;
+    background: var(--panel-subtle);
+  }
+
+  .inventory-desktop-content {
+    display: none;
+  }
+
+  .inventory-card-grid {
+    grid-template-columns: 1fr;
+    padding: 12px;
+  }
+
+  .inventory-status-row {
+    grid-template-columns: 1fr;
+  }
+
+  .inventory-status-card.wide {
+    grid-column: auto;
+  }
+
+  .inventory-card {
+    grid-template-rows: 130px auto;
+  }
+
+  .inventory-card-media {
+    height: 130px;
+  }
+}
+
+@media (max-width: 640px) {
+  .inventory-status-row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px;
+  }
+
+  .inventory-status-card {
+    grid-column: auto;
+    min-height: 92px;
+    padding: 10px;
+  }
+
+  .inventory-status-card.wide {
+    grid-column: 1 / -1;
+  }
+
+  .inventory-status-card > span,
+  .inventory-status-card button > span {
+    width: 20px;
+    height: 20px;
+  }
+
+  .inventory-status-card strong {
+    font-size: var(--font-size-title-lg);
+    line-height: var(--line-height-title-md);
+  }
+
+  .inventory-status-card small,
+  .inventory-status-card em {
+    font-size: var(--font-size-2xs);
+    line-height: 14px;
+  }
+
+  .inventory-list-head {
+    grid-template-columns: 1fr;
+    gap: 8px;
+    padding: 10px;
+  }
+
+  .inventory-title-line {
+    align-items: start;
+    flex-direction: column;
+    gap: 3px;
+  }
+
+  .inventory-toolbar {
+    display: grid;
+    gap: 8px;
+  }
+
+  .inventory-search {
+    width: 100%;
+  }
+
+  .inventory-toolbar-actions {
+    justify-content: flex-start;
+  }
+
+  .inventory-filter-row {
+    flex-wrap: nowrap;
+    min-width: 0;
+    max-width: 100%;
+    overflow-x: auto;
+    overscroll-behavior-x: contain;
+    scrollbar-gutter: stable;
+    scroll-padding-inline: 2px;
+    padding: 2px 2px 6px;
+    scrollbar-width: thin;
+  }
+
+  .inventory-filter-group,
+  .inventory-filter-toggle,
+  .inventory-filter-select,
+  .inventory-filter-clear,
+  .inventory-filter-result {
+    flex: 0 0 auto;
+  }
+
+  .inventory-filter-select,
+  .app-select.inventory-filter-select {
+    width: 158px;
+    min-width: 158px;
+    max-width: none;
+  }
+
+  .inventory-filter-result {
+    margin-left: 0;
+  }
+
+  .inventory-mobile-list {
+    gap: 7px;
+    padding: 8px;
+  }
+
+  .inventory-card,
+  .inventory-mobile-list article {
+    border-radius: 8px;
+  }
+}
+
+@media (max-width: 420px) {
+  .inventory-status-row {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/frontend/src/styles/vehicle-inventory.css
+++ b/frontend/src/styles/vehicle-inventory.css
@@ -207,6 +207,72 @@
   flex: 0 0 auto;
 }
 
+.inventory-inline-switch {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--muted);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-black);
+}
+
+.inventory-inline-switch input {
+  position: absolute;
+  inline-size: 1px;
+  block-size: 1px;
+  opacity: 0;
+}
+
+.inventory-inline-switch span {
+  position: relative;
+  display: inline-block;
+  width: 34px;
+  height: 18px;
+  border-radius: var(--radius-pill);
+  background: color-mix(in srgb, var(--muted) 26%, var(--panel-subtle));
+  border: 1px solid var(--line);
+  transition:
+    background var(--duration-normal) var(--ease-standard),
+    border-color var(--duration-normal) var(--ease-standard);
+}
+
+.inventory-inline-switch span::after {
+  content: "";
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+  border-radius: var(--radius-pill);
+  background: color-mix(in srgb, var(--text) 80%, #fff);
+  transition:
+    transform var(--duration-normal) var(--ease-standard),
+    background var(--duration-normal) var(--ease-standard);
+}
+
+.inventory-inline-switch input:checked + span {
+  background: color-mix(in srgb, var(--accent) 74%, var(--panel));
+  border-color: color-mix(in srgb, var(--accent) 68%, var(--line));
+}
+
+.inventory-inline-switch input:checked + span::after {
+  transform: translateX(16px);
+  background: #07110a;
+}
+
+.inventory-inline-switch input:disabled + span {
+  opacity: 0.42;
+  cursor: not-allowed;
+}
+
+.inventory-inline-switch.active {
+  color: var(--accent-strong);
+}
+
+.inventory-inline-switch em {
+  font-style: normal;
+}
+
 .vehicle-inventory-table th.vehicle-column-inventoryNumber .sort-button,
 .vehicle-inventory-table th.vehicle-column-manufacturer .sort-button,
 .vehicle-inventory-table th.vehicle-column-articleNumber .sort-button,


### PR DESCRIPTION
## Deutsch

### Änderungen

- Allgemeine `.switch-field`-Basisregeln aus den Einstellungsstyles in die gemeinsamen Formular-Controls verschoben.
- Inventarspezifische `.inventory-inline-switch`-Regeln beim Fahrzeug-Inventar gebündelt.
- Inventar-Breakpoints aus dem gemeinsamen Responsive-Sammellayer in `vehicle-inventory-responsive.css` ausgelagert.
- Importreihenfolge explizit abgesichert: gemeinsamer Responsive-Layer zuerst, Inventar-Responsive-Layer danach.
- Statische Besitz- und Kaskadentests ergänzt. Keine unbewiesenen Selektoren entfernt und keine Werte visuell verändert.

### Zeilenumfang der von #145 bis #149 berührten Stylesheets

| Stylesheet | Vorher | Nachher |
|---|---:|---:|
| base.css | 687 | 687 |
| forms-controls.css | 1.716 | 1.692 |
| overview-dashboard.css | 1.047 | 1.047 |
| overrides-responsive.css | 1.009 | 851 |
| vehicle-inventory.css | 954 | 1.020 |
| vehicle-inventory-responsive.css | 0 | 165 |
| settings.css | 3.352 | 3.310 |
| vehicle-create-wizard.css | 1.029 | 1.029 |
| exhibition.css | 1.667 | 1.667 |
| vehicle-uploads.css | 560 | 560 |
| **Gesamt** | **12.021** | **12.028** |

Der Nettozuwachs von sieben Zeilen entsteht durch den fokussierten Responsive-Layer und dessen explizite Struktur. Der gemischte Sammellayer verliert 158 Zeilen.

### Prüfung

- `npm.cmd run test:run -- src/styles/cssConsolidation.test.ts src/features/vehicles/vehicleInventoryResponsive.test.ts src/styles/base.test.ts`: 17/17 grün
- `npm.cmd run test:run`: 137 Testdateien, 815 Tests grün
- `npm.cmd run build`: grün
- `git diff --check`: sauber
- Authentifizierte, isolierte RailKeeper-Instanz mit realem Testfahrzeug geprüft:
  - Desktop Light und Dark
  - 390 × 844 Light und Dark
  - Fahrzeug-Tabelle und Mobilliste, Statusraster, Filter-Scroller sowie acht Settings-Switches
  - lange deutsche Fahrzeugbezeichnung
  - Switch-Geometrie unverändert 36 × 20 px
- Temporäre Testdaten und Browserartefakte wurden anschließend entfernt.

Schließt #151.

---

## English

### Changes

- Moved the shared `.switch-field` base rules from settings styles into shared form controls.
- Co-located the inventory-specific `.inventory-inline-switch` rules with vehicle inventory.
- Extracted inventory breakpoints from the shared responsive catch-all into `vehicle-inventory-responsive.css`.
- Explicitly guarded cascade order: shared responsive layer first, inventory responsive layer second.
- Added static ownership and cascade tests. No unproven selector removal and no visual value changes.

### Line counts

The table above documents all stylesheets touched by #145 through #149. Total stylesheet lines change from 12,021 to 12,028; the shared catch-all loses 158 lines while the focused inventory layer gains 165.

### Verification

- Targeted CSS and inventory suite: 17/17 passed
- Full frontend suite: 137 files, 815 tests passed
- Production build passed
- `git diff --check` clean
- Checked an authenticated, isolated RailKeeper instance with a real test vehicle:
  - Desktop light and dark
  - 390 × 844 light and dark
  - Vehicle table and mobile list, status grid, filter scroller, and eight settings switches
  - Long German vehicle name
  - Switch geometry unchanged at 36 × 20 px
- Temporary test data and browser artifacts were removed afterward.

Closes #151.