### PR TITLE
OpenSSL-Pakete im Runtime-Image absichern / Secure OpenSSL packages in runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,11 @@ RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /out/railkee
 FROM alpine:3.24 AS runtime
 LABEL org.opencontainers.image.source="https://github.com/ichwars/RailKeeper" \
   org.opencontainers.image.licenses="AGPL-3.0-only"
-RUN apk add --no-cache ca-certificates tzdata \
+RUN apk add --no-cache --upgrade \
+  'libcrypto3>=3.5.8-r0' \
+  'libssl3>=3.5.8-r0' \
+  ca-certificates \
+  tzdata \
   && adduser -D -H -u 10001 railkeeper \
   && mkdir -p /app/web /data \
   && chown -R railkeeper:railkeeper /app /data


### PR DESCRIPTION
## Deutsch

Behebt die beiden Trivy-Code-Scanning-Befunde #31 und #32 zu CVE-2026-14456 im veröffentlichten Alpine-Runtime-Image.

- erzwingt `libcrypto3` und `libssl3` ab Version `3.5.8-r0`
- behält Alpine 3.24 und das bestehende Containerverhalten bei
- lässt den Build bei nicht verfügbarer gepatchter Version sicher fehlschlagen

### Prüfung

- `go test ./...` ✅
- `npm.cmd run build` ✅
- Docker Image Workflow auf dem Branch ✅
- Trivy-Scan des gebauten Image-Digests ✅

## English

Fixes the two Trivy code-scanning findings #31 and #32 for CVE-2026-14456 in the published Alpine runtime image.

- requires `libcrypto3` and `libssl3` version `3.5.8-r0` or newer
- preserves Alpine 3.24 and existing container behavior
- fails the build safely when patched packages are unavailable

### Verification

- `go test ./...` ✅
- `npm.cmd run build` ✅
- Docker Image workflow on the branch ✅
- Trivy scan of the built image digest ✅