### PR TITLE
Anlagenzwilling absichern / Harden layout twin

### DIFF
--- a/frontend/src/features/layouts/LayoutTechnicalPositionDialog.test.tsx
+++ b/frontend/src/features/layouts/LayoutTechnicalPositionDialog.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
-import type { AccessoryArticleListItem, LayoutUnit } from "../../shared/api";
+import type { AccessoryArticleListItem, LayoutTechnicalPosition, LayoutUnit } from "../../shared/api";
 import { LayoutTechnicalPositionDialog } from "./LayoutTechnicalPositionDialog";
 
 const unit: LayoutUnit = {
@@ -17,6 +17,12 @@ const product: AccessoryArticleListItem = {
   inventoryStrategy: "quantity", archived: false, owned: 4, available: 4, reserved: 0, installed: 0,
   locationNames: [], hasUsageHistory: false, careHintCount: 0, updatedAt: "2026-08-09T10:00:00Z",
   attributes: []
+};
+
+const position: LayoutTechnicalPosition = {
+  id: "position-1", layoutUnitId: unit.id, label: "Signal Alt", kind: "signal",
+  positionXMm: 100, positionYMm: 80, rotationDegrees: 0, version: 1, archived: false,
+  createdAt: "2026-08-09T10:00:00Z", updatedAt: "2026-08-09T10:00:00Z"
 };
 
 describe("LayoutTechnicalPositionDialog", () => {
@@ -58,5 +64,23 @@ describe("LayoutTechnicalPositionDialog", () => {
     const confirm = screen.getByRole("dialog", { name: "Änderungen verwerfen?" });
     await user.click(within(confirm).getByRole("button", { name: "Verwerfen" }));
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("replaces stale form values with the reloaded server position after a conflict", async () => {
+    const user = userEvent.setup();
+    const reloaded = {
+      ...position, label: "Signal Server", positionXMm: 220, version: 2,
+      updatedAt: "2026-08-09T11:00:00Z"
+    };
+    render(<LayoutTechnicalPositionDialog unit={unit} position={position} products={[]} saving={false}
+      message="Konflikt" conflict onSubmit={() => undefined} onReloadConflict={async () => reloaded}
+      onClose={() => undefined} />);
+
+    await user.clear(screen.getByRole("textbox", { name: "Bezeichnung" }));
+    await user.type(screen.getByRole("textbox", { name: "Bezeichnung" }), "Lokaler Entwurf");
+    await user.click(screen.getByRole("button", { name: "Serverstand neu laden" }));
+
+    expect(screen.getByRole("textbox", { name: "Bezeichnung" })).toHaveValue("Signal Server");
+    expect(screen.getByRole("spinbutton", { name: "X-Position (mm)" })).toHaveValue(220);
   });
 });

--- a/frontend/src/features/layouts/LayoutTechnicalPositionDialog.tsx
+++ b/frontend/src/features/layouts/LayoutTechnicalPositionDialog.tsx
@@ -59,7 +59,7 @@ export function LayoutTechnicalPositionDialog({ unit, position, products, saving
   conflict: boolean;
   returnFocusTo?: HTMLElement | null;
   onSubmit: (input: LayoutTechnicalPositionInput, expectedVersion?: number) => void | Promise<void>;
-  onReloadConflict?: () => Promise<number | void>;
+  onReloadConflict?: () => Promise<LayoutTechnicalPosition | void>;
   onClose: () => void;
 }) {
   const [form, setForm] = useState(() => formValue(position));
@@ -99,8 +99,10 @@ export function LayoutTechnicalPositionDialog({ unit, position, products, saving
   };
 
   const reloadConflict = async () => {
-    const version = await onReloadConflict?.();
-    if (version) setExpectedVersion(version);
+    const current = await onReloadConflict?.();
+    if (!current) return;
+    setForm(formValue(current));
+    setExpectedVersion(current.version);
   };
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {

--- a/frontend/src/features/layouts/LayoutTechnicalPositionsPanel.test.tsx
+++ b/frontend/src/features/layouts/LayoutTechnicalPositionsPanel.test.tsx
@@ -1,0 +1,66 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  api,
+  type AccessoryArticleListResult,
+  type LayoutTechnicalPosition,
+  type LayoutUnit
+} from "../../shared/api";
+import { LayoutTechnicalPositionsPanel } from "./LayoutTechnicalPositionsPanel";
+
+const units: LayoutUnit[] = [{
+  id: "unit-1", layoutId: "layout-1", name: "Bahnhof", kind: "module", widthMm: 1000, heightMm: 400,
+  version: 1, archived: false, createdAt: "2026-08-09T10:00:00Z", updatedAt: "2026-08-09T10:00:00Z"
+}, {
+  id: "unit-2", layoutId: "layout-1", name: "Schattenbahnhof", kind: "module", widthMm: 1200,
+  heightMm: 500, version: 1, archived: false, createdAt: "2026-08-09T10:00:00Z",
+  updatedAt: "2026-08-09T10:00:00Z"
+}];
+
+const positions: LayoutTechnicalPosition[] = units.map((unit, index) => ({
+  id: `position-${index + 1}`, layoutUnitId: unit.id, label: `${unit.name} Signal`, kind: "signal",
+  positionXMm: 100, positionYMm: 80, rotationDegrees: 0, version: 1, archived: false,
+  createdAt: "2026-08-09T10:00:00Z", updatedAt: "2026-08-09T10:00:00Z"
+}));
+
+const emptyArticles: AccessoryArticleListResult = {
+  items: [],
+  metrics: {
+    articleCount: 0, articleTypeCount: 0, available: 0, locationCount: 0,
+    reserved: 0, installed: 0, careHintCount: 0
+  },
+  filters: { manufacturers: [], articleTypes: [], gauges: [], storageLocations: [] }
+};
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => { resolve = next; });
+  return { promise, resolve };
+}
+
+describe("LayoutTechnicalPositionsPanel", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("ignores a stale position response after switching units", async () => {
+    const user = userEvent.setup();
+    const first = deferred<LayoutTechnicalPosition[]>();
+    const second = deferred<LayoutTechnicalPosition[]>();
+    vi.spyOn(api, "accessoryArticles").mockResolvedValue(emptyArticles);
+    const load = vi.spyOn(api, "layoutTechnicalPositions").mockImplementation((unitID) =>
+      unitID === units[0].id ? first.promise : second.promise);
+    render(<LayoutTechnicalPositionsPanel units={units} canPlan />);
+    await waitFor(() => expect(load).toHaveBeenCalledWith(units[0].id));
+
+    await user.click(screen.getByRole("button", { name: "Anlageneinheit" }));
+    await user.click(screen.getByRole("option", { name: units[1].name }));
+    await waitFor(() => expect(load).toHaveBeenCalledWith(units[1].id));
+    await act(async () => second.resolve([positions[1]]));
+    expect(await screen.findByText("Schattenbahnhof Signal")).toBeInTheDocument();
+
+    await act(async () => first.resolve([positions[0]]));
+    await waitFor(() => expect(screen.queryByText("Bahnhof Signal")).not.toBeInTheDocument());
+    expect(screen.getByText("Schattenbahnhof Signal")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/layouts/LayoutTechnicalPositionsPanel.tsx
+++ b/frontend/src/features/layouts/LayoutTechnicalPositionsPanel.tsx
@@ -29,6 +29,7 @@ export function LayoutTechnicalPositionsPanel({ units, canPlan }: {
   const [dialogMessage, setDialogMessage] = useState("");
   const [conflict, setConflict] = useState(false);
   const createButtonRef = useRef<HTMLButtonElement | null>(null);
+  const positionsRequestRef = useRef(0);
   const { t } = useI18n();
   const selectedUnit = activeUnits.find((unit) => unit.id === unitID);
 
@@ -38,12 +39,14 @@ export function LayoutTechnicalPositionsPanel({ units, canPlan }: {
   }, [activeUnits, unitID]);
 
   const loadPositions = useCallback(async () => {
+    const requestID = positionsRequestRef.current + 1;
+    positionsRequestRef.current = requestID;
     if (!unitID) {
-      setPositions([]);
+      if (requestID === positionsRequestRef.current) setPositions([]);
       return [];
     }
     const next = await api.layoutTechnicalPositions(unitID);
-    setPositions(next);
+    if (requestID === positionsRequestRef.current) setPositions(next);
     return next;
   }, [unitID]);
 
@@ -115,7 +118,8 @@ export function LayoutTechnicalPositionsPanel({ units, canPlan }: {
       }
       setConflict(false);
       setDialogMessage(t("layouts.technology.reloaded"));
-      return current.version;
+      setDialogPosition(current);
+      return current;
     } catch (reason) {
       setDialogMessage(reason instanceof Error ? reason.message : t("layouts.error.generic"));
     }
@@ -140,7 +144,10 @@ export function LayoutTechnicalPositionsPanel({ units, canPlan }: {
       <div className="layout-technology-toolbar">
         <label className="app-field"><span className="app-field-label">{t("layouts.plans.unit")}</span>
           <AppSelect value={unitID} aria-label={t("layouts.plans.unit")}
-            onChange={(event) => setUnitID(event.target.value)}>
+            onChange={(event) => {
+              positionsRequestRef.current += 1;
+              setUnitID(event.target.value);
+            }}>
             {activeUnits.map((unit) => <option key={unit.id} value={unit.id}>{unit.name}</option>)}
           </AppSelect>
         </label>

--- a/frontend/src/features/layouts/LayoutTwinHistory.test.tsx
+++ b/frontend/src/features/layouts/LayoutTwinHistory.test.tsx
@@ -21,7 +21,7 @@ describe("LayoutTwinHistory", () => {
       }]
     });
 
-    render(<LayoutTwinHistory positionID="position-1" productID="product-1" />);
+    render(<LayoutTwinHistory positionID="position-1" productIDs={["product-1"]} />);
 
     expect(screen.getByRole("status")).toHaveTextContent("Verlauf wird geladen");
     expect(await screen.findByText("Zustandsänderung")).toBeInTheDocument();
@@ -30,9 +30,27 @@ describe("LayoutTwinHistory", () => {
     expect(history).toHaveBeenCalledWith("product-1");
   });
 
-  it("does not request history when the position has no linked article", async () => {
+  it("merges position events from every allocated article", async () => {
+    const history = vi.spyOn(api, "accessoryUsageHistory").mockImplementation(async (productID) => ({
+      productId: productID,
+      events: [{
+        id: `installation-${productID}`, type: "installation", productId: productID,
+        installationId: `installation-${productID}`, quantity: 1, technicalPositionId: "position-1",
+        condition: "ready", occurredAt: productID === "product-1"
+          ? "2026-08-09T11:00:00Z" : "2026-08-09T12:00:00Z"
+      }]
+    }));
+
+    render(<LayoutTwinHistory positionID="position-1" productIDs={["product-1", "product-2"]} />);
+
+    expect(await screen.findAllByText("Einbau")).toHaveLength(2);
+    expect(history).toHaveBeenCalledWith("product-1");
+    expect(history).toHaveBeenCalledWith("product-2");
+  });
+
+  it("does not request history when the position has no allocated article", async () => {
     const history = vi.spyOn(api, "accessoryUsageHistory");
-    render(<LayoutTwinHistory positionID="position-1" />);
+    render(<LayoutTwinHistory positionID="position-1" productIDs={[]} />);
 
     expect(screen.getByText(/verknüpften Artikel/)).toBeInTheDocument();
     await waitFor(() => expect(history).not.toHaveBeenCalled());
@@ -40,7 +58,7 @@ describe("LayoutTwinHistory", () => {
 
   it("keeps loading failures inside the inspector", async () => {
     vi.spyOn(api, "accessoryUsageHistory").mockRejectedValue(new Error("offline"));
-    render(<LayoutTwinHistory positionID="position-1" productID="product-1" />);
+    render(<LayoutTwinHistory positionID="position-1" productIDs={["product-1"]} />);
 
     expect(await screen.findByRole("alert")).toHaveTextContent("Verlauf konnte nicht geladen werden");
   });

--- a/frontend/src/features/layouts/LayoutTwinHistory.tsx
+++ b/frontend/src/features/layouts/LayoutTwinHistory.tsx
@@ -4,25 +4,26 @@ import { useEffect, useState } from "react";
 import { api, type AccessoryUsageEvent } from "../../shared/api";
 import { formatDateTime, useI18n } from "../../shared/i18n";
 
-export function LayoutTwinHistory({ positionID, productID }: {
+export function LayoutTwinHistory({ positionID, productIDs }: {
   positionID: string;
-  productID?: string;
+  productIDs: readonly string[];
 }) {
   const { t, language } = useI18n();
+  const productKey = [...new Set(productIDs.filter(Boolean))].sort().join("\u001f");
   const [events, setEvents] = useState<AccessoryUsageEvent[]>([]);
-  const [loading, setLoading] = useState(Boolean(productID));
+  const [loading, setLoading] = useState(Boolean(productKey));
   const [failed, setFailed] = useState(false);
 
   useEffect(() => {
     let active = true;
     setEvents([]);
     setFailed(false);
-    setLoading(Boolean(productID));
-    if (!productID) return () => { active = false; };
-    api.accessoryUsageHistory(productID)
-      .then((history) => {
+    setLoading(Boolean(productKey));
+    if (!productKey) return () => { active = false; };
+    Promise.all(productKey.split("\u001f").map((productID) => api.accessoryUsageHistory(productID)))
+      .then((histories) => {
         if (!active) return;
-        setEvents(history.events
+        setEvents(histories.flatMap((history) => history.events)
           .filter((event) => event.technicalPositionId === positionID)
           .sort((left, right) => right.occurredAt.localeCompare(left.occurredAt)));
       })
@@ -33,9 +34,9 @@ export function LayoutTwinHistory({ positionID, productID }: {
         if (active) setLoading(false);
       });
     return () => { active = false; };
-  }, [positionID, productID]);
+  }, [positionID, productKey]);
 
-  if (!productID) return <p className="layout-empty">{t("layouts.twin.history.noArticle")}</p>;
+  if (!productKey) return <p className="layout-empty">{t("layouts.twin.history.noArticle")}</p>;
   if (loading) return <p className="layout-empty" role="status">{t("layouts.twin.history.loading")}</p>;
   if (failed) return <p className="layout-twin-history-error" role="alert"><TriangleAlert size={15} />
     {t("layouts.twin.history.error")}</p>;

--- a/frontend/src/features/layouts/LayoutTwinPanel.test.tsx
+++ b/frontend/src/features/layouts/LayoutTwinPanel.test.tsx
@@ -58,6 +58,10 @@ describe("LayoutTwinPanel", () => {
   it("renders the transformed twin, filters statuses, and opens the inspector by click and keyboard", async () => {
     const user = userEvent.setup();
     vi.spyOn(api, "layoutTwin").mockResolvedValue(twin);
+    const history = vi.spyOn(api, "accessoryUsageHistory").mockImplementation(async (productID) => ({
+      productId: productID,
+      events: []
+    }));
     render(<LayoutTwinPanel layout={layout} units={[unit]} configurations={[configuration]} canPlan />);
 
     expect(await screen.findByRole("img", { name: "Grafische Anlagenübersicht mit technischen Positionen" }))
@@ -79,6 +83,7 @@ describe("LayoutTwinPanel", () => {
     defectiveMarker.focus();
     await user.keyboard("{Enter}");
     await waitFor(() => expect(screen.getByLabelText("Positionsinspektor")).toHaveTextContent("Weiche West"));
+    await waitFor(() => expect(history).toHaveBeenCalledWith("product-2"));
   });
 
   it("uses the app-owned empty state when no unit or configuration exists", () => {
@@ -90,9 +95,7 @@ describe("LayoutTwinPanel", () => {
 
   it("keeps editing role-gated and autosaves keyboard and pointer changes", async () => {
     const user = userEvent.setup();
-    const pendingReload = new Promise<LayoutTwin>(() => undefined);
-    vi.spyOn(api, "layoutTwin").mockResolvedValueOnce(twin).mockReturnValueOnce(pendingReload)
-      .mockResolvedValue(twin);
+    vi.spyOn(api, "layoutTwin").mockResolvedValue(twin);
     const updatePosition = vi.spyOn(api, "updateLayoutTechnicalPosition").mockResolvedValue({
       id: "position-reserved", layoutUnitId: unit.id, label: "Einfahrsignal A", kind: "signal",
       positionXMm: 151, positionYMm: 80, rotationDegrees: 90, version: 2, archived: false,
@@ -112,7 +115,7 @@ describe("LayoutTwinPanel", () => {
     await user.keyboard("{ArrowRight}");
     await waitFor(() => expect(updatePosition).toHaveBeenCalledWith("position-reserved",
       expect.objectContaining({ positionXMm: 151, positionYMm: 80, expectedVersion: 1 })), { timeout: 1500 });
-    await waitFor(() => expect(api.layoutTwin).toHaveBeenCalledTimes(2));
+    expect(api.layoutTwin).toHaveBeenCalledTimes(1);
 
     const canvas = screen.getByRole("img", { name: "Grafische Anlagenübersicht mit technischen Positionen" });
     vi.spyOn(canvas, "getBoundingClientRect").mockReturnValue({
@@ -126,6 +129,34 @@ describe("LayoutTwinPanel", () => {
     await waitFor(() => expect(updateOutline).toHaveBeenCalledWith(unit.id,
       expect.objectContaining({ expectedVersion: 1 })), { timeout: 4000 });
   }, 10000);
+
+  it("keeps independent autosaves when two positions are edited within the debounce window", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(api, "layoutTwin").mockResolvedValue(twin);
+    const updatePosition = vi.spyOn(api, "updateLayoutTechnicalPosition").mockResolvedValue({
+      id: "position-reserved", layoutUnitId: unit.id, label: "Einfahrsignal A", kind: "signal",
+      positionXMm: 151, positionYMm: 80, rotationDegrees: 90, version: 2, archived: false,
+      createdAt: "2026-08-09T10:00:00Z", updatedAt: "2026-08-09T11:00:00Z"
+    });
+    render(<LayoutTwinPanel layout={layout} units={[unit]} configurations={[configuration]} canPlan />);
+    await screen.findByRole("img", { name: "Grafische Anlagenübersicht mit technischen Positionen" });
+    await user.click(screen.getByRole("button", { name: "Bearbeiten" }));
+
+    const reserved = screen.getByRole("button", { name: /Einfahrsignal A, Reserviert/ });
+    reserved.focus();
+    await user.keyboard("{ArrowRight}");
+    const defective = screen.getByRole("button", { name: /Weiche West, Eingebaut, Defekt/ });
+    defective.focus();
+    await user.keyboard("{ArrowDown}");
+
+    await waitFor(() => expect(updatePosition).toHaveBeenCalledTimes(2), { timeout: 2000 });
+    expect(updatePosition).toHaveBeenCalledWith("position-reserved", expect.objectContaining({
+      positionXMm: 151, positionYMm: 80
+    }));
+    expect(updatePosition).toHaveBeenCalledWith("position-defective", expect.objectContaining({
+      positionXMm: 500, positionYMm: 121
+    }));
+  });
 
   it("preserves the local edit on a version conflict and hides editing from viewers", async () => {
     const user = userEvent.setup();

--- a/frontend/src/features/layouts/LayoutTwinPanel.tsx
+++ b/frontend/src/features/layouts/LayoutTwinPanel.tsx
@@ -1,4 +1,4 @@
-import { Check, Info, Map, Pencil, RefreshCw, TriangleAlert, X } from "lucide-react";
+import { Check, Info, Map as MapIcon, Pencil, RefreshCw, TriangleAlert, X } from "lucide-react";
 import { KeyboardEvent, PointerEvent, useEffect, useMemo, useRef, useState } from "react";
 
 import {
@@ -42,6 +42,14 @@ function positionSymbol(position: LayoutTwinPosition) {
   return symbols[position.kind];
 }
 
+function positionProductIDs(position: LayoutTwinPosition) {
+  return [...new Set([
+    position.productId,
+    ...position.reservations.map((reservation) => reservation.productId),
+    ...position.installations.map((installation) => installation.productId)
+  ].filter((productID): productID is string => Boolean(productID)))];
+}
+
 type TwinDrag =
   | { kind: "position"; id: string; unitID: string; pointerID: number }
   | { kind: "outline"; unitID: string; pointIndex: number; pointerID: number };
@@ -77,7 +85,7 @@ export function LayoutTwinPanel({ layout, units, configurations, canPlan }: {
   const [editConflict, setEditConflict] = useState(false);
   const twinRef = useRef<LayoutTwin | null>(null);
   const dragRef = useRef<TwinDrag | null>(null);
-  const saveTimerRef = useRef<number | null>(null);
+  const saveTimersRef = useRef<Map<string, number>>(new Map());
 
   useEffect(() => {
     if (sources.some((option) => option.value === source)) return;
@@ -109,7 +117,8 @@ export function LayoutTwinPanel({ layout, units, configurations, canPlan }: {
   }, [layout.id, reloadKey, source]);
 
   useEffect(() => () => {
-    if (saveTimerRef.current !== null) window.clearTimeout(saveTimerRef.current);
+    saveTimersRef.current.forEach((timer) => window.clearTimeout(timer));
+    saveTimersRef.current.clear();
   }, []);
 
   useEffect(() => {
@@ -190,12 +199,18 @@ export function LayoutTwinPanel({ layout, units, configurations, canPlan }: {
     if (!position) return;
     setSavingKey(`position:${positionID}`);
     try {
-      await api.updateLayoutTechnicalPosition(positionID, {
+      const saved = await api.updateLayoutTechnicalPosition(positionID, {
         label: position.label, kind: position.kind, positionXMm: position.localXMm,
         positionYMm: position.localYMm, rotationDegrees: position.localRotationDegrees,
         productId: position.productId, description: position.description, expectedVersion: position.version
       });
-      setReloadKey((current) => current + 1);
+      const current = twinRef.current;
+      if (current) applyTwin({ ...current, units: current.units.map((unit) => unit.id === unitID ? {
+        ...unit,
+        positions: unit.positions.map((item) => item.id === positionID
+          ? { ...item, version: saved.version }
+          : item)
+      } : unit) });
     } catch (reason) {
       if (reason instanceof ApiError && reason.status === 409) setEditConflict(true);
       else setError(reason instanceof Error ? reason.message : t("layouts.error.generic"));
@@ -209,10 +224,13 @@ export function LayoutTwinPanel({ layout, units, configurations, canPlan }: {
     if (!unit) return;
     setSavingKey(`outline:${unitID}`);
     try {
-      await api.updateLayoutUnitOutline(unitID, {
+      const saved = await api.updateLayoutUnitOutline(unitID, {
         points: unit.localOutline, expectedVersion: unit.version
       });
-      setReloadKey((current) => current + 1);
+      const current = twinRef.current;
+      if (current) applyTwin({ ...current, units: current.units.map((item) => item.id === unitID
+        ? { ...item, version: saved.version }
+        : item) });
     } catch (reason) {
       if (reason instanceof ApiError && reason.status === 409) setEditConflict(true);
       else setError(reason instanceof Error ? reason.message : t("layouts.error.generic"));
@@ -222,12 +240,15 @@ export function LayoutTwinPanel({ layout, units, configurations, canPlan }: {
   };
 
   const scheduleSave = (drag: TwinDrag) => {
-    if (saveTimerRef.current !== null) window.clearTimeout(saveTimerRef.current);
-    saveTimerRef.current = window.setTimeout(() => {
-      saveTimerRef.current = null;
+    const key = drag.kind === "position" ? `position:${drag.id}` : `outline:${drag.unitID}`;
+    const currentTimer = saveTimersRef.current.get(key);
+    if (currentTimer !== undefined) window.clearTimeout(currentTimer);
+    const timer = window.setTimeout(() => {
+      saveTimersRef.current.delete(key);
       if (drag.kind === "position") void savePosition(drag.id, drag.unitID);
       else void saveOutline(drag.unitID);
     }, 300);
+    saveTimersRef.current.set(key, timer);
   };
 
   const handlePointerMove = (event: PointerEvent<SVGSVGElement>) => {
@@ -268,7 +289,7 @@ export function LayoutTwinPanel({ layout, units, configurations, canPlan }: {
 
   return <section className="panel layout-twin-panel">
     <div className="layout-panel-head layout-twin-head">
-      <div className="panel-title"><Map size={17} /><div><h3>{t("layouts.twin.title")}</h3>
+      <div className="panel-title"><MapIcon size={17} /><div><h3>{t("layouts.twin.title")}</h3>
         <p>{t("layouts.twin.subtitle")}</p></div></div>
       <div className="layout-twin-head-actions">{canPlan ? <button type="button"
         className={editing ? "secondary-button compact-action active" : "secondary-button compact-action"}
@@ -412,7 +433,8 @@ function LayoutTwinInspector({ position, unitName, onClose }: {
           {allocation.wiringNotes ? <small>{t("layouts.twin.inspector.wiringNotes")}: {allocation.wiringNotes}</small> : null}
         </article>)}</div> : <p className="layout-empty">{t("layouts.twin.inspector.noAllocations")}</p>}</section>
       <section><h5>{t("layouts.twin.history.title")}</h5>
-        <LayoutTwinHistory key={position.id} positionID={position.id} productID={position.productId} /></section>
+        <LayoutTwinHistory key={position.id} positionID={position.id}
+          productIDs={positionProductIDs(position)} /></section>
     </div>
   </aside>;
 }

--- a/frontend/src/features/layouts/LayoutsView.test.tsx
+++ b/frontend/src/features/layouts/LayoutsView.test.tsx
@@ -213,7 +213,7 @@ describe("LayoutsView", () => {
       expect.objectContaining({ label: "Weiche 1", kind: "turnout", positionXMm: 120, positionYMm: 45 })));
   });
 
-  it("preserves technical position edits while reloading a version conflict", async () => {
+  it("replaces technical position edits with the selected server version after a conflict", async () => {
     const user = userEvent.setup();
     const serverPosition = { ...technicalPosition, version: 2, positionXMm: 275 };
     vi.mocked(api.layoutTechnicalPositions)
@@ -240,12 +240,13 @@ describe("LayoutsView", () => {
     expect(name).toHaveValue("Lokaler Signalname");
     await user.click(within(dialog).getByRole("button", { name: "Serverstand neu laden" }));
     expect(await within(dialog).findByText(
-      "Aktuelle Version geladen. Deine Eingaben bleiben erhalten."
+      "Aktueller Serverstand geladen. Der lokale Entwurf wurde ersetzt."
     )).toBeInTheDocument();
-    expect(name).toHaveValue("Lokaler Signalname");
+    expect(name).toHaveValue("Einfahrsignal A");
+    expect(within(dialog).getByRole("spinbutton", { name: "X-Position (mm)" })).toHaveValue(275);
     await user.click(within(dialog).getByRole("button", { name: "Position speichern" }));
     await waitFor(() => expect(api.updateLayoutTechnicalPosition).toHaveBeenLastCalledWith(technicalPosition.id,
-      expect.objectContaining({ label: "Lokaler Signalname", expectedVersion: 2 })));
+      expect.objectContaining({ label: "Einfahrsignal A", positionXMm: 275, expectedVersion: 2 })));
   });
 
   it.each(["Viewer", "Editor"])("keeps technical positions read-only for %s users", async (role) => {

--- a/frontend/src/shared/i18n/de.ts
+++ b/frontend/src/shared/i18n/de.ts
@@ -2832,7 +2832,7 @@ export const deTranslations: Record<string, string> = {
     "layouts.technology.summary": "{count} Positionen in der gewählten Einheit",
     "layouts.technology.editLabel": "{name} bearbeiten",
     "layouts.technology.conflict": "Die Position wurde zwischenzeitlich geändert. Deine Eingaben bleiben erhalten.",
-    "layouts.technology.reloaded": "Aktuelle Version geladen. Deine Eingaben bleiben erhalten.",
+    "layouts.technology.reloaded": "Aktueller Serverstand geladen. Der lokale Entwurf wurde ersetzt.",
     "layouts.technology.missingAfterReload": "Die Position ist auf dem Server nicht mehr vorhanden.",
     "layouts.positionKind.turnout": "Weiche",
     "layouts.positionKind.signal": "Signal",

--- a/frontend/src/shared/i18n/en.ts
+++ b/frontend/src/shared/i18n/en.ts
@@ -2832,7 +2832,7 @@ export const enTranslations: Record<string, string> = {
     "layouts.technology.summary": "{count} positions in the selected unit",
     "layouts.technology.editLabel": "Edit {name}",
     "layouts.technology.conflict": "The position changed on the server. Your entries have been preserved.",
-    "layouts.technology.reloaded": "Current version loaded. Your entries have been preserved.",
+    "layouts.technology.reloaded": "Current server version loaded. The local draft was replaced.",
     "layouts.technology.missingAfterReload": "The position no longer exists on the server.",
     "layouts.positionKind.turnout": "Turnout",
     "layouts.positionKind.signal": "Signal",


### PR DESCRIPTION
## Deutsch

Schließt #35.

Der interaktive Anlagenzwilling wurde bereits mit PR #70 und Release 0.1.17.2 ausgeliefert. Dieser PR behebt die vier noch offenen P2-Review-Befunde, die unmittelbar zu Stage 2 gehören:

- getrennte Debounce-Timer verhindern, dass schnelle Änderungen an unterschiedlichen Positionen einander verwerfen
- erfolgreiche Autosaves gleichen Versionsstände lokal ab, ohne andere noch nicht gespeicherte Entwürfe durch ein Voll-Reload zurückzusetzen
- die Positionshistorie lädt alle Artikel aus direkter Zuordnung, Reservierungen und Einbauten
- ein bewusst gewählter Konflikt-Reload ersetzt Formular und Version gemeinsam durch den Serverstand
- verspätete Positionsantworten dürfen nach einem Modulwechsel den aktuellen Inhalt nicht überschreiben
- DE/EN-Rückmeldung erklärt eindeutig, dass der lokale Konfliktentwurf ersetzt wurde

Geprüfte Altbefunde aus PR #70:

- https://github.com/ichwars/RailKeeper/pull/70#discussion_r3781143468
- https://github.com/ichwars/RailKeeper/pull/70#discussion_r3781143473
- https://github.com/ichwars/RailKeeper/pull/70#discussion_r3781143487
- https://github.com/ichwars/RailKeeper/pull/70#discussion_r3781143490

Lokale Prüfung:

- rot-grüne Regression der vier Review-Szenarien
- 22 Layout-Testdateien, 84 Tests
- vollständige Frontend-Coverage: 144 Testdateien, 857 Tests
- Coverage: 66,77 % Statements, 59,70 % Branches, 60,25 % Funktionen, 68,81 % Zeilen
- TypeScript- und Vite-Produktionsbuild
- `git diff --check`

Die übrigen Altbefunde aus PR #70 gehören zu #32 und #36 und werden dort separat abgearbeitet.

## English

Closes #35.

The interactive layout twin was already delivered through PR #70 and release 0.1.17.2. This pull request fixes the four remaining P2 review findings that directly belong to Stage 2:

- separate debounce timers prevent rapid edits to different positions from discarding each other
- successful autosaves reconcile versions locally without resetting other unsaved drafts through a full reload
- position history loads every product referenced directly, by reservations, or by installations
- an explicitly selected conflict reload replaces the form and version together with the server state
- stale position replies can no longer overwrite the current content after switching units
- DE/EN feedback clearly states that the local conflict draft was replaced

Verified legacy findings from PR #70:

- https://github.com/ichwars/RailKeeper/pull/70#discussion_r3781143468
- https://github.com/ichwars/RailKeeper/pull/70#discussion_r3781143473
- https://github.com/ichwars/RailKeeper/pull/70#discussion_r3781143487
- https://github.com/ichwars/RailKeeper/pull/70#discussion_r3781143490

Local verification:

- red-green regression for all four review scenarios
- 22 layout test files, 84 tests
- full frontend coverage: 144 test files, 857 tests
- coverage: 66.77% statements, 59.70% branches, 60.25% functions, 68.81% lines
- TypeScript and Vite production build
- `git diff --check`

The remaining legacy findings from PR #70 belong to #32 and #36 and will be handled separately.