### PR TITLE
Ausstellung vollständig drucken und v0.1.20.4 vorbereiten / Print complete exhibitions and prepare v0.1.20.4

### DIFF
--- a/CHANGELOG.de.md
+++ b/CHANGELOG.de.md
@@ -6,6 +6,31 @@ Diese Datei dokumentiert alle wesentlichen Änderungen an RailKeeper.
 
 ## Unveröffentlicht
 
+## [0.1.20.4] - 2026-09-03
+
+### Geändert
+
+- Ausstellungen erhalten eine separate Druckansicht im A4-Querformat. Sie enthält alle
+  gespeicherten Einträge der ausgewählten Veranstaltung mit Bildern, Modell- und Steuerungsdaten,
+  Fahrtagen, Verfügbarkeit, Status, vollständigen Funktionstasten und Notizen. Bildschirmfilter
+  begrenzen den Ausdruck nicht; Navigation und Bedienelemente werden nicht mitgedruckt.
+- Z21 bietet eine zeitlich und mengenmäßig begrenzte, rein lesende Vorschau bekannter
+  Lokadressen. Intellibox-Transportauswahl und Z21-Diagnose grenzen verfügbare und noch geplante
+  Fähigkeiten deutlicher ab. Diese Abläufe schreiben nichts auf die Zentrale.
+
+### Behoben
+
+- Drucken wartet auf die Bilder und bleibt beim Wechsel zu einer noch nicht geladenen
+  Ausstellung gesperrt. Ältere Freitext-Funktionsbelegungen bleiben erhalten. Versteckte
+  Zeilenaktionen verursachen in der Ausstellungsansicht keinen Seitenüberlauf mehr.
+- ECoS weist unvollständige Kompatibilitätsantworten ab und unterscheidet sie von vollständigen
+  Antworten mit noch nicht verifizierter Firmware.
+- Parallele Änderungen und Autosaves im Anlagenzwilling bewahren andere ungespeicherte Entwürfe.
+  Positionshistorie, Konflikt-Neuladen und verspätete Antworten nach Modulwechseln wurden korrigiert.
+- Der Gleisplaner sichert Drag-Vorgänge, Spurweitenprüfung, Materialanalyse und transaktionales
+  Snapping ab. Modulport-Vorschauen berücksichtigen ungespeicherte Platzierungen;
+  Dimensionsänderungen dürfen vorhandene Ports nicht außerhalb der Modulgrenzen verschieben.
+
 ## [0.1.20.3] - 2026-08-28
 
 ### Hinzugefügt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ All notable changes to RailKeeper are documented in this file.
 
 ## Unreleased
 
+## [0.1.20.4] - 2026-09-03
+
+### Changed
+
+- Exhibitions have a separate A4 landscape print document. It includes every saved entry in the
+  selected event with images, model and control data, operating days, availability, status, complete
+  function assignments, and notes. Screen filters do not limit the report; navigation and controls
+  are excluded.
+- Z21 provides a read-only preview of known locomotive addresses with time and item limits.
+  Intellibox transport selection and Z21 diagnostics distinguish available capabilities from
+  planned ones more clearly. These flows do not write to the command station.
+
+### Fixed
+
+- Printing waits for images and remains disabled while a newly selected exhibition is loading.
+  Legacy free-text function assignments are preserved. Hidden row actions no longer cause
+  page overflow in the exhibition view.
+- ECoS rejects incomplete compatibility replies and distinguishes them from complete replies
+  with firmware that has not yet been verified.
+- Concurrent edits and autosaves in the layout twin preserve other unsaved drafts. Position
+  history, conflict reloads, and stale replies after switching modules were corrected.
+- The track planner safeguards dragging, gauge validation, material analysis, and transactional
+  snapping. Module-port previews account for unsaved placements; dimension changes cannot leave
+  existing ports outside module bounds.
+
 ## [0.1.20.3] - 2026-08-28
 
 ### Added

--- a/README.de.md
+++ b/README.de.md
@@ -162,7 +162,7 @@ SQLite-Datenbank, Uploads und lokale Dateien bleiben im Docker-Volume `railkeepe
 Um statt `latest` ein bestimmtes Release festzulegen, trage Folgendes in `.env` ein:
 
 ```env
-RAILKEEPER_IMAGE=ghcr.io/ichwars/railkeeper:v0.1.20.3
+RAILKEEPER_IMAGE=ghcr.io/ichwars/railkeeper:v0.1.20.4
 ```
 
 Wenn du bewusst den ausgecheckten Quellstand bauen möchtest, verwende:

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ The SQLite database, uploads and local files stay in the `railkeeper_data` Docke
 To pin a specific release instead of `latest`, set this in `.env`:
 
 ```env
-RAILKEEPER_IMAGE=ghcr.io/ichwars/railkeeper:v0.1.20.3
+RAILKEEPER_IMAGE=ghcr.io/ichwars/railkeeper:v0.1.20.4
 ```
 
 If you intentionally want to build the checked-out source tree, use:

--- a/backend/cmd/railkeeper/main.go
+++ b/backend/cmd/railkeeper/main.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	version               = "0.1.20.3"
+	version               = "0.1.20.4"
 	defaultUpdateCheckURL = "https://api.github.com/repos/ichwars/RailKeeper/releases/latest"
 )
 

--- a/docs/releases/v0.1.20.4.md
+++ b/docs/releases/v0.1.20.4.md
@@ -1,0 +1,48 @@
+# RailKeeper v0.1.20.4
+
+## Deutsch
+
+Die Ausstellungsliste wird als eigenes Dokument im A4-Querformat gedruckt. Der Ausdruck enthält
+alle gespeicherten Einträge der ausgewählten Veranstaltung, einschließlich Fahrzeugbildern,
+Modell- und Steuerungsdaten, Fahrtagen, Verfügbarkeit, Prüfstatus, vollständigen Funktionstasten
+und Notizen. Bildschirmfilter beeinflussen den Umfang nicht. Navigation und Bedienelemente
+erscheinen nicht im Ausdruck. RailKeeper wartet auf die Bilder und verhindert das Drucken einer
+veralteten Liste während eines Veranstaltungswechsels.
+
+Z21 erhält eine begrenzte, rein lesende Vorschau bekannter Lokadressen. Die Vorschau ist kein
+Loklistenimport und liefert keine Loknamen. Intellibox-Transporte und Z21-Diagnose zeigen ihre
+verfügbaren Fähigkeiten klarer; LocoNet-TCP bleibt geplant. ECoS unterscheidet unvollständige
+Kompatibilitätsantworten von vollständigen Antworten mit noch nicht verifizierter Firmware.
+Reale Hardwaretests für Z21 und Intellibox stehen weiterhin aus.
+
+Im Anlagenzwilling bleiben parallele Entwürfe bei Autosaves erhalten. Positionshistorie,
+Konflikt-Neuladen und der Umgang mit verspäteten Antworten wurden korrigiert. Der Gleisplaner
+verbessert Drag-Vorgänge, Spurweitenprüfung, Materialanalyse und transaktionales Snapping.
+Modulport-Vorschauen berücksichtigen den ungespeicherten Entwurf; Dimensionsänderungen prüfen
+vorhandene Anschlussgrenzen.
+
+Weitere Details stehen im
+[deutschen Änderungsprotokoll](https://github.com/ichwars/RailKeeper/blob/v0.1.20.4/CHANGELOG.de.md).
+
+## English
+
+The exhibition list prints as a separate A4 landscape document. It includes every saved entry in
+the selected event, including vehicle images, model and control data, operating days, availability,
+check status, complete function assignments, and notes. Screen filters do not affect the report.
+Navigation and controls are excluded. RailKeeper waits for images and prevents printing a stale
+list while switching events.
+
+Z21 gains a bounded, read-only preview of known locomotive addresses. This is not a roster import
+and does not provide locomotive names. Intellibox transports and Z21 diagnostics distinguish
+available capabilities more clearly; LocoNet TCP remains planned. ECoS distinguishes incomplete
+compatibility replies from complete replies with firmware that has not yet been verified.
+Real hardware testing for Z21 and Intellibox remains outstanding.
+
+In the layout twin, autosaves preserve concurrent drafts. Position history, conflict reloads,
+and stale-response handling were corrected. The track planner improves dragging, gauge validation,
+material analysis, and transactional snapping. Module-port previews account for the unsaved draft;
+dimension changes validate existing port bounds.
+
+See the
+[English changelog](https://github.com/ichwars/RailKeeper/blob/v0.1.20.4/CHANGELOG.md)
+for details.

--- a/docs/site/administration/index.md
+++ b/docs/site/administration/index.md
@@ -3,7 +3,7 @@ title: Installation and Administration
 description: Install, configure, secure, and operate RailKeeper.
 audience: admin
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-16
 ---
 

--- a/docs/site/administration/master-data-articles.md
+++ b/docs/site/administration/master-data-articles.md
@@ -3,7 +3,7 @@ title: Article master data and storage locations
 description: Configure accessory units, classifications, custom fields, and hierarchical storage locations.
 audience: admin
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-28
 ---
 

--- a/docs/site/administration/master-data-general.md
+++ b/docs/site/administration/master-data-general.md
@@ -3,7 +3,7 @@ title: General master data
 description: Maintain vehicle classifications, manufacturers, CV8 identities, and function symbols.
 audience: admin
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-28
 ---
 

--- a/docs/site/administration/master-data-inventory-numbers.md
+++ b/docs/site/administration/master-data-inventory-numbers.md
@@ -3,7 +3,7 @@ title: Inventory-number schemes
 description: Configure automatic vehicle and accessory article inventory numbers without collisions.
 audience: admin
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-16
 ---
 

--- a/docs/site/administration/master-data-transfer.md
+++ b/docs/site/administration/master-data-transfer.md
@@ -3,7 +3,7 @@ title: Master-data transfer
 description: Export and reconcile RailKeeper master data with the versioned JSON document.
 audience: admin
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-16
 ---
 

--- a/docs/site/administration/master-data.md
+++ b/docs/site/administration/master-data.md
@@ -3,7 +3,7 @@ title: Master-data administration
 description: Govern RailKeeper master data, inventory-number schemes, locations, and transfers safely.
 audience: admin
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-28
 ---
 

--- a/docs/site/de/administration/index.md
+++ b/docs/site/de/administration/index.md
@@ -3,7 +3,7 @@ title: Installation und Administration
 description: RailKeeper installieren, konfigurieren, absichern und betreiben.
 audience: admin
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-16
 ---
 

--- a/docs/site/de/administration/master-data-articles.md
+++ b/docs/site/de/administration/master-data-articles.md
@@ -3,7 +3,7 @@ title: Artikelstammdaten und Lagerorte
 description: Bestandseinheiten, Artikelklassifizierung, eigene Felder und hierarchische Lagerorte konfigurieren.
 audience: admin
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-28
 ---
 

--- a/docs/site/de/administration/master-data-general.md
+++ b/docs/site/de/administration/master-data-general.md
@@ -3,7 +3,7 @@ title: Allgemeine Stammdaten
 description: Fahrzeugklassifizierungen, Hersteller, CV8-Kennungen und Funktionssymbole verwalten.
 audience: admin
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-28
 ---
 

--- a/docs/site/de/administration/master-data-inventory-numbers.md
+++ b/docs/site/de/administration/master-data-inventory-numbers.md
@@ -3,7 +3,7 @@ title: Inventarnummernschemata
 description: Automatische Inventarnummern für Fahrzeuge und Zubehörartikel kollisionsfrei konfigurieren.
 audience: admin
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-16
 ---
 

--- a/docs/site/de/administration/master-data-transfer.md
+++ b/docs/site/de/administration/master-data-transfer.md
@@ -3,7 +3,7 @@ title: Stammdatentransfer
 description: RailKeeper-Stammdaten mit dem versionierten JSON-Dokument exportieren und abgleichen.
 audience: admin
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-16
 ---
 

--- a/docs/site/de/administration/master-data.md
+++ b/docs/site/de/administration/master-data.md
@@ -3,7 +3,7 @@ title: Stammdaten-Administration
 description: Stammdaten, Inventarnummern, Lagerorte und Transfer in RailKeeper sicher verwalten.
 audience: admin
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-28
 ---
 

--- a/docs/site/de/guide/accessories/allocations-history.md
+++ b/docs/site/de/guide/accessories/allocations-history.md
@@ -3,7 +3,7 @@ title: Reservierungen, Einbauten und Verwendung
 description: Zubehör reservieren, Einbauten erfassen und die Verwendungshistorie verstehen.
 audience: user
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-16
 ---
 

--- a/docs/site/de/guide/accessories/article-records.md
+++ b/docs/site/de/guide/accessories/article-records.md
@@ -3,7 +3,7 @@ title: Artikelstammdaten und Fachangaben
 description: Zubehörartikel anlegen, ihre Identität pflegen und technische Angaben prüfen.
 audience: user
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-16
 ---
 

--- a/docs/site/de/guide/accessories/index.md
+++ b/docs/site/de/guide/accessories/index.md
@@ -3,7 +3,7 @@ title: Zubehörübersicht
 description: Zubehörartikel finden, filtern, prüfen und sicher verwalten.
 audience: user
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-16
 ---
 

--- a/docs/site/de/guide/accessories/stock-purchases-documents.md
+++ b/docs/site/de/guide/accessories/stock-purchases-documents.md
@@ -3,7 +3,7 @@ title: Bestand, Käufe und Dokumente
 description: Zubehörmengen, Einzelstücke, Käufe, Bilder und Dokumente verwalten.
 audience: user
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-16
 ---
 

--- a/docs/site/de/guide/exhibition/entries-and-printing.md
+++ b/docs/site/de/guide/exhibition/entries-and-printing.md
@@ -3,8 +3,8 @@ title: Einträge und Drucken
 description: Messeloks erfassen, Adresskonflikte lösen und die Betriebsliste drucken.
 audience: user
 status: stable
-reviewedVersion: 0.1.20.3
-lastReviewed: 2026-08-16
+reviewedVersion: 0.1.20.4
+lastReviewed: 2026-08-31
 ---
 
 # Einträge und Drucken
@@ -86,11 +86,11 @@ zuerst mit Admin oder einem Messekonto mit bestandsberechtigter Zusatzrolle.
 | Adresse SX | Optionaler Freitext, der getrennt mit anderen geladenen Einträgen verglichen wird. |
 | Analog | Schalter für die Verfügbarkeit des Analogbetriebs. |
 
-Tabelle und Report verbinden DCC und SX unter **Adresse**, zeigen Analog als Ja oder Nein und führen
-Decoder-Typ und Schnittstelle getrennt auf. Leere Werte erscheinen als Strich.
+Die Tabelle verbindet DCC und SX unter **Adresse**. Der aktuelle Druckreport zeigt beide Adressen,
+Analogzustand, Decoder-Typ, Adapter und Zentrale getrennt. Leere Werte erscheinen als Strich.
 
-**Baureihe** wird mit dem Eintrag gespeichert, erscheint in v0.1.20.3 jedoch weder in Tabelle und
-Listenansicht noch im gedruckten Report. Öffne **Eintrag bearbeiten**, um den Wert zu prüfen.
+**Baureihe** wird mit dem Eintrag gespeichert und im aktuellen Druckreport ausgegeben. In der
+kompakten Bildschirmtabelle ist sie nicht enthalten. Öffne **Eintrag bearbeiten**, um den Wert zu ändern.
 
 ### Nr. / Beschriftung / Merkmale
 
@@ -181,30 +181,32 @@ Das Löschen ist sofort und dauerhaft. Danach lädt RailKeeper Einträge und Anz
 allgemeiner Fahrzeugdatensatz wird nicht gelöscht. Messe erhält das Löschbedienelement nicht. Eine
 gesperrte Liste weist die Serveranfrage auch für Admin zurück.
 
-## Report ansehen und drucken
+## Ausstellungsliste drucken
 
-**Ansehen** öffnet eine schreibgeschützte Tabelle für eine Liste. Sie zeigt Bild, Besitzer und Tage,
-Lokdaten, Steuerungsdaten und belegte Funktionstasten. **Drucken** in diesem Dialog führt weiter zu
-**Report drucken**.
+Die separate Druckansicht ist ab RailKeeper v0.1.20.4 verfügbar.
 
-Alternativ stehen **Drucken** in einer Listenzeile und **Liste drucken** über der ausgewählten
-Eintragstabelle zur Verfügung. Gehört die Aktion zu einer anderen Liste, lädt RailKeeper zuerst
-deren Einträge. Die Aktion der ausgewählten Liste verwendet die aktuell angezeigten Einträge.
+Wähle die Veranstaltung und anschließend **Drucken** in ihrer Übersicht. RailKeeper erzeugt ein
+separates Dokument im A4-Querformat. Navigation, andere Veranstaltungen, Filter und Schaltflächen
+erscheinen darin nicht. Gedruckt werden sämtliche gespeicherten Einträge der ausgewählten
+Ausstellung, unabhängig von Suchtext, Tages- und Statusfiltern auf dem Bildschirm.
 
-Lasse in **Report drucken** die Option **Mit Bildern drucken** aktiviert oder deaktiviere sie, um
-die Bildspalte wegzulassen. Der erzeugte Report verwendet A4 im Querformat und enthält:
+Der Report enthält:
 
-- RailKeeper-Zeichen, Listenbezeichnung, Datum und Eintragsanzahl;
-- optional das Bild;
-- Besitzer und Tagesumfang;
-- Lokidentität sowie vorhandene Angaben zu Hersteller, Gattung und Epoche;
-- Adressen, Analogzustand, Decoder und Schnittstelle;
-- belegte Funktionstasten und Symbole;
-- Notizen.
+- Veranstaltungsname, Zeitraum, Ort, Status, Eintragsanzahl, Beschreibung und Organisationshinweise;
+- je Fahrzeug Bild, Besitzer, Fahrtage, Verfügbarkeit und Prüfstatus;
+- Lokbezeichnung, Hersteller, Baureihe, Gattung, Epoche und Bahnverwaltung;
+- Digitaldecoder, Decoder-Typ, Adapter, DCC- und SX-Adresse, Zentrale und Analogzustand;
+- alle gespeicherten Funktionstasten mit Beschreibung, Typ und vorhandenem Symbol;
+- vollständige Notizen mit Zeilenumbrüchen.
 
-Mit **Drucken** öffnet sich der Druckdialog des Browsers. Papierauswahl, Ränder, Skalierung,
-Druckerverfügbarkeit, Abbruch und endgültige Ausgabe bleiben Entscheidungen von Browser und
-Betriebssystem. Eine leere Liste erzeugt eine Reportzeile mit **Keine Einträge.**
+Funktionstasten stehen über die volle Listenbreite. Ältere Freitextbelegungen bleiben erhalten;
+fehlende Belegungen werden nicht durch Standardfunktionen ergänzt. Leere Listen zeigen
+**Keine Einträge.** Beim Wechsel der Veranstaltung ist Drucken gesperrt, bis ihre Daten geladen sind.
+
+RailKeeper wartet auf das Laden der Druckansicht einschließlich ihrer Bilder. Danach öffnet sich
+der Druckdialog des Browsers. Papierauswahl, Skalierung, Druckerverfügbarkeit, Abbruch und endgültige
+Ausgabe bleiben Entscheidungen von Browser und Betriebssystem. Verwende den **Drucken**-Knopf der
+Ausstellung, nicht den allgemeinen Browserbefehl zum Drucken der Webseite.
 
 ## Eintrags- und Druckfehler beheben
 
@@ -217,7 +219,7 @@ Betriebssystem. Eine leere Liste erzeugt eine Reportzeile mit **Keine Einträge.
 | Bild hat keine Vorschau | Vor dem Speichern eine lesbare PNG-, JPEG- oder WebP-Datei bis 10 MB wählen. |
 | Speichern gelingt, aber der Refresh scheitert | Öffne den Arbeitsbereich neu und prüfe den Eintrag vor dem Wiederholen. |
 | Detail oder Report öffnet nicht | Lade Liste und Einträge neu und wiederhole danach die Leseaktion. |
-| Browser-Druckdialog wird ohne Ausgabe geschlossen | Öffne **Report drucken** erneut; RailKeeper-Daten wurden nicht geändert. |
+| Browser-Druckdialog wird ohne Ausgabe geschlossen | Wähle **Drucken** erneut; RailKeeper-Daten wurden nicht geändert. |
 
 ## Verwandte Seiten
 
@@ -228,5 +230,4 @@ Betriebssystem. Eine leere Liste erzeugt eine Reportzeile mit **Keine Einträge.
 
 ## Dokumentierte RailKeeper-Version
 
-Diese Seite beschreibt RailKeeper v0.1.20.3. Der Entwicklungsstand auf `main` kann abweichen und
-gehört nicht zu diesem Benutzerablauf.
+Diese Seite beschreibt RailKeeper v0.1.20.4.

--- a/docs/site/de/guide/exhibition/index.md
+++ b/docs/site/de/guide/exhibition/index.md
@@ -3,7 +3,7 @@ title: Messearbeitsbereich
 description: Messelisten sicher vorbereiten, pflegen, prüfen und drucken.
 audience: user
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-16
 ---
 

--- a/docs/site/de/guide/exhibition/lists-and-locking.md
+++ b/docs/site/de/guide/exhibition/lists-and-locking.md
@@ -3,7 +3,7 @@ title: Listen und Sperren
 description: Messelisten anlegen, sperren, entsperren und sicher löschen.
 audience: user
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-16
 ---
 

--- a/docs/site/de/guide/getting-started/index.md
+++ b/docs/site/de/guide/getting-started/index.md
@@ -3,7 +3,7 @@ title: Ersteinrichtung und Anmeldung
 description: Ersten Administrator anlegen, sicher anmelden und den Zugang zu RailKeeper wiederherstellen.
 audience: user
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-16
 ---
 

--- a/docs/site/de/guide/import-export/cs3-import.md
+++ b/docs/site/de/guide/import-export/cs3-import.md
@@ -3,7 +3,7 @@ title: CS3-Lokdaten read-only lesen
 description: Märklin-CS3-Lokomotiven sicher lesen und im Digitalzentralen-Arbeitsbereich vergleichen.
 audience: user
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-28
 ---
 

--- a/docs/site/de/guide/import-export/ecos-sync.md
+++ b/docs/site/de/guide/import-export/ecos-sync.md
@@ -3,7 +3,7 @@ title: ECoS-Lokabgleich
 description: Ausgewählte ESU-ECoS-Lokdaten lesen, prüfen, importieren und ausdrücklich schreiben.
 audience: user
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-16
 ---
 

--- a/docs/site/de/guide/import-export/exports.md
+++ b/docs/site/de/guide/import-export/exports.md
@@ -3,7 +3,7 @@ title: Bestand exportieren
 description: CSV, RailKeeper-JSON und eine druckbare Fahrzeug-Bestandsausgabe erstellen.
 audience: user
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-16
 ---
 

--- a/docs/site/de/guide/import-export/file-import.md
+++ b/docs/site/de/guide/import-export/file-import.md
@@ -3,7 +3,7 @@ title: Fahrzeugdateien importieren
 description: Fahrzeugzeilen aus CSV, TSV, XML oder JSON zuordnen, prüfen und speichern.
 audience: user
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-16
 ---
 

--- a/docs/site/de/guide/import-export/index.md
+++ b/docs/site/de/guide/import-export/index.md
@@ -3,7 +3,7 @@ title: Import und Export
 description: Fahrzeug-, Zubehör- und Messedaten über geprüfte Transferaufträge austauschen.
 audience: user
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-27
 ---
 

--- a/docs/site/de/guide/index.md
+++ b/docs/site/de/guide/index.md
@@ -3,7 +3,7 @@ title: Benutzerhandbuch
 description: Alle stabilen Arbeitsabläufe in RailKeeper kennenlernen.
 audience: user
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-16
 ---
 

--- a/docs/site/de/guide/overview/index.md
+++ b/docs/site/de/guide/overview/index.md
@@ -3,7 +3,7 @@ title: Übersicht, Kennzahlen und Datenqualität
 description: RailKeeper-Dashboard auswerten, Datenlücken bearbeiten und Kacheln anordnen.
 audience: user
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-16
 ---
 

--- a/docs/site/de/guide/settings/appearance.md
+++ b/docs/site/de/guide/settings/appearance.md
@@ -3,7 +3,7 @@ title: Darstellung
 description: Designmodus wählen und helle sowie dunkle Varianten getrennt konfigurieren.
 audience: user
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-16
 ---
 

--- a/docs/site/de/guide/settings/index.md
+++ b/docs/site/de/guide/settings/index.md
@@ -3,7 +3,7 @@ title: Einstellungen
 description: Persönliche Einstellungen, Darstellung und die Abgrenzung zur Administration verstehen.
 audience: user
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-16
 ---
 

--- a/docs/site/de/guide/settings/personal-preferences.md
+++ b/docs/site/de/guide/settings/personal-preferences.md
@@ -3,7 +3,7 @@ title: Persönliche Einstellungen
 description: Sprache, Startseite, Datum, Zeit, Druckausgabe und Seitenleisten-Reihenfolge konfigurieren.
 audience: user
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-16
 ---
 

--- a/docs/site/de/guide/vehicles/decoder-cv.md
+++ b/docs/site/de/guide/vehicles/decoder-cv.md
@@ -3,7 +3,7 @@ title: Decoder, Funktionen und CV-Daten
 description: Digitalfunktionen zuordnen, Fahrkurven prüfen, CV-Werte pflegen und Decoder-Dateien speichern.
 audience: user
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-16
 ---
 

--- a/docs/site/de/guide/vehicles/index.md
+++ b/docs/site/de/guide/vehicles/index.md
@@ -3,7 +3,7 @@ title: Fahrzeugbestand und Grunddaten
 description: Fahrzeuge suchen, filtern, anlegen, pflegen, ausgeben und sicher löschen.
 audience: user
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-17
 ---
 

--- a/docs/site/de/guide/vehicles/maintenance.md
+++ b/docs/site/de/guide/vehicles/maintenance.md
@@ -3,7 +3,7 @@ title: Fahrzeugwartung und Zustand
 description: Fahrzeugwartungen erfassen, planen, abschließen, prüfen und sicher entfernen.
 audience: user
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-16
 ---
 

--- a/docs/site/de/guide/vehicles/media.md
+++ b/docs/site/de/guide/vehicles/media.md
@@ -3,7 +3,7 @@ title: Fahrzeugbilder und Beilagen
 description: Fahrzeugbilder und Beilagen hochladen, ordnen, anzeigen, herunterladen und sicher entfernen.
 audience: user
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-16
 ---
 

--- a/docs/site/de/guide/vehicles/search-and-spares.md
+++ b/docs/site/de/guide/vehicles/search-and-spares.md
@@ -3,7 +3,7 @@ title: Artikelsuche, Web-Dokumente und Ersatzteile
 description: Externe Artikeldaten prüfen, Web-Dokumente importieren und Fahrzeugersatzteile pflegen.
 audience: user
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-16
 ---
 

--- a/docs/site/de/index.md
+++ b/docs/site/de/index.md
@@ -4,7 +4,7 @@ title: RailKeeper-Dokumentation
 description: Vollständige Benutzer-, Administrations- und Entwicklungsdokumentation für RailKeeper.
 audience: reference
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-15
 hero:
   name: RailKeeper-Dokumentation

--- a/docs/site/guide/accessories/allocations-history.md
+++ b/docs/site/guide/accessories/allocations-history.md
@@ -3,7 +3,7 @@ title: Reservations, installations, and usage
 description: Reserve accessory stock, record installations, and understand usage history.
 audience: user
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-16
 ---
 

--- a/docs/site/guide/accessories/article-records.md
+++ b/docs/site/guide/accessories/article-records.md
@@ -3,7 +3,7 @@ title: Article records and technical data
 description: Create accessory records, maintain their identity, and verify technical data.
 audience: user
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-16
 ---
 

--- a/docs/site/guide/accessories/index.md
+++ b/docs/site/guide/accessories/index.md
@@ -3,7 +3,7 @@ title: Accessories overview
 description: Find, filter, inspect, and safely manage accessory articles.
 audience: user
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-16
 ---
 

--- a/docs/site/guide/accessories/stock-purchases-documents.md
+++ b/docs/site/guide/accessories/stock-purchases-documents.md
@@ -3,7 +3,7 @@ title: Stock, purchases, and documents
 description: Manage accessory quantities, individual items, purchases, images, and documents.
 audience: user
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-16
 ---
 

--- a/docs/site/guide/exhibition/entries-and-printing.md
+++ b/docs/site/guide/exhibition/entries-and-printing.md
@@ -3,8 +3,8 @@ title: Entries and printing
 description: Record exhibition locomotives, resolve address conflicts, and print the operating list.
 audience: user
 status: stable
-reviewedVersion: 0.1.20.3
-lastReviewed: 2026-08-16
+reviewedVersion: 0.1.20.4
+lastReviewed: 2026-08-31
 ---
 
 # Entries and printing
@@ -80,11 +80,11 @@ Messe account with an inventory-capable role to verify it first.
 | SX address | Optional free text checked separately against other loaded entries. |
 | Analog | Switch indicating that analog operation is available. |
 
-The table and report combine DCC and SX into **Address**, show analog as Yes or No, and list decoder
-type and interface separately. Empty values appear as a dash.
+The table combines DCC and SX into **Address**. The current print report shows both addresses,
+analogue state, decoder type, adapter and command station separately. Empty values appear as a dash.
 
-**Class** is saved with the entry but is not shown in the stable table, read-only list view, or
-printed report. Reopen **Edit entry** when that value must be checked.
+**Class** is saved with the entry and included in the current print report. It is not part of the
+compact screen table. Reopen **Edit entry** to change it.
 
 ### No. / lettering / features
 
@@ -170,29 +170,31 @@ The delete is immediate and permanent, then RailKeeper reloads the entries and c
 delete a general vehicle. Messe does not receive the delete control. A locked list rejects the
 server request even for Admin.
 
-## View and print the report
+## Print the exhibition list
 
-**View** opens a read-only table for one list. It shows image, owner and days, locomotive data,
-control data, and configured function keys. **Print** from that dialog continues to **Print report**.
+The separate print document is available from RailKeeper v0.1.20.4.
 
-You can also use **Print** on a list row or **Print list** above the selected entry table. If the
-action belongs to another list, RailKeeper loads that list's entries first. The selected-list action
-uses the entries currently displayed.
+Select the event, then choose **Print** in its overview. RailKeeper generates a separate A4 landscape
+document without navigation, other events, filters or buttons. It includes every saved entry in the
+selected exhibition, regardless of the screen's search, day and status filters.
 
-In **Print report**, keep **Print with images** selected or clear it to omit the image column. The
-generated report uses A4 landscape and contains:
+The report includes:
 
-- RailKeeper mark, list designation, date, and entry count;
-- optional image;
-- owner and day scope;
-- locomotive identity and available manufacturer, type, and epoch;
-- addresses, analog state, decoder, and interface;
-- configured function keys and symbols;
-- notes.
+- event name, date range, location, status, entry count, description and organisation notes;
+- each vehicle's image, owner, operating days, availability and check status;
+- locomotive name, manufacturer, series, category, epoch and railway company;
+- digital decoder, decoder type, adapter, DCC and SX addresses, command station and analogue state;
+- all saved function keys with description, type and available symbol;
+- complete notes with line breaks.
 
-Select **Print** to open the browser's print dialog. Paper selection, margins, scaling, printer
-availability, cancellation, and the final output remain browser and operating-system decisions.
-An empty list produces a report row reading **No entries.**
+Function keys use the full table width. Legacy free-text assignments are preserved; missing
+assignments are not replaced with default functions. Empty lists show **No entries.** Printing is
+disabled while a newly selected event's data is still loading.
+
+RailKeeper waits for the print document, including its images, to load before opening the browser's
+print dialog. Paper selection, scaling, printer availability, cancellation and final output remain
+browser and operating-system decisions. Use the event's **Print** button rather than the browser's
+general command for printing the web page.
 
 ## Resolve entry and print errors
 
@@ -205,7 +207,7 @@ An empty list produces a report row reading **No entries.**
 | Image has no preview | Choose a readable PNG, JPEG, or WebP up to 10 MB before saving. |
 | Save succeeds but reload fails | Reopen the workspace and inspect the stored entry before retrying. |
 | Detail or report does not open | Reload the list and entries, then retry the read-only action. |
-| Browser print dialog closes without output | Reopen **Print report**; no RailKeeper data was changed. |
+| Browser print dialog closes without output | Select **Print** again; no RailKeeper data was changed. |
 
 ## Related pages
 
@@ -216,5 +218,4 @@ An empty list produces a report row reading **No entries.**
 
 ## Documented RailKeeper version
 
-This page describes stable RailKeeper v0.1.20.3. Development behavior on `main` may differ and is
-not part of this user workflow.
+This page describes RailKeeper v0.1.20.4.

--- a/docs/site/guide/exhibition/index.md
+++ b/docs/site/guide/exhibition/index.md
@@ -3,7 +3,7 @@ title: Exhibition workspace
 description: Prepare, maintain, review, and print exhibition lists safely.
 audience: user
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-16
 ---
 

--- a/docs/site/guide/exhibition/lists-and-locking.md
+++ b/docs/site/guide/exhibition/lists-and-locking.md
@@ -3,7 +3,7 @@ title: Lists and locking
 description: Create exhibition lists, control their lock state, and remove them safely.
 audience: user
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-16
 ---
 

--- a/docs/site/guide/getting-started/index.md
+++ b/docs/site/guide/getting-started/index.md
@@ -3,7 +3,7 @@ title: First setup and sign-in
 description: Create the first administrator, sign in securely, and recover access to RailKeeper.
 audience: user
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-16
 ---
 

--- a/docs/site/guide/import-export/cs3-import.md
+++ b/docs/site/guide/import-export/cs3-import.md
@@ -3,7 +3,7 @@ title: Read CS3 locomotives without writing
 description: Safely read Märklin CS3 locomotives and compare them in the Digital centers workspace.
 audience: user
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-28
 ---
 

--- a/docs/site/guide/import-export/ecos-sync.md
+++ b/docs/site/guide/import-export/ecos-sync.md
@@ -3,7 +3,7 @@ title: ECoS locomotive sync
 description: Read, review, import, and explicitly write selected ESU ECoS locomotive data.
 audience: user
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-16
 ---
 

--- a/docs/site/guide/import-export/exports.md
+++ b/docs/site/guide/import-export/exports.md
@@ -3,7 +3,7 @@ title: Export inventory
 description: Create CSV, RailKeeper JSON, and printable vehicle inventory output.
 audience: user
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-16
 ---
 

--- a/docs/site/guide/import-export/file-import.md
+++ b/docs/site/guide/import-export/file-import.md
@@ -3,7 +3,7 @@ title: Import vehicle files
 description: Map, validate, review, and save vehicle rows from CSV, TSV, XML, or JSON.
 audience: user
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-16
 ---
 

--- a/docs/site/guide/import-export/index.md
+++ b/docs/site/guide/import-export/index.md
@@ -3,7 +3,7 @@ title: Import and export
 description: Exchange vehicle, accessory, and exhibition data through reviewed transfer jobs.
 audience: user
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-27
 ---
 

--- a/docs/site/guide/index.md
+++ b/docs/site/guide/index.md
@@ -3,7 +3,7 @@ title: User Guide
 description: Learn every stable RailKeeper workflow.
 audience: user
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-16
 ---
 

--- a/docs/site/guide/overview/index.md
+++ b/docs/site/guide/overview/index.md
@@ -3,7 +3,7 @@ title: Overview, metrics, and data quality
 description: Read the RailKeeper dashboard, follow data gaps, and arrange its widgets.
 audience: user
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-16
 ---
 

--- a/docs/site/guide/settings/appearance.md
+++ b/docs/site/guide/settings/appearance.md
@@ -3,7 +3,7 @@ title: Appearance
 description: Choose the theme mode and configure light and dark variants independently.
 audience: user
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-16
 ---
 

--- a/docs/site/guide/settings/index.md
+++ b/docs/site/guide/settings/index.md
@@ -3,7 +3,7 @@ title: Settings
 description: Understand personal preferences, appearance, and the boundaries between user and administration settings.
 audience: user
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-16
 ---
 

--- a/docs/site/guide/settings/personal-preferences.md
+++ b/docs/site/guide/settings/personal-preferences.md
@@ -3,7 +3,7 @@ title: Personal preferences
 description: Configure language, start page, date and time choices, printing, and sidebar order.
 audience: user
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-16
 ---
 

--- a/docs/site/guide/vehicles/decoder-cv.md
+++ b/docs/site/guide/vehicles/decoder-cv.md
@@ -3,7 +3,7 @@ title: Decoder, functions, and CV data
 description: Map digital functions, inspect speed curves, manage CV values, and store decoder files.
 audience: user
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-16
 ---
 

--- a/docs/site/guide/vehicles/index.md
+++ b/docs/site/guide/vehicles/index.md
@@ -3,7 +3,7 @@ title: Vehicle inventory and core records
 description: Search, filter, create, maintain, report, and safely delete RailKeeper vehicle records.
 audience: user
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-17
 ---
 

--- a/docs/site/guide/vehicles/maintenance.md
+++ b/docs/site/guide/vehicles/maintenance.md
@@ -3,7 +3,7 @@ title: Vehicle maintenance and condition
 description: Record, schedule, complete, review, and safely remove vehicle maintenance entries.
 audience: user
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-16
 ---
 

--- a/docs/site/guide/vehicles/media.md
+++ b/docs/site/guide/vehicles/media.md
@@ -3,7 +3,7 @@ title: Vehicle images and attachments
 description: Upload, organize, preview, download, and safely remove vehicle images and attachments.
 audience: user
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-16
 ---
 

--- a/docs/site/guide/vehicles/search-and-spares.md
+++ b/docs/site/guide/vehicles/search-and-spares.md
@@ -3,7 +3,7 @@ title: Article search, web documents, and spare parts
 description: Verify external article data, import web documents, and maintain vehicle spare parts.
 audience: user
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-16
 ---
 

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -4,7 +4,7 @@ title: RailKeeper Documentation
 description: Complete user, administration, and development documentation for RailKeeper.
 audience: reference
 status: stable
-reviewedVersion: 0.1.20.3
+reviewedVersion: 0.1.20.4
 lastReviewed: 2026-08-15
 hero:
   name: RailKeeper Documentation

--- a/docs/versions.json
+++ b/docs/versions.json
@@ -1,4 +1,4 @@
 {
-  "stable": "0.1.20.3",
+  "stable": "0.1.20.4",
   "development": "main"
 }

--- a/frontend/src/features/exhibition/ExhibitionView.tsx
+++ b/frontend/src/features/exhibition/ExhibitionView.tsx
@@ -11,7 +11,7 @@ import {
   Upload
 } from "lucide-react";
 import { api, ExhibitionEntry, ExhibitionEntryInput, ExhibitionList, ExhibitionListInput, MasterDataEntry } from "../../shared/api";
-import { functionSymbolImageData } from "../../shared/functionSymbolImages";
+import { printList } from "./exhibitionPrint";
 import { FunctionSymbolPicker, functionSymbolIcon, functionSymbolMetadata } from "../../shared/functionSymbols";
 import { useI18n } from "../../shared/i18n";
 import { AppSelect } from "../../shared/ui/AppSelect";
@@ -23,7 +23,6 @@ type ListSortKey = "designation" | "date" | "entryCount" | "locked";
 type EntrySortKey = "owner" | "locomotiveName" | "dtDecoder" | "decoderNumber" | "functionKeys";
 type SortDirection = "asc" | "desc";
 type EntryTab = "general" | "images" | "functions";
-type PrintOptions = { includeImages: boolean };
 
 type ExhibitionMasterDataOptions = {
   manufacturers: MasterDataEntry[];
@@ -69,13 +68,6 @@ const functionKeys = Array.from({ length: 32 }, (_, index) => `F${index}`);
 const functionTypes = ["standard", "licht", "sound", "kupplung", "rauch", "sonderfunktion"];
 const dayScopes = ["all", "day1", "day2", "day3", "day4"];
 const selectableDayScopes = dayScopes.filter((scope) => scope !== "all");
-const htmlEscapes: Record<string, string> = {
-  "&": "&amp;",
-  "<": "&lt;",
-  ">": "&gt;",
-  "\"": "&quot;",
-  "'": "&#39;"
-};
 function defaultFunction(key: string): ExhibitionFunction {
   return {
     key,
@@ -224,21 +216,6 @@ function controlRows(
   ];
 }
 
-export function printFunctionChips(value: string | undefined, symbols: MasterDataEntry[]) {
-  const configured = parseFunctions(value).filter(isConfiguredFunction);
-  if (configured.length === 0) return "-";
-  return configured.map((item) => {
-    const metadata = functionSymbolMetadata(symbols, item.symbolKey);
-    const imageData = functionSymbolImageData(metadata, "print");
-    const label = functionDisplayName(item);
-    return `<span class="function-chip">${imageData ? `<img src="${escapeHTML(imageData)}" alt="" />` : ""}<strong>${escapeHTML(item.key)}</strong> ${escapeHTML(label)}</span>`;
-  }).join("");
-}
-
-function escapeHTML(value: unknown) {
-  return String(value ?? "").replace(/[&<>"']/g, (char) => htmlEscapes[char] || char);
-}
-
 function fileToDataURL(file: File) {
   return new Promise<string>((resolve, reject) => {
     const reader = new FileReader();
@@ -246,133 +223,6 @@ function fileToDataURL(file: File) {
     reader.onerror = () => reject(reader.error || new Error("Bild konnte nicht gelesen werden."));
     reader.readAsDataURL(file);
   });
-}
-
-function printHTMLDocument(html: string) {
-  const frame = document.createElement("iframe");
-  frame.setAttribute("aria-hidden", "true");
-  frame.style.position = "fixed";
-  frame.style.right = "0";
-  frame.style.bottom = "0";
-  frame.style.width = "0";
-  frame.style.height = "0";
-  frame.style.border = "0";
-  frame.style.opacity = "0";
-  document.body.appendChild(frame);
-
-  const printWindow = frame.contentWindow;
-  if (!printWindow) {
-    frame.remove();
-    return;
-  }
-
-  let printed = false;
-  const runPrint = () => {
-    if (printed) return;
-    printed = true;
-    printWindow.focus();
-    printWindow.print();
-    window.setTimeout(() => frame.remove(), 1200);
-  };
-
-  frame.onload = runPrint;
-  printWindow.document.open();
-  printWindow.document.write(html);
-  printWindow.document.close();
-  window.setTimeout(runPrint, 250);
-}
-
-function printList(
-  list: ExhibitionList,
-  entries: ExhibitionEntry[],
-  symbols: MasterDataEntry[] = [],
-  language = "de",
-  t: (key: string, values?: Record<string, string | number>) => string = (key) => key,
-  options: PrintOptions = { includeImages: true }
-) {
-  const rows = entries.map((entry) => {
-    const modelParts = modelMeta(entry);
-    const controlParts = controlRows(entry, t);
-    return `
-    <tr>
-      ${options.includeImages ? `<td class="image-cell">${entry.imageUrl ? `<img src="${escapeHTML(entry.imageUrl)}" alt="" />` : `<span>-</span>`}</td>` : ""}
-      <td class="owner-cell">${escapeHTML(entry.owner)}<small>${escapeHTML(dayScopeLabel(entry.dayScope, t))}</small></td>
-      <td class="loco-cell">
-        <strong>${escapeHTML(locomotiveTitle(entry))}</strong>
-        ${modelParts.length > 0 ? `<small>${modelParts.map(escapeHTML).join(" | ")}</small>` : ""}
-      </td>
-      <td class="control-cell">${controlParts.map(([label, value]) => `<span class="control-row"><em>${escapeHTML(label)}:</em> <strong>${escapeHTML(value)}</strong></span>`).join("")}</td>
-      <td class="function-cell"><div class="function-chip-grid">${printFunctionChips(entry.functionKeys, symbols)}</div></td>
-      <td class="notes-cell">${entry.notes ? escapeHTML(entry.notes) : "-"}</td>
-    </tr>
-  `;
-  }).join("");
-  const emptyColSpan = options.includeImages ? 6 : 5;
-  const colGroup = options.includeImages
-    ? `<colgroup><col class="col-image" /><col class="col-owner" /><col class="col-loco" /><col class="col-control" /><col class="col-functions" /><col class="col-notes" /></colgroup>`
-    : `<colgroup><col class="col-owner" /><col class="col-loco" /><col class="col-control" /><col class="col-functions" /><col class="col-notes" /></colgroup>`;
-  printHTMLDocument(`<!doctype html>
-    <html lang="${escapeHTML(language)}">
-      <head>
-        <meta charset="utf-8" />
-        <title> </title>
-        <style>
-          @page { size: A4 landscape; margin: 13mm 12mm 12mm; }
-          * { box-sizing: border-box; }
-          body { font-family: Arial, sans-serif; margin: 0; color: #111; }
-          .print-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 20px; margin-bottom: 12px; padding-bottom: 10px; border-bottom: 2px solid #78b943; }
-          .print-eyebrow { margin: 0 0 4px; color: #4e7f27; font-size: 10px; font-weight: 700; letter-spacing: .04em; text-transform: uppercase; }
-          h1 { margin: 0 0 5px; font-size: 22px; line-height: 1.12; }
-          p { margin: 0; color: #555; }
-          .print-meta { font-size: 11px; }
-          .print-logo { width: 44px; height: 44px; object-fit: contain; flex: 0 0 auto; }
-          table { width: 100%; table-layout: fixed; border-collapse: collapse; font-size: 10.5px; }
-          .col-image { width: 74px; }
-          .col-owner { width: 102px; }
-          .col-loco { width: 200px; }
-          .col-control { width: 180px; }
-          .col-functions { width: 178px; }
-          .col-notes { width: auto; }
-          th, td { border-bottom: 1px solid #d7ddd9; padding: 7px 8px; text-align: left; vertical-align: top; overflow-wrap: anywhere; }
-          th { background: #eef5ee; color: #26352a; font-size: 9px; text-transform: uppercase; }
-          td strong, td small { display: block; }
-          td small { margin-top: 3px; color: #666; line-height: 1.35; }
-          .image-cell { width: 74px; }
-          .image-cell img, .image-cell span { display: grid; width: 66px; height: 46px; place-items: center; border: 1px solid #d7ddd9; border-radius: 4px; object-fit: contain; }
-          .control-row { display: grid; grid-template-columns: 76px minmax(0, 1fr); gap: 5px; margin-bottom: 3px; line-height: 1.25; }
-          .control-row em { color: #666; font-style: normal; }
-          .function-cell { min-width: 0; }
-          .function-chip-grid { display: grid; grid-template-columns: repeat(2, max-content); gap: 5px 6px; align-content: start; min-width: 0; }
-          .function-chip { display: inline-flex; align-items: center; gap: 4px; min-width: 54px; padding: 3px 6px; border: 1px solid #d9e4dc; border-radius: 4px; white-space: nowrap; }
-          .function-chip img { width: 14px; height: 14px; object-fit: contain; }
-          .function-chip strong { display: inline; }
-        </style>
-      </head>
-      <body>
-        <header class="print-head">
-          <div>
-            <p class="print-eyebrow">RailKeeper Ausstellung</p>
-            <h1>${escapeHTML(list.designation)}</h1>
-            <p class="print-meta">${escapeHTML(t("exhibition.entriesCountWithDate", { date: formatDate(list.date, language), count: entries.length }))}</p>
-          </div>
-          <img class="print-logo" src="/brand/railkeeper-mark.png" alt="RailKeeper" />
-        </header>
-        <table>
-          ${colGroup}
-          <thead>
-            <tr>
-              ${options.includeImages ? `<th>${escapeHTML(t("exhibition.image"))}</th>` : ""}
-              <th>${escapeHTML(t("exhibition.owner"))}</th>
-              <th>${escapeHTML(t("exhibition.locomotiveName"))}</th>
-              <th>${escapeHTML(t("exhibition.controlData"))}</th>
-              <th>${escapeHTML(t("exhibition.functionKeys"))}</th>
-              <th>${escapeHTML(t("exhibition.notes"))}</th>
-            </tr>
-          </thead>
-          <tbody>${rows || `<tr><td colspan="${emptyColSpan}">${escapeHTML(t("exhibition.printEmpty"))}</td></tr>`}</tbody>
-        </table>
-      </body>
-    </html>`);
 }
 
 export function ExhibitionView({ roles }: { roles: string[] }) {

--- a/frontend/src/features/exhibition/ExhibitionWorkspacePage.tsx
+++ b/frontend/src/features/exhibition/ExhibitionWorkspacePage.tsx
@@ -35,6 +35,7 @@ import { useI18n } from "../../shared/i18n";
 import { AppDateInput } from "../../shared/ui/AppDateInput";
 import { useModalDialogLayer } from "../../shared/ui/useModalDialogLayer";
 import { ExhibitionEntryDialog, ExhibitionEntryMasterData } from "./ExhibitionEntryDialog";
+import { printList } from "./exhibitionPrint";
 
 type EntryFilter = "all" | "ready" | "check";
 type ExhibitionDialog = "event" | "entry" | "conflicts" | "lock" | null;
@@ -156,7 +157,7 @@ function conflictDescription(conflict: ExhibitionConflict, language: "de" | "en"
 }
 
 export function ExhibitionWorkspacePage({ roles }: { roles: string[] }) {
-  const { language } = useI18n();
+  const { language, t } = useI18n();
   const de = language === "de";
   const admin = hasAdmin(roles);
   const manager = admin || roles.includes("Editor");
@@ -169,6 +170,7 @@ export function ExhibitionWorkspacePage({ roles }: { roles: string[] }) {
   const [symbols, setSymbols] = useState<MasterDataEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [printing, setPrinting] = useState(false);
   const [message, setMessage] = useState("");
   const [dialog, setDialog] = useState<ExhibitionDialog>(null);
   const [editingEvent, setEditingEvent] = useState<ExhibitionList | null>(null);
@@ -187,6 +189,18 @@ export function ExhibitionWorkspacePage({ roles }: { roles: string[] }) {
   const locked = Boolean(selectedList?.locked);
   const planningOpen = selectedList?.status === "draft" || selectedList?.status === "open";
   const canEditEntries = entryManager && planningOpen && !locked;
+
+  const printCurrentList = async () => {
+    if (!workspace || workspace.list.id !== selectedID || printing) return;
+    setPrinting(true);
+    try {
+      await printList(workspace.list, workspace.entries, symbols, language, t);
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : de ? "Drucken fehlgeschlagen." : "Printing failed.");
+    } finally {
+      setPrinting(false);
+    }
+  };
 
   const loadLists = async (preferredID?: string) => {
     setLoading(true);
@@ -437,7 +451,10 @@ export function ExhibitionWorkspacePage({ roles }: { roles: string[] }) {
               {selectedList.location && <span className="exhibition-event-location"><MapPin size={14} />{selectedList.location}</span>}
             </div>
             <div className="exhibition-summary-actions">
-              <button type="button" className="secondary-button" onClick={() => window.print()}><Printer size={17} />{de ? "Drucken" : "Print"}</button>
+              <button type="button" className="secondary-button" onClick={() => void printCurrentList()}
+                disabled={printing || workspace.list.id !== selectedID}>
+                <Printer size={17} />{printing ? (de ? "Druck wird vorbereitet…" : "Preparing print…") : (de ? "Drucken" : "Print")}
+              </button>
               {manager && (selectedList.status === "open" || selectedList.status === "locked") && <button type="button" className="secondary-button" onClick={() => selectedList.locked ? void updateStatus("open", de ? "Liste wieder geöffnet" : "List reopened") : void updateStatus("locked")}>
                 {selectedList.locked ? <LockOpen size={17} /> : <Lock size={17} />}{selectedList.locked ? (de ? "Liste entsperren" : "Unlock list") : (de ? "Liste sperren" : "Lock list")}
               </button>}

--- a/frontend/src/features/exhibition/ExhibitionWorkspaceView.test.tsx
+++ b/frontend/src/features/exhibition/ExhibitionWorkspaceView.test.tsx
@@ -3,7 +3,9 @@ import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { api, ExhibitionList, ExhibitionWorkspace, MasterDataEntry } from "../../shared/api";
-import { ExhibitionView, printFunctionChips } from "./ExhibitionView";
+import { ExhibitionView } from "./ExhibitionView";
+import { printFunctionChips } from "./exhibitionPrint";
+import * as exhibitionPrint from "./exhibitionPrint";
 
 const list: ExhibitionList = {
   id: "messe-koeln",
@@ -55,7 +57,7 @@ const lightSymbol: MasterDataEntry = {
   label: "Licht",
   active: true,
   sortOrder: 10,
-  metadata: { imageData: "print-data", activeImageData: "active-data" },
+  metadata: { imageData: "data:image/png;base64,cHJpbnQ=", activeImageData: "data:image/png;base64,YWN0aXZl" },
   createdAt: list.createdAt,
   updatedAt: list.updatedAt,
 };
@@ -102,8 +104,45 @@ describe("Exhibition reference workspace", () => {
       [lightSymbol],
     );
 
-    expect(html).toContain('src="print-data"');
-    expect(html).not.toContain('src="active-data"');
+    expect(html).toContain('src="data:image/png;base64,cHJpbnQ="');
+    expect(html).not.toContain('src="data:image/png;base64,YWN0aXZl"');
+  });
+
+  it("prints all saved entries in the selected event despite screen filters", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(api, "exhibitionLists").mockResolvedValue([list]);
+    vi.spyOn(api, "exhibitionWorkspace").mockResolvedValue(workspace);
+    vi.spyOn(api, "masterData").mockResolvedValue([lightSymbol]);
+    const print = vi.spyOn(exhibitionPrint, "printList").mockResolvedValue();
+    const pagePrint = vi.spyOn(window, "print").mockImplementation(() => {});
+    render(<ExhibitionView roles={["Messe"]} />);
+    await screen.findByText("BR 103 113-7");
+    await user.click(screen.getByRole("button", { name: /^Tag 1/ }));
+    await user.type(screen.getByRole("textbox", { name: "Einträge durchsuchen" }), "BR 103");
+    expect(screen.queryByText("V 200 033")).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Drucken" }));
+    expect(print).toHaveBeenCalledWith(list, workspace.entries, [lightSymbol], "de", expect.any(Function));
+    expect(pagePrint).not.toHaveBeenCalled();
+  });
+
+  it("blocks printing the previous workspace while another event loads and reports failures", async () => {
+    const user = userEvent.setup();
+    const nextList = { ...list, id: "next-event", designation: "Nächste Ausstellung" };
+    let finishLoad: (value: ExhibitionWorkspace) => void = () => {};
+    vi.spyOn(api, "exhibitionLists").mockResolvedValue([list, nextList]);
+    vi.spyOn(api, "exhibitionWorkspace").mockResolvedValueOnce(workspace)
+      .mockReturnValueOnce(new Promise((resolve) => { finishLoad = resolve; }));
+    vi.spyOn(api, "masterData").mockResolvedValue([]);
+    const print = vi.spyOn(exhibitionPrint, "printList").mockRejectedValue(new Error("Druck nicht verfügbar"));
+    render(<ExhibitionView roles={["Messe"]} />);
+    await screen.findByText("BR 103 113-7");
+    await user.click(screen.getByRole("button", { name: /Nächste Ausstellung/ }));
+    expect(screen.getByRole("button", { name: "Drucken" })).toBeDisabled();
+    finishLoad({ ...workspace, list: nextList, entries: [] });
+    await waitFor(() => expect(screen.getByRole("button", { name: "Drucken" })).toBeEnabled());
+    await user.click(screen.getByRole("button", { name: "Drucken" }));
+    expect(print).toHaveBeenCalledWith(nextList, [], [], "de", expect.any(Function));
+    expect(await screen.findByRole("alert")).toHaveTextContent("Druck nicht verfügbar");
   });
 
   it("persists lifecycle transitions from the event menu", async () => {

--- a/frontend/src/features/exhibition/exhibitionPrint.test.ts
+++ b/frontend/src/features/exhibition/exhibitionPrint.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ExhibitionList, ExhibitionWorkspaceEntry } from "../../shared/api";
+import { buildExhibitionPrintHTML, printFunctionChips, printList } from "./exhibitionPrint";
+
+const list: ExhibitionList = {
+  id: "event", designation: "Modellbahntage Köln", date: "2026-08-31", endDate: "2026-09-05",
+  location: "Vereinshalle", description: "Betrieb mit Gästen", organizationNotes: "Aufbau ab 08:00",
+  status: "locked", locked: true, lockReason: "Planung abgeschlossen", entryCount: 1, revision: 3,
+  createdAt: "2026-08-01", updatedAt: "2026-08-30"
+};
+const entry: ExhibitionWorkspaceEntry = {
+  id: "entry", listId: list.id, locomotiveName: "BR 103 113-7", owner: "Fahrgemeinschaft Köln",
+  manufacturer: "Roco", series: "103", gattung: "Elektrolokomotive", epoch: "IV", railwayCompany: "DB",
+  dtDecoder: true, decoderType: "LokSound 5", decoderNumber: "103", sxAddress: "42",
+  adapter: "PluX22", interfaceName: "ECoS", analog: false, availability: "unavailable",
+  dayScope: "day1,day5", notes: "Kupplung prüfen\nNur im äußeren Gleis", sortOrder: 2,
+  functionKeys: JSON.stringify([{ key: "F31", name: "Bahnhofsansage", type: "sound", symbolKey: "speaker" }]),
+  imageUrl: "/vehicle.png", revision: 1, status: "unavailable", conflictIds: [],
+  createdAt: "2026-08-01", updatedAt: "2026-08-30"
+};
+const t = (key: string, values?: Record<string, string | number>) => `${key}${values ? ` ${values.count}` : ""}`;
+
+describe("exhibition print report", () => {
+  afterEach(() => {
+    document.querySelectorAll("iframe").forEach((frame) => frame.remove());
+    vi.useRealTimers();
+  });
+
+  it("includes all operational fields, event metadata and saved functions", () => {
+    const html = buildExhibitionPrintHTML(list, [entry], [], "de", t);
+    const doc = new DOMParser().parseFromString(html, "text/html");
+    for (const value of [
+      list.designation, "31.8.2026", "5.9.2026", list.location, list.description, list.organizationNotes,
+      list.lockReason, entry.locomotiveName, entry.owner, entry.manufacturer, entry.series, entry.gattung,
+      entry.epoch, entry.railwayCompany, entry.decoderType, entry.decoderNumber, entry.sxAddress,
+      entry.adapter, entry.interfaceName, "Nicht verfügbar", "Tag 1, Tag 5", entry.notes,
+      "F31", "Bahnhofsansage", "sound", "speaker"
+    ]) expect(doc.body.textContent).toContain(value);
+    expect(doc.querySelector("img")?.getAttribute("src")).toBe(entry.imageUrl);
+    expect(doc.querySelectorAll("tbody.entry")).toHaveLength(1);
+    expect(doc.querySelectorAll("button, nav, aside")).toHaveLength(0);
+    expect(html).toContain("@page { size: A4 landscape");
+    expect(html).toContain("table-header-group");
+    expect(html).toContain("break-inside: avoid");
+    expect(html).toContain("white-space: pre-wrap");
+    expect(html).not.toContain("white-space: nowrap");
+  });
+
+  it("keeps imported text inert and rejects executable image URLs", () => {
+    const payload = '<img src=x onerror="alert(1)">';
+    const html = buildExhibitionPrintHTML({ ...list, designation: payload }, [{
+      ...entry, owner: payload, notes: payload, imageUrl: "javascript:alert(1)",
+      functionKeys: JSON.stringify([{ key: "F1", name: payload, type: "sound" }])
+    }], [], "de", t);
+    const doc = new DOMParser().parseFromString(html, "text/html");
+    expect(doc.querySelectorAll("img, script, [onerror]")).toHaveLength(0);
+    expect(doc.body.textContent).toContain(payload);
+    expect(doc.querySelector('meta[http-equiv="Content-Security-Policy"]')?.getAttribute("content"))
+      .toContain("default-src 'none'");
+  });
+
+  it("preserves legacy or malformed function text without adding unsaved F0 defaults", () => {
+    expect(printFunctionChips("F2: Horn\nF31: Ansage", [])).toContain("F2: Horn\nF31: Ansage");
+    expect(printFunctionChips("F2: Horn", [])).not.toContain("F0");
+    expect(printFunctionChips("", [])).toBe("–");
+    expect(printFunctionChips("[]", [])).toBe("–");
+    expect(printFunctionChips('[null,{"name":"Unvollständig"}]', [])).toContain("Unvollständig");
+  });
+
+  it("supports empty lists, English and the existing image-free option", () => {
+    expect(buildExhibitionPrintHTML(list, [], [], "en", t)).toContain("exhibition.printEmpty");
+    const html = buildExhibitionPrintHTML(list, [entry], [], "en", t, { includeImages: false });
+    expect(html).toContain("Day 1, Day 5");
+    expect(html).toContain("Unavailable");
+    expect(html).toContain("Organisation notes");
+    expect(html).not.toContain("<img");
+  });
+
+  it("prints only its loaded document and retains it until the print dialog closes", async () => {
+    vi.useFakeTimers();
+    const pagePrint = vi.spyOn(window, "print").mockImplementation(() => {});
+    const pending = printList(list, [entry], [], "de", t);
+    const frame = document.querySelector("iframe");
+    expect(frame?.srcdoc).toContain(list.designation);
+    const printWindow = frame!.contentWindow!;
+    vi.spyOn(printWindow, "focus").mockImplementation(() => {});
+    const print = vi.spyOn(printWindow, "print").mockImplementation(() => {});
+    expect(print).not.toHaveBeenCalled();
+    frame!.dispatchEvent(new Event("load"));
+    await pending;
+    expect(print).toHaveBeenCalledOnce();
+    expect(pagePrint).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(2_000);
+    expect(frame?.isConnected).toBe(true);
+    printWindow.dispatchEvent(new Event("afterprint"));
+    expect(frame?.isConnected).toBe(false);
+  });
+
+  it("cleans up and rejects when the print document fails to load", async () => {
+    vi.useFakeTimers();
+    const pending = printList(list, [entry], [], "de", t);
+    const rejected = expect(pending).rejects.toThrow("Druckansicht konnte nicht geladen werden");
+    vi.advanceTimersByTime(15_000);
+    await rejected;
+    expect(document.querySelector("iframe")).toBeNull();
+  });
+});

--- a/frontend/src/features/exhibition/exhibitionPrint.ts
+++ b/frontend/src/features/exhibition/exhibitionPrint.ts
@@ -1,0 +1,213 @@
+import { ExhibitionEntry, ExhibitionEntryStatus, ExhibitionList, MasterDataEntry } from "../../shared/api";
+import { functionSymbolImageData } from "../../shared/functionSymbolImages";
+import { functionSymbolMetadata } from "../../shared/functionSymbols";
+
+type Translate = (key: string, values?: Record<string, string | number>) => string;
+type PrintEntry = ExhibitionEntry & { status?: ExhibitionEntryStatus };
+type PrintOptions = { includeImages: boolean };
+
+const htmlEscapes: Record<string, string> = {
+  "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;"
+};
+
+function escapeHTML(value: unknown) {
+  return String(value ?? "").replace(/[&<>"']/g, (char) => htmlEscapes[char]);
+}
+
+function imageHTML(source: string | undefined, alt = "") {
+  if (!source) return "";
+  // Attribute escaping alone does not make an imported image URL safe.
+  try {
+    const url = new URL(source, "https://railkeeper.invalid");
+    if (!["http:", "https:"].includes(url.protocol) &&
+      !/^data:image\/(png|jpeg|webp|gif|svg\+xml)[;,]/i.test(source)) return "";
+  } catch {
+    return "";
+  }
+  return `<img src="${escapeHTML(source)}" alt="${escapeHTML(alt)}" />`;
+}
+
+export function printFunctionChips(value: string | undefined, symbols: MasterDataEntry[]) {
+  if (!value?.trim()) return "–";
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (Array.isArray(parsed)) {
+      const chips = parsed.map((item: unknown) => {
+        if (!item || typeof item !== "object" || !("key" in item) || typeof item.key !== "string") {
+          return "";
+        }
+        const name = "name" in item && typeof item.name === "string" ? item.name : "";
+        const type = "type" in item && typeof item.type === "string" ? item.type : "";
+        const symbolKey = "symbolKey" in item && typeof item.symbolKey === "string" ? item.symbolKey : "";
+        const symbol = symbols.find((entry) => entry.key === symbolKey);
+        const metadata = functionSymbolMetadata(symbols, symbolKey);
+        const symbolLabel = symbol?.label || symbolKey;
+        return `<span class="function-chip">${imageHTML(functionSymbolImageData(metadata, "print"))}
+          <strong>${escapeHTML(item.key)}</strong> ${escapeHTML(name || symbolLabel || type)}
+          <small>${escapeHTML([type, symbolLabel].filter(Boolean).join(" · "))}</small></span>`;
+      }).filter(Boolean);
+      if (chips.length > 0) return chips.join("");
+      if (parsed.length === 0) return "–";
+    }
+  } catch {
+    // Older entries store free text. Keep it verbatim instead of inventing default functions.
+  }
+  return `<span class="function-text">${escapeHTML(value)}</span>`;
+}
+
+export function buildExhibitionPrintHTML(
+  list: ExhibitionList,
+  entries: PrintEntry[],
+  symbols: MasterDataEntry[],
+  language: string,
+  t: Translate,
+  options: PrintOptions = { includeImages: true }
+) {
+  const de = language === "de";
+  const yesNo = (value: boolean) => t(value ? "exhibition.yes" : "exhibition.no");
+  const fields = (values: [string, string | undefined][]) => values.map(([label, value]) =>
+    `<div class="field"><dt>${escapeHTML(label)}</dt><dd>${escapeHTML(value || "–")}</dd></div>`
+  ).join("");
+  const date = (value: string) => value
+    ? new Intl.DateTimeFormat(de ? "de-DE" : "en-GB").format(new Date(`${value}T12:00:00`)) : "–";
+  const statusLabels = de
+    ? { draft: "Entwurf", open: "Offen", locked: "Gesperrt", running: "Läuft", completed: "Abgeschlossen", archived: "Archiviert" }
+    : { draft: "Draft", open: "Open", locked: "Locked", running: "Running", completed: "Completed", archived: "Archived" };
+  const entryStatusLabels = de
+    ? { ready: "Bereit", addressConflict: "Adresskonflikt", missing: "Angaben fehlen", check: "Prüfen", unavailable: "Nicht verfügbar" }
+    : { ready: "Ready", addressConflict: "Address conflict", missing: "Missing data", check: "Check", unavailable: "Unavailable" };
+  const days = (value: string) => (value || "all").split(",").map((scope) => {
+    const day = scope.trim();
+    if (day === "all") return t("exhibition.dayScope.all");
+    const number = /^day(\d+)$/.exec(day)?.[1];
+    return number ? `${de ? "Tag" : "Day"} ${number}` : day;
+  }).join(", ");
+  const rows = entries.map((entry, index) => `<tbody class="entry">
+    <tr>
+      <td class="identity">
+        <h2>${index + 1}. ${escapeHTML(entry.locomotiveName)}</h2>
+        ${options.includeImages ? imageHTML(entry.imageUrl) : ""}
+        <dl>${fields([
+          [t("exhibition.owner"), entry.owner],
+          [t("exhibition.dayScope"), days(entry.dayScope)],
+          [de ? "Verfügbarkeit" : "Availability", entry.availability === "unavailable"
+            ? (de ? "Nicht verfügbar" : "Unavailable") : (de ? "Verfügbar" : "Available")],
+          ["Status", entry.status ? entryStatusLabels[entry.status] : undefined]
+        ])}</dl>
+      </td>
+      <td><dl>${fields([
+        [t("exhibition.manufacturer"), entry.manufacturer], [t("exhibition.series"), entry.series],
+        [t("exhibition.gattung"), entry.gattung], [t("exhibition.epoch"), entry.epoch],
+        [t("exhibition.railwayCompany"), entry.railwayCompany]
+      ])}</dl></td>
+      <td><dl>${fields([
+        [de ? "Digitaldecoder" : "Digital decoder", yesNo(entry.dtDecoder)],
+        [t("exhibition.decoderType"), entry.decoderType], [t("exhibition.adapter"), entry.adapter],
+        [t("exhibition.dccAddress"), entry.decoderNumber], [t("exhibition.sxAddress"), entry.sxAddress],
+        [de ? "Zentrale / Schnittstelle" : "Command station / interface", entry.interfaceName],
+        [t("exhibition.analog"), yesNo(entry.analog)]
+      ])}</dl></td>
+    </tr>
+    <tr><td colspan="3"><h3>${escapeHTML(t("exhibition.functionKeys"))}</h3>
+      <div class="functions">${printFunctionChips(entry.functionKeys, symbols)}</div></td></tr>
+    <tr><td colspan="3"><h3>${escapeHTML(t("exhibition.notesSection"))}</h3>
+      <p class="notes">${escapeHTML(entry.notes || "–")}</p></td></tr>
+  </tbody>`).join("");
+  const dateRange = [date(list.date), list.endDate && list.endDate !== list.date ? date(list.endDate) : ""]
+    .filter(Boolean).join(" – ");
+  return `<!doctype html><html lang="${escapeHTML(language)}"><head><meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src http: https: data:; style-src 'unsafe-inline'; base-uri 'none'; form-action 'none'" />
+    <title>${escapeHTML(list.designation)} · RailKeeper</title>
+    <style>
+      @page { size: A4 landscape; margin: 12mm; }
+      * { box-sizing: border-box; }
+      body { margin: 0; color: #111; background: #fff; font: 12px/1.4 Arial, sans-serif; }
+      header { border-bottom: 2px solid #333; padding-bottom: 8px; margin-bottom: 12px; }
+      h1 { font-size: 20px; margin: 4px 0; }
+      h2 { font-size: 14px; margin: 0 0 8px; break-after: avoid; }
+      h3 { font-size: 12px; margin: 0 0 4px; break-after: avoid; }
+      p, dl, dd { margin: 0; }
+      table { width: 100%; border-collapse: collapse; table-layout: fixed; }
+      thead { display: table-header-group; }
+      th, td { text-align: left; vertical-align: top; padding: 8px; overflow-wrap: anywhere; }
+      th { border-block: 1px solid #555; }
+      .entry { break-inside: avoid; }
+      .entry + .entry { border-top: 2px solid #555; }
+      .entry td { border-bottom: 1px solid #ccc; }
+      .field { display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1.2fr); gap: 8px; margin: 2px 0; }
+      dt { color: #444; }
+      dd { font-weight: 600; white-space: pre-wrap; }
+      .identity img { width: 100%; height: 72px; object-fit: contain; object-position: left; margin-bottom: 4px; }
+      .functions { display: flex; flex-wrap: wrap; gap: 4px 12px; }
+      .function-chip { display: inline-flex; flex-wrap: wrap; align-items: center; gap: 4px; max-width: 100%; break-inside: avoid; }
+      .function-chip img { width: 16px; height: 16px; object-fit: contain; }
+      .function-chip small { color: #444; }
+      .notes, .function-text { white-space: pre-wrap; overflow-wrap: anywhere; }
+      .event-notes { margin-top: 8px; }
+      @media screen and (max-width: 600px) {
+        thead { display: none; }
+        table, tbody, tr, td { display: block; width: 100%; }
+      }
+    </style></head><body>
+    <header><p>RailKeeper · ${escapeHTML(t("exhibition.title"))}</p>
+      <h1>${escapeHTML(list.designation)}</h1>
+      <p>${escapeHTML(dateRange)} · ${escapeHTML(list.location || "–")} · ${escapeHTML(statusLabels[list.status])}
+        · ${escapeHTML(t("exhibition.entriesCount", { count: entries.length }))}</p>
+      ${list.description ? `<p class="event-notes notes">${escapeHTML(list.description)}</p>` : ""}
+      ${list.organizationNotes ? `<div class="event-notes"><h3>${de ? "Organisationshinweise" : "Organisation notes"}</h3><p class="notes">${escapeHTML(list.organizationNotes)}</p></div>` : ""}
+      ${list.lockReason ? `<div class="event-notes"><h3>${de ? "Sperrgrund" : "Lock reason"}</h3><p class="notes">${escapeHTML(list.lockReason)}</p></div>` : ""}
+    </header>
+    <table><thead><tr><th>${de ? "Fahrzeug / Betrieb" : "Vehicle / operation"}</th>
+      <th>${de ? "Modelldaten" : "Model data"}</th><th>${escapeHTML(t("exhibition.controlData"))}</th></tr></thead>
+      ${rows || `<tbody><tr><td colspan="3">${escapeHTML(t("exhibition.printEmpty"))}</td></tr></tbody>`}
+    </table></body></html>`;
+}
+
+export function printList(
+  list: ExhibitionList,
+  entries: PrintEntry[],
+  symbols: MasterDataEntry[],
+  language: string,
+  t: Translate,
+  options: PrintOptions = { includeImages: true }
+) {
+  const html = buildExhibitionPrintHTML(list, entries, symbols, language, t, options);
+  return new Promise<void>((resolve, reject) => {
+    const frame = document.createElement("iframe");
+    frame.title = list.designation;
+    frame.setAttribute("aria-hidden", "true");
+    frame.style.cssText = "position:fixed;width:0;height:0;border:0;opacity:0;pointer-events:none";
+    let cleanupTimer: number;
+    const cleanup = () => {
+      window.clearTimeout(cleanupTimer);
+      frame.remove();
+    };
+    cleanupTimer = window.setTimeout(() => {
+      cleanup();
+      reject(new Error(language === "de" ? "Druckansicht konnte nicht geladen werden." : "Print view could not be loaded."));
+    }, 15_000);
+    frame.onload = () => {
+      const printWindow = frame.contentWindow;
+      if (!printWindow) {
+        cleanup();
+        reject(new Error(language === "de" ? "Druckfenster ist nicht verfügbar." : "Print window is unavailable."));
+        return;
+      }
+      window.clearTimeout(cleanupTimer);
+      // Load includes images. Keep the frame until the native preview has closed.
+      printWindow.addEventListener("afterprint", cleanup, { once: true });
+      cleanupTimer = window.setTimeout(cleanup, 300_000);
+      try {
+        printWindow.focus();
+        printWindow.print();
+        resolve();
+      } catch (error) {
+        cleanup();
+        reject(error);
+      }
+    };
+    frame.srcdoc = html;
+    document.body.appendChild(frame);
+  });
+}

--- a/frontend/src/styles/base.test.ts
+++ b/frontend/src/styles/base.test.ts
@@ -16,6 +16,11 @@ function cssFiles(directory: string): string[] {
 }
 
 describe("base design system", () => {
+  it("confines hidden exhibition row actions to the scrollable table", () => {
+    const exhibitionCss = readFileSync(join(stylesDirectory, "exhibition.css"), "utf8");
+    expect(exhibitionCss).toMatch(/\.exhibition-row-menu\s*\{[^}]*position:\s*relative/s);
+  });
+
   it("defines the shared spacing, radius, duration, and easing scales", () => {
     const expectedTokens = [
       "--space-xs: 4px",

--- a/frontend/src/styles/exhibition.css
+++ b/frontend/src/styles/exhibition.css
@@ -735,6 +735,7 @@
 }
 
 .exhibition-row-menu {
+  position: relative;
   display: inline-flex;
   align-items: center;
 }


### PR DESCRIPTION
## Deutsch

Der bisherige Drucken-Knopf der aktuellen Ausstellung druckte die gesamte Webseite und ließ
zugleich gespeicherte Ausstellungsfelder aus. Dieser PR erzeugt stattdessen ein eigenes,
sicher gekapseltes A4-Querformat-Dokument für die vollständige ausgewählte Ausstellung.

### Änderungen

- druckt alle gespeicherten Einträge unabhängig von Such-, Tages- und Statusfiltern
- enthält Veranstaltungsdaten, Bilder, Besitzer, Modell-, Betriebs- und Steuerungsdaten,
  Funktionstasten mit Symbolen sowie vollständige Notizen
- wartet vor dem Druck auf Bilder und verhindert veraltete Ausdrucke während eines Listenwechsels
- escaped gespeicherte Texte, beschränkt Bildquellen und kapselt das Dokument mit einer CSP
- verhindert Seitenüberlauf durch versteckte Zeilenaktionen
- dokumentiert den Ablauf auf Deutsch und Englisch
- bereitet Version 0.1.20.4 mit Changelogs, Release-Notizen und Stable-Dokumentationsabgleich vor

Die mögliche automatische Hintergrundentfernung bei Fahrzeugbildern wurde bewertet. Sie ist nicht
Teil dieses Releases: Eine lokale Browser-Lösung ist grundsätzlich möglich, benötigt aber ein
größeres Modellpaket und einen angepassten transparenten Bild- und Thumbnail-Ablauf.

### Prüfung

- `go test ./... -count=1`
- `npm.cmd run test:coverage`: 145 Dateien, 866 Tests
- Coverage: 67,06 % Statements, 59,94 % Branches, 60,45 % Funktionen, 69,08 % Zeilen
- `npm.cmd run build`
- `npm.cmd run check`: 19 Dokumentationstests, Validator und VitePress-Build
- `git diff --check`
- betroffene Ausstellungsansicht lokal in Desktop-, Tablet- und Mobilbreiten sowie Hell/Dunkel geprüft

Der native Druckdialog konnte in der automatisierten Browserumgebung nicht geöffnet werden. Aufbau,
Feldumfang, Bild-Ladezyklus und die ausschließliche Verwendung des Druck-Iframes sind durch Tests
und die lokale Vorschau abgedeckt.

## English

The current exhibition's existing print button printed the entire web page while omitting saved
exhibition fields. This pull request instead creates a separate, safely isolated A4 landscape
document for the complete selected exhibition.

### Changes

- prints every saved entry regardless of search, day, or status filters
- includes event data, images, owners, model, operating, and control data, function assignments
  with symbols, and complete notes
- waits for images before printing and prevents stale reports while switching lists
- escapes stored text, restricts image sources, and isolates the document with a CSP
- prevents hidden row actions from causing page overflow
- documents the flow in German and English
- prepares version 0.1.20.4 with changelogs, release notes, and stable documentation alignment

Automatic vehicle-image background removal was assessed and is not part of this release. A local
browser implementation is feasible, but it requires a larger model download and a revised
transparent-image and thumbnail pipeline.

### Verification

- `go test ./... -count=1`
- `npm.cmd run test:coverage`: 145 files, 866 tests
- Coverage: 67.06% statements, 59.94% branches, 60.45% functions, 69.08% lines
- `npm.cmd run build`
- `npm.cmd run check`: 19 documentation tests, validator, and VitePress build
- `git diff --check`
- affected exhibition view checked locally at desktop, tablet, and mobile widths in light and dark themes

The native print dialog could not be opened in the automated browser environment. Tests and the
local preview cover the layout, field set, image loading lifecycle, and exclusive use of the print
iframe.
