### PR TITLE
Gleisplaner transaktional absichern / Harden track planner transactions

### DIFF
--- a/backend/internal/application/track_planner.go
+++ b/backend/internal/application/track_planner.go
@@ -403,11 +403,6 @@ func (service *TrackPlannerService) UpdateObject(
 	if _, err := domain.EffectiveGeometryForObject(*moving); err != nil {
 		return nil, ErrTrackPlanValidation
 	}
-	if snap := domain.FindTrackSnap(*moving, plan.Objects); snap.Snapped {
-		input.PositionXMM = snap.Pose.PositionXMM
-		input.PositionYMM = snap.Pose.PositionYMM
-		input.RotationDegrees = snap.Pose.RotationDegrees
-	}
 	return service.repository.UpdateObject(ctx, id, input, actor)
 }
 

--- a/backend/internal/application/track_planner_test.go
+++ b/backend/internal/application/track_planner_test.go
@@ -350,7 +350,7 @@ func TestTrackPlannerServicePreviewsTransitionCurveWithoutMutation(t *testing.T)
 
 func float64Pointer(value float64) *float64 { return &value }
 
-func TestTrackPlannerSnapAppliesNearestCompatiblePose(t *testing.T) {
+func TestTrackPlannerServiceDelegatesRequestedPoseForTransactionalSnapping(t *testing.T) {
 	moving := trackPlannerTestG1("moving", 172, 2, 2)
 	target := trackPlannerTestG1("target", 0, 0, 0)
 	repository := &trackPlannerRepositorySpy{planForObject: &TrackPlan{
@@ -366,8 +366,8 @@ func TestTrackPlannerSnapAppliesNearestCompatiblePose(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if updated.PositionXMM != 166 || updated.PositionYMM != 0 || updated.RotationDegrees != 0 {
-		t.Fatalf("expected authoritative snapped pose, got %#v", updated)
+	if updated.PositionXMM != 172 || updated.PositionYMM != 2 || updated.RotationDegrees != 2 {
+		t.Fatalf("requested pose changed before repository update: %#v", updated)
 	}
 }
 

--- a/backend/internal/infrastructure/track_planner_repository.go
+++ b/backend/internal/infrastructure/track_planner_repository.go
@@ -356,8 +356,20 @@ WHERE geometry.id=?`, line.GeometryID).
 
 		rows, err := repository.db.QueryContext(ctx, `
 SELECT product.id, product.inventory_number,
-       COALESCE((SELECT SUM(stock.quantity) FROM accessory_stock stock
-                 WHERE stock.product_id=product.id), 0),
+       CASE WHEN product.inventory_strategy='individual' THEN
+              COALESCE((SELECT COUNT(*) FROM accessory_assets asset
+                        WHERE asset.product_id=product.id
+                          AND asset.storage_location_id IS NOT NULL
+                          AND asset.lifecycle_state IN ('stored', 'reserved')), 0)
+            WHEN product.inventory_strategy='quantity_later_individual' THEN
+              COALESCE((SELECT SUM(stock.quantity) FROM accessory_stock stock
+                        WHERE stock.product_id=product.id), 0)
+              + COALESCE((SELECT COUNT(*) FROM accessory_assets asset
+                          WHERE asset.product_id=product.id
+                            AND asset.storage_location_id IS NOT NULL
+                            AND asset.lifecycle_state IN ('stored', 'reserved')), 0)
+            ELSE COALESCE((SELECT SUM(stock.quantity) FROM accessory_stock stock
+                           WHERE stock.product_id=product.id), 0) END,
        COALESCE((SELECT SUM(reservation.quantity) FROM accessory_reservations reservation
                  WHERE reservation.product_id=product.id AND reservation.status='active'), 0)
 FROM accessory_products product
@@ -476,6 +488,13 @@ func (repository *TrackPlannerRepository) CreateObject(
 		) {
 			return application.ErrTrackPlanValidation
 		}
+		gaugeMatches, err := trackGeometryMatchesRevisionGauge(ctx, tx, revisionID, geometry.LibraryID)
+		if err != nil {
+			return err
+		}
+		if !gaugeMatches {
+			return application.ErrTrackPlanValidation
+		}
 		geometrySnapshotJSON, err := json.Marshal(geometry)
 		if err != nil {
 			return fmt.Errorf("encode track geometry snapshot: %w", err)
@@ -515,7 +534,7 @@ func (repository *TrackPlannerRepository) UpdateObject(
 		return nil, application.ErrTrackPlanValidation
 	}
 	err = repository.withTx(ctx, func(tx *sql.Tx) error {
-		status, version, err := trackObjectState(ctx, tx, id)
+		status, revisionID, version, err := trackObjectState(ctx, tx, id)
 		if err != nil {
 			return err
 		}
@@ -524,6 +543,29 @@ func (repository *TrackPlannerRepository) UpdateObject(
 		}
 		if version != input.ExpectedVersion {
 			return application.ErrTrackPlanConflict
+		}
+		objects, err := trackObjectsForRevision(ctx, tx, revisionID)
+		if err != nil {
+			return err
+		}
+		for index := range objects {
+			if objects[index].ID != id {
+				continue
+			}
+			moving := objects[index]
+			moving.PositionXMM = input.PositionXMM
+			moving.PositionYMM = input.PositionYMM
+			moving.RotationDegrees = input.RotationDegrees
+			moving.ElevationStartMM = input.ElevationStartMM
+			moving.ElevationEndMM = input.ElevationEndMM
+			moving.FlexPath = input.FlexPath
+			moving.TransitionPath = input.TransitionPath
+			if snap := domain.FindTrackSnap(moving, objects); snap.Snapped {
+				input.PositionXMM = snap.Pose.PositionXMM
+				input.PositionYMM = snap.Pose.PositionYMM
+				input.RotationDegrees = snap.Pose.RotationDegrees
+			}
+			break
 		}
 		result, err := tx.ExecContext(ctx, `
 UPDATE plan_track_objects
@@ -558,7 +600,7 @@ func (repository *TrackPlannerRepository) DeleteObject(
 ) error {
 	now := timestamp()
 	return repository.withTx(ctx, func(tx *sql.Tx) error {
-		status, version, err := trackObjectState(ctx, tx, id)
+		status, _, version, err := trackObjectState(ctx, tx, id)
 		if err != nil {
 			return err
 		}
@@ -650,25 +692,75 @@ SELECT status FROM track_geometry_libraries WHERE id=?`, geometry.LibraryID).Sca
 	return geometry, geometry.Status.Placeable() && libraryStatus.Placeable(), nil
 }
 
+func trackGeometryMatchesRevisionGauge(
+	ctx context.Context,
+	tx *sql.Tx,
+	revisionID string,
+	libraryID string,
+) (bool, error) {
+	var layoutGauge, libraryGauge string
+	err := tx.QueryRowContext(ctx, `
+SELECT layout.gauge, library.gauge
+FROM plan_revisions revision
+JOIN plan_variants variant ON variant.id=revision.variant_id
+JOIN layout_units unit ON unit.id=variant.layout_unit_id
+JOIN layouts layout ON layout.id=unit.layout_id
+JOIN track_geometry_libraries library ON library.id=?
+WHERE revision.id=?`, libraryID, revisionID).Scan(&layoutGauge, &libraryGauge)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, application.ErrTrackPlanNotFound
+	}
+	if err != nil {
+		return false, fmt.Errorf("read track geometry and layout gauge: %w", err)
+	}
+	return strings.EqualFold(strings.TrimSpace(layoutGauge), strings.TrimSpace(libraryGauge)), nil
+}
+
+func trackObjectsForRevision(
+	ctx context.Context,
+	tx *sql.Tx,
+	revisionID string,
+) ([]domain.PlanTrackObject, error) {
+	rows, err := tx.QueryContext(ctx, trackObjectSelect+`
+WHERE object.revision_id=? ORDER BY object.created_at, object.id`, revisionID)
+	if err != nil {
+		return nil, fmt.Errorf("list transactional track plan objects: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	objects := []domain.PlanTrackObject{}
+	for rows.Next() {
+		object, err := scanTrackObject(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan transactional track plan object: %w", err)
+		}
+		objects = append(objects, *object)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate transactional track plan objects: %w", err)
+	}
+	return objects, nil
+}
+
 func trackObjectState(
 	ctx context.Context,
 	tx *sql.Tx,
 	id string,
-) (domain.PlanRevisionStatus, int, error) {
+) (domain.PlanRevisionStatus, string, int, error) {
 	var status domain.PlanRevisionStatus
+	var revisionID string
 	var version int
 	err := tx.QueryRowContext(ctx, `
-SELECT revision.status, object.version
+SELECT revision.status, object.revision_id, object.version
 FROM plan_track_objects object
 JOIN plan_revisions revision ON revision.id=object.revision_id
-WHERE object.id=?`, id).Scan(&status, &version)
+WHERE object.id=?`, id).Scan(&status, &revisionID, &version)
 	if errors.Is(err, sql.ErrNoRows) {
-		return "", 0, application.ErrTrackPlanNotFound
+		return "", "", 0, application.ErrTrackPlanNotFound
 	}
 	if err != nil {
-		return "", 0, fmt.Errorf("read track plan object state: %w", err)
+		return "", "", 0, fmt.Errorf("read track plan object state: %w", err)
 	}
-	return status, version, nil
+	return status, revisionID, version, nil
 }
 
 const trackGeometrySelect = `

--- a/backend/internal/infrastructure/track_planner_repository_test.go
+++ b/backend/internal/infrastructure/track_planner_repository_test.go
@@ -292,10 +292,37 @@ INSERT INTO track_geometry_definitions(
 	}
 }
 
+func TestTrackPlannerRepositoryRejectsGeometryFromDifferentLayoutGauge(t *testing.T) {
+	db := openTrackPlannerSchemaDB(t)
+	seedTrackPlanRevision(t, db)
+	if _, err := db.Exec(`
+INSERT INTO track_geometry_libraries(
+  id, manufacturer, track_system, gauge, scale, version, source_url, status, created_at
+) VALUES('h0-library', 'Test', 'H0 Test', 'H0', '1:87', '1', 'https://example.invalid/h0',
+         'verified', 'now');
+INSERT INTO track_geometry_definitions(
+  id, library_id, article_number, name, kind, length_mm, geometry_json,
+  source_url, status, created_at
+) SELECT 'h0-geometry', 'h0-library', 'H0-1', 'H0-Gleis', kind, length_mm, geometry_json,
+         'https://example.invalid/h0', 'verified', 'now'
+  FROM track_geometry_definitions WHERE id='tillig-tt-modellgleis-83101-v1';
+`); err != nil {
+		t.Fatal(err)
+	}
+	planner := application.NewTrackPlannerService(infrastructure.NewTrackPlannerRepository(db))
+	_, err := planner.CreateObject(t.Context(), "revision-track-1", application.CreatePlanTrackObjectInput{
+		GeometryID: "h0-geometry",
+	}, "planner")
+	if !errors.Is(err, application.ErrTrackPlanValidation) {
+		t.Fatalf("expected mismatched gauge validation error, got %v", err)
+	}
+}
+
 func TestTrackPlannerSnapPersistsAuthoritativePose(t *testing.T) {
 	db := openTrackPlannerSchemaDB(t)
 	seedTrackPlanRevision(t, db)
-	planner := application.NewTrackPlannerService(infrastructure.NewTrackPlannerRepository(db))
+	repository := infrastructure.NewTrackPlannerRepository(db)
+	planner := application.NewTrackPlannerService(repository)
 	geometryID := "tillig-tt-modellgleis-83101-v1"
 	if _, err := planner.CreateObject(t.Context(), "revision-track-1", application.CreatePlanTrackObjectInput{
 		GeometryID: geometryID, PositionXMM: 0, PositionYMM: 0,
@@ -309,7 +336,7 @@ func TestTrackPlannerSnapPersistsAuthoritativePose(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	updated, err := planner.UpdateObject(t.Context(), moving.ID, application.UpdatePlanTrackObjectInput{
+	updated, err := repository.UpdateObject(t.Context(), moving.ID, application.UpdatePlanTrackObjectInput{
 		PositionXMM: 172, PositionYMM: 2, RotationDegrees: 2, ExpectedVersion: moving.Version,
 	}, "planner")
 	if err != nil {
@@ -317,6 +344,90 @@ func TestTrackPlannerSnapPersistsAuthoritativePose(t *testing.T) {
 	}
 	if updated.PositionXMM != 166 || updated.PositionYMM != 0 || updated.RotationDegrees != 0 {
 		t.Fatalf("unexpected authoritative snapped pose: %#v", updated)
+	}
+}
+
+func TestTrackPlannerAnalysisCountsStoredIndividualAssets(t *testing.T) {
+	db := openTrackPlannerSchemaDB(t)
+	seedTrackPlanRevision(t, db)
+	if _, err := db.Exec(`
+INSERT INTO storage_locations(id, name, created_at, updated_at)
+VALUES('asset-location', 'Assetlager', 'now', 'now');
+INSERT INTO accessory_products(
+  id, inventory_number, manufacturer, article_number, name, category, tracking_mode,
+  inventory_strategy, created_at, updated_at
+) VALUES(
+  'asset-product', 'RK-ART-ASSET', 'Tillig', '83101', 'Gleisstück G1', 'track', 'individual',
+  'individual', 'now', 'now'
+);
+INSERT INTO accessory_assets(
+  id, product_id, inventory_number, lifecycle_state, storage_location_id, created_at, updated_at
+) VALUES('track-asset', 'asset-product', 'RK-ASSET-1', 'stored', 'asset-location', 'now', 'now');
+INSERT INTO plan_track_objects(
+  id, revision_id, geometry_id, position_x_mm, position_y_mm, rotation_degrees,
+  version, created_at, updated_at
+) VALUES(
+  'track-material-asset', 'revision-track-1', 'tillig-tt-modellgleis-83101-v1', 0, 0, 0, 1,
+  'now', 'now');
+`); err != nil {
+		t.Fatal(err)
+	}
+	planner := application.NewTrackPlannerService(infrastructure.NewTrackPlannerRepository(db))
+	analysis, err := planner.AnalyzePlan(t.Context(), "revision-track-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(analysis.Materials) != 1 {
+		t.Fatalf("unexpected material lines: %#v", analysis.Materials)
+	}
+	material := analysis.Materials[0]
+	if material.PhysicalQuantity != 1 || material.AvailableQuantity != 1 || material.MissingQuantity != 0 {
+		t.Fatalf("individual asset not counted as available material: %#v", material)
+	}
+}
+
+func TestTrackPlannerAnalysisCombinesQuantityAndAssetsForHybridInventory(t *testing.T) {
+	db := openTrackPlannerSchemaDB(t)
+	seedTrackPlanRevision(t, db)
+	if _, err := db.Exec(`
+INSERT INTO storage_locations(id, name, created_at, updated_at)
+VALUES('hybrid-location', 'Hybridlager', 'now', 'now');
+INSERT INTO accessory_products(
+  id, inventory_number, manufacturer, article_number, name, category, tracking_mode,
+  inventory_strategy, created_at, updated_at
+) VALUES(
+  'hybrid-product', 'RK-ART-HYBRID', 'Tillig', '83101', 'Gleisstueck G1', 'track', 'quantity',
+  'quantity_later_individual', 'now', 'now'
+);
+INSERT INTO accessory_stock(product_id, location_id, quantity, updated_at)
+VALUES('hybrid-product', 'hybrid-location', 2, 'now');
+INSERT INTO accessory_assets(
+  id, product_id, inventory_number, lifecycle_state, storage_location_id, created_at, updated_at
+) VALUES('hybrid-asset', 'hybrid-product', 'RK-HYBRID-1', 'stored', 'hybrid-location', 'now', 'now');
+INSERT INTO plan_track_objects(
+  id, revision_id, geometry_id, position_x_mm, position_y_mm, rotation_degrees,
+  version, created_at, updated_at
+) VALUES
+  ('track-material-hybrid-1', 'revision-track-1', 'tillig-tt-modellgleis-83101-v1', 0, 0, 0, 1,
+   'now', 'now'),
+  ('track-material-hybrid-2', 'revision-track-1', 'tillig-tt-modellgleis-83101-v1', 166, 0, 0, 1,
+   'now', 'now'),
+  ('track-material-hybrid-3', 'revision-track-1', 'tillig-tt-modellgleis-83101-v1', 332, 0, 0, 1,
+   'now', 'now');
+`); err != nil {
+		t.Fatal(err)
+	}
+	planner := application.NewTrackPlannerService(infrastructure.NewTrackPlannerRepository(db))
+	analysis, err := planner.AnalyzePlan(t.Context(), "revision-track-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(analysis.Materials) != 1 {
+		t.Fatalf("unexpected material lines: %#v", analysis.Materials)
+	}
+	material := analysis.Materials[0]
+	if material.PhysicalQuantity != 3 || material.AvailableQuantity != 3 || material.MissingQuantity != 0 {
+		t.Fatalf("hybrid inventory was not combined: %#v", material)
 	}
 }
 

--- a/frontend/src/features/layouts/TrackPlannerCanvas.test.tsx
+++ b/frontend/src/features/layouts/TrackPlannerCanvas.test.tsx
@@ -171,7 +171,10 @@ describe("TrackPlannerCanvas", () => {
       toJSON: () => ({})
     });
     const placed = await screen.findByRole("button", { name: "Bahnsteig" });
+    const capturePointer = vi.fn();
+    Object.defineProperty(placed, "setPointerCapture", { value: capturePointer });
     fireEvent.pointerDown(placed, { pointerId: 7, clientX: 600, clientY: 250 });
+    expect(capturePointer).toHaveBeenCalledWith(7);
     fireEvent.pointerMove(canvas, { pointerId: 7, clientX: 700, clientY: 300 });
     fireEvent.pointerUp(canvas, { pointerId: 7, clientX: 700, clientY: 300 });
     await waitFor(() => expect(update).toHaveBeenCalledTimes(1));
@@ -244,7 +247,10 @@ describe("TrackPlannerCanvas", () => {
       toJSON: () => ({})
     });
     const placed = screen.getByRole("button", { name: "Gleis Tillig 83101 · Gleisstück G1" });
+    const capturePointer = vi.fn();
+    Object.defineProperty(placed, "setPointerCapture", { value: capturePointer });
     fireEvent.pointerDown(placed, { pointerId: 4, clientX: 517, clientY: 250 });
+    expect(capturePointer).toHaveBeenCalledWith(4);
     fireEvent.pointerMove(canvas, { pointerId: 4, clientX: 540, clientY: 270 });
     fireEvent.pointerUp(canvas, { pointerId: 4, clientX: 540, clientY: 270 });
     await waitFor(() => expect(update).toHaveBeenCalledWith(trackObject.id,

--- a/frontend/src/features/layouts/TrackPlannerCanvas.tsx
+++ b/frontend/src/features/layouts/TrackPlannerCanvas.tsx
@@ -281,6 +281,7 @@ export function TrackPlannerCanvas({ unit, gauge, revision, canPlan, onClose }: 
   const startDrag = (event: ReactPointerEvent<SVGGElement>, object: PlanTrackObject) => {
     if (!editable || saving) return;
     event.preventDefault();
+    event.currentTarget.setPointerCapture?.(event.pointerId);
     const point = canvasPoint(event.nativeEvent);
     dragRef.current = { object, offsetX: point.x - object.positionXMm, offsetY: point.y - object.positionYMm };
     setSelectedID(object.id);
@@ -290,6 +291,7 @@ export function TrackPlannerCanvas({ unit, gauge, revision, canPlan, onClose }: 
   const startFreeDrag = (event: ReactPointerEvent<SVGGElement>, object: PlanFreeObject) => {
     if (!editable || saving) return;
     event.preventDefault();
+    event.currentTarget.setPointerCapture?.(event.pointerId);
     const point = canvasPoint(event.nativeEvent);
     freeDragRef.current = { object, offsetX: point.x - object.positionXMm, offsetY: point.y - object.positionYMm };
     setSelectedID("");


### PR DESCRIPTION
## Deutsch

Behebt die vier noch offenen Review-Befunde aus der ursprünglichen Umsetzung des Gleisplaners:

- Pointer-Capture hält Gleis- und Freiform-Drag auch außerhalb des Elements stabil.
- Gleisgeometrien mit abweichender Spurweite werden beim Platzieren abgelehnt.
- Die Materialanalyse zählt Einzelobjekte und kombiniert bei Hybridartikeln Mengen- und Einzelbestand.
- Das autoritative Snapping wird mit dem aktuellen Revisionsstand innerhalb derselben Update-Transaktion neu berechnet.

Ursprüngliche Befunde:
- https://github.com/ichwars/RailKeeper/pull/70#discussion_r3781143477
- https://github.com/ichwars/RailKeeper/pull/70#discussion_r3781143481
- https://github.com/ichwars/RailKeeper/pull/70#discussion_r3781143485
- https://github.com/ichwars/RailKeeper/pull/70#discussion_r3781143492

Lokale Prüfung:
- go test ./...
- golangci-lint run: 0 Befunde
- npm run build
- npm run test:coverage: 144 Dateien, 857 Tests

Closes #32

## English

Resolves the four remaining review findings from the original track planner implementation:

- Pointer capture keeps track and free-object dragging stable outside the element.
- Track geometries with a gauge different from the layout are rejected during placement.
- Material analysis counts individual assets and combines quantity and asset stock for hybrid products.
- Authoritative snapping is recalculated against the current revision state inside the same update transaction.

Original findings:
- https://github.com/ichwars/RailKeeper/pull/70#discussion_r3781143477
- https://github.com/ichwars/RailKeeper/pull/70#discussion_r3781143481
- https://github.com/ichwars/RailKeeper/pull/70#discussion_r3781143485
- https://github.com/ichwars/RailKeeper/pull/70#discussion_r3781143492

Local verification:
- go test ./...
- golangci-lint run: 0 findings
- npm run build
- npm run test:coverage: 144 files, 857 tests

Closes #32