### PR TITLE
Entwurfs-Snapping und Modulport-Grenzen absichern / Safeguard draft snapping and module-port bounds

### DIFF
--- a/backend/internal/api/layout_handlers_test.go
+++ b/backend/internal/api/layout_handlers_test.go
@@ -122,6 +122,9 @@ func TestLayoutRoutesEnforceRoleAndCSRFBoundaries(t *testing.T) {
 		response := layoutRequest(t, router, session, http.MethodPost,
 			"/api/v1/layout-configurations/"+configuration.ID+"/unit-snap-preview", map[string]any{
 				"unitId": unit.ID, "positionXMm": 0, "positionYMm": 0, "rotationDegrees": 0,
+				"units": []map[string]any{{
+					"unitId": unit.ID, "positionXMm": 0, "positionYMm": 0, "rotationDegrees": 0,
+				}},
 			}, true)
 		want := http.StatusForbidden
 		if role == "admin" || role == "planner" {

--- a/backend/internal/application/layouts.go
+++ b/backend/internal/application/layouts.go
@@ -212,14 +212,17 @@ type LayoutUnitPortRepository interface {
 
 type LayoutConfigurationPortRepository interface {
 	LoadConfigurationPortPlacements(context.Context, string) ([]domain.ModulePortPlacement, error)
-	ConfigurationContainsUnit(context.Context, string, string) (bool, error)
+	LoadDraftConfigurationPortPlacements(
+		context.Context, string, []ConfigurationUnitInput,
+	) ([]domain.ModulePortPlacement, error)
 }
 
 type PreviewConfigurationUnitSnapInput struct {
-	UnitID          string  `json:"unitId"`
-	PositionXMM     float64 `json:"positionXMm"`
-	PositionYMM     float64 `json:"positionYMm"`
-	RotationDegrees float64 `json:"rotationDegrees"`
+	UnitID          string                   `json:"unitId"`
+	PositionXMM     float64                  `json:"positionXMm"`
+	PositionYMM     float64                  `json:"positionYMm"`
+	RotationDegrees float64                  `json:"rotationDegrees"`
+	Units           []ConfigurationUnitInput `json:"units"`
 }
 
 type LayoutService struct {
@@ -360,16 +363,30 @@ func (s *LayoutService) PreviewConfigurationUnitSnap(
 		!finite(input.PositionYMM) || !finite(input.RotationDegrees) {
 		return nil, ErrLayoutValidation
 	}
-	placements, err := s.configurationPortRepository.LoadConfigurationPortPlacements(ctx, configurationID)
-	if err != nil {
-		return nil, err
+	seen := make(map[string]struct{}, len(input.Units))
+	movingIncluded := false
+	for index := range input.Units {
+		unit := &input.Units[index]
+		unit.UnitID = strings.TrimSpace(unit.UnitID)
+		if unit.UnitID == "" || !finite(unit.PositionXMM) || !finite(unit.PositionYMM) ||
+			!finite(unit.RotationDegrees) {
+			return nil, ErrLayoutValidation
+		}
+		if _, duplicate := seen[unit.UnitID]; duplicate {
+			return nil, ErrLayoutValidation
+		}
+		seen[unit.UnitID] = struct{}{}
+		unit.RotationDegrees = normalizeRotation(unit.RotationDegrees)
+		movingIncluded = movingIncluded || unit.UnitID == input.UnitID
 	}
-	found, err := s.configurationPortRepository.ConfigurationContainsUnit(ctx, configurationID, input.UnitID)
-	if err != nil {
-		return nil, err
-	}
-	if !found {
+	if !movingIncluded {
 		return nil, ErrLayoutValidation
+	}
+	placements, err := s.configurationPortRepository.LoadDraftConfigurationPortPlacements(
+		ctx, configurationID, input.Units,
+	)
+	if err != nil {
+		return nil, err
 	}
 	result := domain.FindModulePortSnap(input.UnitID, domain.TrackPose{
 		PositionXMM: input.PositionXMM, PositionYMM: input.PositionYMM,

--- a/backend/internal/application/layouts_test.go
+++ b/backend/internal/application/layouts_test.go
@@ -95,6 +95,35 @@ func (spy *layoutRepositorySpy) LoadConfigurationPortPlacements(
 	return spy.configurationPorts, nil
 }
 
+func (spy *layoutRepositorySpy) LoadDraftConfigurationPortPlacements(
+	_ context.Context,
+	_ string,
+	units []ConfigurationUnitInput,
+) ([]domain.ModulePortPlacement, error) {
+	placements := append([]domain.ModulePortPlacement(nil), spy.configurationPorts...)
+	poses := make(map[string]domain.TrackPose, len(units))
+	for _, unit := range units {
+		known := spy.configurationUnit == unit.UnitID
+		for _, placement := range spy.configurationPorts {
+			known = known || placement.UnitID == unit.UnitID
+		}
+		if !known {
+			return nil, ErrLayoutValidation
+		}
+		poses[unit.UnitID] = domain.TrackPose{
+			PositionXMM: unit.PositionXMM, PositionYMM: unit.PositionYMM,
+			RotationDegrees: unit.RotationDegrees,
+		}
+	}
+	for index := range placements {
+		pose, included := poses[placements[index].UnitID]
+		if included {
+			placements[index].UnitPose = pose
+		}
+	}
+	return placements, nil
+}
+
 func (spy *layoutRepositorySpy) ConfigurationContainsUnit(
 	_ context.Context,
 	_ string,
@@ -389,11 +418,17 @@ func TestLayoutServiceAnalyzesConfigurationPortsAndPreviewsWithoutMutation(t *te
 	}
 
 	preview, err := service.PreviewConfigurationUnitSnap(t.Context(), " configuration-1 ",
-		PreviewConfigurationUnitSnapInput{UnitID: " moving ", PositionXMM: 5})
+		PreviewConfigurationUnitSnapInput{
+			UnitID: " moving ", PositionXMM: 43,
+			Units: []ConfigurationUnitInput{
+				{UnitID: "moving", PositionXMM: 43},
+				{UnitID: "target", PositionXMM: 150},
+			},
+		})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !preview.Snapped || preview.Pose.PositionXMM != 12 || preview.TargetUnitID != "target" {
+	if !preview.Snapped || preview.Pose.PositionXMM != 50 || preview.TargetUnitID != "target" {
 		t.Fatalf("unexpected snap preview: %#v", preview)
 	}
 	if repository.configurationPorts[0].UnitPose.PositionXMM != 5 {
@@ -409,11 +444,14 @@ func TestLayoutServiceRejectsInvalidConfigurationPortRequests(t *testing.T) {
 	if _, err := service.AnalyzeConfigurationPorts(t.Context(), " "); !errors.Is(err, ErrLayoutValidation) {
 		t.Fatalf("expected blank configuration rejection, got %v", err)
 	}
+	validUnits := []ConfigurationUnitInput{{UnitID: "unit-1"}}
 	invalid := []PreviewConfigurationUnitSnapInput{
 		{},
-		{UnitID: "missing"},
-		{UnitID: "unit-1", PositionXMM: math.NaN()},
-		{UnitID: "unit-1", PositionYMM: math.Inf(1)},
+		{UnitID: "missing", Units: []ConfigurationUnitInput{{UnitID: "missing"}}},
+		{UnitID: "unit-1", PositionXMM: math.NaN(), Units: validUnits},
+		{UnitID: "unit-1", PositionYMM: math.Inf(1), Units: validUnits},
+		{UnitID: "unit-1"},
+		{UnitID: "unit-1", Units: []ConfigurationUnitInput{{UnitID: "unit-1"}, {UnitID: "unit-1"}}},
 	}
 	for _, input := range invalid {
 		if _, err := service.PreviewConfigurationUnitSnap(t.Context(), "configuration-1", input); !errors.Is(err, ErrLayoutValidation) {
@@ -425,7 +463,8 @@ func TestLayoutServiceRejectsInvalidConfigurationPortRequests(t *testing.T) {
 func TestLayoutServicePreviewsUnsnappedUnitWithoutActivePorts(t *testing.T) {
 	service := NewLayoutService(&layoutRepositorySpy{configurationUnit: "unit-without-ports"})
 	preview, err := service.PreviewConfigurationUnitSnap(t.Context(), "configuration-1",
-		PreviewConfigurationUnitSnapInput{UnitID: "unit-without-ports"})
+		PreviewConfigurationUnitSnapInput{UnitID: "unit-without-ports",
+			Units: []ConfigurationUnitInput{{UnitID: "unit-without-ports"}}})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/infrastructure/layout_repository.go
+++ b/backend/internal/infrastructure/layout_repository.go
@@ -297,6 +297,27 @@ func (r *LayoutRepository) UpdateUnit(
 ) (*application.LayoutUnit, error) {
 	now := timestamp()
 	err := r.withTx(ctx, func(tx *sql.Tx) error {
+		var version int
+		if err := tx.QueryRowContext(ctx, `SELECT version FROM layout_units WHERE id=?`, id).Scan(&version); errors.Is(err, sql.ErrNoRows) {
+			return application.ErrLayoutNotFound
+		} else if err != nil {
+			return fmt.Errorf("read layout unit version: %w", err)
+		}
+		if version != input.ExpectedVersion {
+			return application.ErrLayoutVersionConflict
+		}
+		var portOutsideBounds int
+		if err := tx.QueryRowContext(ctx, `
+SELECT EXISTS(
+  SELECT 1 FROM layout_unit_ports port
+  WHERE port.layout_unit_id=?
+    AND ((? > 0 AND port.x_mm > ?) OR (? > 0 AND port.y_mm > ?))
+)`, id, input.WidthMM, input.WidthMM, input.HeightMM, input.HeightMM).Scan(&portOutsideBounds); err != nil {
+			return fmt.Errorf("validate layout unit port bounds: %w", err)
+		}
+		if portOutsideBounds != 0 {
+			return application.ErrLayoutValidation
+		}
 		result, err := tx.ExecContext(ctx, `
 UPDATE layout_units
 SET name=?, kind=?, owner_label=?, width_mm=?, height_mm=?, archived=?, version=version+1, updated_at=?
@@ -390,6 +411,80 @@ ORDER BY u.name COLLATE NOCASE, cu.unit_id, p.name COLLATE NOCASE, p.id`, config
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterate layout configuration port placements: %w", err)
+	}
+	return placements, nil
+}
+
+func (r *LayoutRepository) LoadDraftConfigurationPortPlacements(
+	ctx context.Context,
+	configurationID string,
+	units []application.ConfigurationUnitInput,
+) ([]domain.ModulePortPlacement, error) {
+	var layoutID string
+	if err := r.db.QueryRowContext(ctx,
+		`SELECT layout_id FROM layout_configurations WHERE id=?`, configurationID).Scan(&layoutID); errors.Is(err, sql.ErrNoRows) {
+		return nil, application.ErrLayoutNotFound
+	} else if err != nil {
+		return nil, fmt.Errorf("find layout configuration for draft port preview: %w", err)
+	}
+	unitRows, err := r.db.QueryContext(ctx, `SELECT id FROM layout_units WHERE layout_id=?`, layoutID)
+	if err != nil {
+		return nil, fmt.Errorf("list layout units for draft port preview: %w", err)
+	}
+	available := make(map[string]struct{})
+	for unitRows.Next() {
+		var unitID string
+		if err := unitRows.Scan(&unitID); err != nil {
+			_ = unitRows.Close()
+			return nil, fmt.Errorf("scan layout unit for draft port preview: %w", err)
+		}
+		available[unitID] = struct{}{}
+	}
+	if err := unitRows.Err(); err != nil {
+		_ = unitRows.Close()
+		return nil, fmt.Errorf("iterate layout units for draft port preview: %w", err)
+	}
+	if err := unitRows.Close(); err != nil {
+		return nil, fmt.Errorf("close layout units for draft port preview: %w", err)
+	}
+	poses := make(map[string]domain.TrackPose, len(units))
+	for _, unit := range units {
+		if _, found := available[unit.UnitID]; !found {
+			return nil, application.ErrLayoutValidation
+		}
+		poses[unit.UnitID] = domain.TrackPose{
+			PositionXMM: unit.PositionXMM, PositionYMM: unit.PositionYMM,
+			RotationDegrees: unit.RotationDegrees,
+		}
+	}
+	rows, err := r.db.QueryContext(ctx, `
+SELECT unit.id, unit.name, port.id, port.name, port.kind, port.interface_key,
+       port.x_mm, port.y_mm, port.direction_degrees
+FROM layout_units unit
+JOIN layout_unit_ports port ON port.layout_unit_id=unit.id AND port.archived=0
+WHERE unit.layout_id=?
+ORDER BY unit.name COLLATE NOCASE, unit.id, port.name COLLATE NOCASE, port.id`, layoutID)
+	if err != nil {
+		return nil, fmt.Errorf("list draft configuration port placements: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	placements := []domain.ModulePortPlacement{}
+	for rows.Next() {
+		placement := domain.ModulePortPlacement{}
+		if err := rows.Scan(&placement.UnitID, &placement.UnitName, &placement.PortID, &placement.PortName,
+			&placement.Kind, &placement.InterfaceKey, &placement.XMM, &placement.YMM,
+			&placement.DirectionDegrees); err != nil {
+			return nil, fmt.Errorf("scan draft configuration port placement: %w", err)
+		}
+		pose, included := poses[placement.UnitID]
+		if !included {
+			continue
+		}
+		placement.UnitPose = pose
+		placements = append(placements, placement)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate draft configuration port placements: %w", err)
 	}
 	return placements, nil
 }

--- a/backend/internal/infrastructure/layout_repository_test.go
+++ b/backend/internal/infrastructure/layout_repository_test.go
@@ -88,6 +88,45 @@ func TestLayoutUnitPortRepositoryPersistsAndRejectsStaleUpdates(t *testing.T) {
 	}
 }
 
+func TestLayoutRepositoryRejectsUnitDimensionsOutsideExistingPortBounds(t *testing.T) {
+	_, service := testLayoutServiceWithDB(t)
+	ctx := t.Context()
+	layout, err := service.CreateLayout(ctx, application.CreateLayoutInput{
+		Name: "Club", Kind: domain.LayoutKindClub, Gauge: "TT", Scale: "1:120",
+	}, "admin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	unit, err := service.CreateUnit(ctx, layout.ID, application.CreateLayoutUnitInput{
+		Name: "Module A", Kind: domain.LayoutUnitKindModule, WidthMM: 1000, HeightMM: 500,
+	}, "planner")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := service.CreateUnitPort(ctx, unit.ID, application.CreateLayoutUnitPortInput{
+		Name: "East", Kind: domain.LayoutUnitPortTrack, InterfaceKey: "track:tillig-tt-modellgleis",
+		XMM: 1000, YMM: 250,
+	}, "planner"); err != nil {
+		t.Fatal(err)
+	}
+	_, err = service.UpdateUnit(ctx, unit.ID, application.UpdateLayoutUnitInput{
+		CreateLayoutUnitInput: application.CreateLayoutUnitInput{
+			Name: unit.Name, Kind: unit.Kind, OwnerLabel: unit.OwnerLabel, WidthMM: 999, HeightMM: unit.HeightMM,
+		},
+		ExpectedVersion: unit.Version,
+	}, "planner")
+	if !errors.Is(err, application.ErrLayoutValidation) {
+		t.Fatalf("expected port bounds validation error, got %v", err)
+	}
+	stored, err := service.ListUnits(ctx, layout.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stored) != 1 || stored[0].WidthMM != 1000 || stored[0].Version != unit.Version {
+		t.Fatalf("unit changed despite invalid port bounds: %#v", stored)
+	}
+}
+
 func TestLayoutConfigurationPortRepositoryLoadsActivePlacements(t *testing.T) {
 	db, service := testLayoutServiceWithDB(t)
 	ctx := t.Context()
@@ -140,6 +179,35 @@ func TestLayoutConfigurationPortRepositoryLoadsActivePlacements(t *testing.T) {
 		placements[0].UnitName != "West" || placements[0].UnitPose.PositionXMM != 10 ||
 		placements[0].UnitPose.PositionYMM != 20 || placements[0].UnitPose.RotationDegrees != 90 {
 		t.Fatalf("unexpected configuration port placements: %#v", placements)
+	}
+	draftPlacements, err := repository.LoadDraftConfigurationPortPlacements(ctx, configuration.ID,
+		[]application.ConfigurationUnitInput{
+			{UnitID: west.ID, PositionXMM: 75, PositionYMM: 30, RotationDegrees: 180},
+			{UnitID: east.ID, PositionXMM: 900, PositionYMM: 40},
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(draftPlacements) != 1 || draftPlacements[0].PortID != active.ID ||
+		draftPlacements[0].UnitPose.PositionXMM != 75 || draftPlacements[0].UnitPose.PositionYMM != 30 ||
+		draftPlacements[0].UnitPose.RotationDegrees != 180 {
+		t.Fatalf("unexpected draft port placements: %#v", draftPlacements)
+	}
+	otherLayout, err := service.CreateLayout(ctx, application.CreateLayoutInput{
+		Name: "Other", Kind: domain.LayoutKindPrivate, Gauge: "TT", Scale: "1:120",
+	}, "admin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherUnit, err := service.CreateUnit(ctx, otherLayout.ID, application.CreateLayoutUnitInput{
+		Name: "Foreign", Kind: domain.LayoutUnitKindModule,
+	}, "planner")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repository.LoadDraftConfigurationPortPlacements(ctx, configuration.ID,
+		[]application.ConfigurationUnitInput{{UnitID: otherUnit.ID}}); !errors.Is(err, application.ErrLayoutValidation) {
+		t.Fatalf("expected draft unit membership validation error, got %v", err)
 	}
 	contained, err := repository.ConfigurationContainsUnit(ctx, configuration.ID, east.ID)
 	if err != nil || !contained {

--- a/frontend/src/features/layouts/LayoutConfigurationsPanel.tsx
+++ b/frontend/src/features/layouts/LayoutConfigurationsPanel.tsx
@@ -79,7 +79,8 @@ export function LayoutConfigurationsPanel({ configurations, units, layoutID, can
         unitId: unitID,
         positionXMm: item.positionXMm || 0,
         positionYMm: item.positionYMm || 0,
-        rotationDegrees: item.rotationDegrees || 0
+        rotationDegrees: item.rotationDegrees || 0,
+        units: form.units
       });
       if (!preview.snapped) {
         setMessage(t("layouts.setups.snapMissing"));

--- a/frontend/src/features/layouts/LayoutsView.test.tsx
+++ b/frontend/src/features/layouts/LayoutsView.test.tsx
@@ -158,11 +158,18 @@ describe("LayoutsView", () => {
 
   it("previews module-port alignment without saving the configuration", async () => {
     const user = userEvent.setup();
+    const targetUnit: LayoutUnit = {
+      ...unit, id: "unit-2", name: "Streckenmodul", ownerLabel: "Verein"
+    };
     const configuration: LayoutConfiguration = {
       id: "setup-1", layoutId: layout.id, name: "Ausstellung 2026", version: 2, archived: false,
-      units: [{ unitId: unit.id, positionXMm: 5, positionYMm: 10, rotationDegrees: 2, sortOrder: 0 }],
+      units: [
+        { unitId: unit.id, positionXMm: 5, positionYMm: 10, rotationDegrees: 2, sortOrder: 0 },
+        { unitId: targetUnit.id, positionXMm: 112, positionYMm: 0, rotationDegrees: 0, sortOrder: 1 }
+      ],
       createdAt: "2026-08-10T10:00:00Z", updatedAt: "2026-08-10T10:00:00Z"
     };
+    vi.mocked(api.layoutUnits).mockResolvedValue([unit, targetUnit]);
     vi.mocked(api.layoutConfigurations).mockResolvedValue([configuration]);
     vi.spyOn(api, "previewLayoutConfigurationUnitSnap").mockResolvedValue({
       snapped: true,
@@ -175,14 +182,21 @@ describe("LayoutsView", () => {
 
     await user.click(screen.getByRole("tab", { name: "Aufbauten" }));
     await user.click(await screen.findByRole("button", { name: /Ausstellung 2026/ }));
+    const xInputs = screen.getAllByLabelText("X (mm)");
+    await user.clear(xInputs[1]);
+    await user.type(xInputs[1], "150");
     await user.click(screen.getByRole("button", { name: "Bahnhofsmodul an Ports ausrichten" }));
 
     await waitFor(() => expect(api.previewLayoutConfigurationUnitSnap).toHaveBeenCalledWith(configuration.id, {
-      unitId: unit.id, positionXMm: 5, positionYMm: 10, rotationDegrees: 2
+      unitId: unit.id, positionXMm: 5, positionYMm: 10, rotationDegrees: 2,
+      units: [
+        { unitId: unit.id, positionXMm: 5, positionYMm: 10, rotationDegrees: 2 },
+        { unitId: targetUnit.id, positionXMm: 150, positionYMm: 0, rotationDegrees: 0 }
+      ]
     }));
-    expect(screen.getByLabelText("X (mm)")).toHaveValue(12);
-    expect(screen.getByLabelText("Y (mm)")).toHaveValue(20);
-    expect(screen.getByLabelText("Drehung (Grad)")).toHaveValue(0);
+    expect(screen.getAllByLabelText("X (mm)")[0]).toHaveValue(12);
+    expect(screen.getAllByLabelText("Y (mm)")[0]).toHaveValue(20);
+    expect(screen.getAllByLabelText("Drehung (Grad)")[0]).toHaveValue(0);
     expect(screen.getByText("Ausrichtung übernommen. Aufbau noch speichern.")).toBeInTheDocument();
     expect(update).not.toHaveBeenCalled();
   });

--- a/frontend/src/shared/apiLayoutsAccessories.test.ts
+++ b/frontend/src/shared/apiLayoutsAccessories.test.ts
@@ -75,7 +75,8 @@ describe("layout and accessory API client", () => {
     await api.updateLayoutConfiguration("configuration/1", configurationInput);
     await api.layoutConfigurationPortAnalysis("configuration/1");
     await api.previewLayoutConfigurationUnitSnap("configuration/1", {
-      unitId: "unit/1", positionXMm: 10, positionYMm: 20, rotationDegrees: 90
+      unitId: "unit/1", positionXMm: 10, positionYMm: 20, rotationDegrees: 90,
+      units: [{ unitId: "unit/1", positionXMm: 10, positionYMm: 20, rotationDegrees: 90 }]
     });
     await api.planVariants("unit/1");
     await api.createPlanVariant("unit/1", { name: "Sommer", description: "Variante" });
@@ -123,7 +124,8 @@ describe("layout and accessory API client", () => {
       ["PUT", "/api/v1/layout-configurations/configuration%2F1", configurationInput],
       ["GET", "/api/v1/layout-configurations/configuration%2F1/port-analysis"],
       ["POST", "/api/v1/layout-configurations/configuration%2F1/unit-snap-preview", {
-        unitId: "unit/1", positionXMm: 10, positionYMm: 20, rotationDegrees: 90
+        unitId: "unit/1", positionXMm: 10, positionYMm: 20, rotationDegrees: 90,
+        units: [{ unitId: "unit/1", positionXMm: 10, positionYMm: 20, rotationDegrees: 90 }]
       }],
       ["GET", "/api/v1/layout-units/unit%2F1/plan-variants"],
       ["POST", "/api/v1/layout-units/unit%2F1/plan-variants", { name: "Sommer", description: "Variante" }],

--- a/frontend/src/shared/apiLayoutsAccessories.ts
+++ b/frontend/src/shared/apiLayoutsAccessories.ts
@@ -273,6 +273,7 @@ export type ConfigurationUnitSnapPreviewInput = {
   positionXMm: number;
   positionYMm: number;
   rotationDegrees: number;
+  units: ConfigurationUnitInput[];
 };
 
 export type ModulePortSnapResult = {

--- a/openapi/railkeeper.yaml
+++ b/openapi/railkeeper.yaml
@@ -3822,7 +3822,7 @@ components:
             $ref: "#/components/schemas/ModulePortIssue"
     ConfigurationUnitSnapPreviewInput:
       type: object
-      required: [unitId, positionXMm, positionYMm, rotationDegrees]
+      required: [unitId, positionXMm, positionYMm, rotationDegrees, units]
       properties:
         unitId:
           type: string
@@ -3832,6 +3832,11 @@ components:
           type: number
         rotationDegrees:
           type: number
+        units:
+          type: array
+          minItems: 1
+          items:
+            $ref: "#/components/schemas/ConfigurationUnitInput"
     ModulePortSnapResult:
       type: object
       required: [snapped, pose]


### PR DESCRIPTION
## Deutsch

Behebt die zwei verbliebenen Review-Befunde der erweiterten Geometrie:

- Die Modulport-Snap-Vorschau erhält alle aktuellen Formular-Platzierungen und berechnet Zielports damit gegen den ungespeicherten Entwurf, ohne die Konfiguration zu speichern.
- Das Unit-Update prüft innerhalb seiner Transaktion, ob vorhandene Modulports nach einer Dimensionsänderung weiterhin innerhalb der Grenzen liegen.
- Frontend-Typen, Handler-Fixtures und OpenAPI-Vertrag sind auf den neuen Entwurfs-Request abgestimmt.

Ursprüngliche Befunde:
- https://github.com/ichwars/RailKeeper/pull/70#discussion_r3781143470
- https://github.com/ichwars/RailKeeper/pull/70#discussion_r3781143483

Lokale Prüfung:
- go test ./...
- go vet ./...
- npm run build
- npm run test:coverage: 144 Dateien, 857 Tests
- fokussierte Frontend-, Service-, Repository- und OpenAPI-Regressionen

Closes #36

## English

Resolves the two remaining advanced-geometry review findings:

- The module-port snap preview receives every current form placement and calculates target ports against the unsaved draft without saving the configuration.
- The unit update verifies inside its transaction that existing module ports remain within bounds after a dimension change.
- Frontend types, handler fixtures, and the OpenAPI contract now match the draft request.

Original findings:
- https://github.com/ichwars/RailKeeper/pull/70#discussion_r3781143470
- https://github.com/ichwars/RailKeeper/pull/70#discussion_r3781143483

Local verification:
- go test ./...
- go vet ./...
- npm run build
- npm run test:coverage: 144 files, 857 tests
- focused frontend, service, repository, and OpenAPI regressions

Closes #36